### PR TITLE
fix(ci): grant id-token permissions to deploy-all.yml caller jobs

### DIFF
--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -119,6 +119,9 @@ jobs:
     name: Deploy AWS Lambda
     needs: determine-deployment
     if: needs.determine-deployment.outputs.deploy-aws-lambda == 'true'
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/deploy-aws-lambda.yml
     with:
       environment: ${{ needs.determine-deployment.outputs.environment }}
@@ -133,6 +136,9 @@ jobs:
     name: Deploy AWS Fargate
     needs: determine-deployment
     if: needs.determine-deployment.outputs.deploy-aws-fargate == 'true'
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/deploy-aws-fargate.yml
     with:
       environment: ${{ needs.determine-deployment.outputs.environment }}
@@ -145,6 +151,9 @@ jobs:
     name: Deploy GCP Cloud Run
     needs: determine-deployment
     if: needs.determine-deployment.outputs.deploy-gcp == 'true'
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/deploy-gcp.yml
     with:
       environment: ${{ needs.determine-deployment.outputs.environment }}
@@ -157,6 +166,9 @@ jobs:
     name: Deploy Azure Container Apps
     needs: determine-deployment
     if: needs.determine-deployment.outputs.deploy-azure == 'true'
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/deploy-azure.yml
     with:
       environment: ${{ needs.determine-deployment.outputs.environment }}


### PR DESCRIPTION
## Summary

- `deploy-all.yml` declares no `permissions:` anywhere, so its four caller jobs (each invoking a reusable deploy workflow via `uses:`) cannot pass `id-token: write` down to the callee. `id-token` is never in the default `GITHUB_TOKEN` scope, so every OIDC-based cloud login (`configure-aws-credentials`, `google-github-actions/auth`, `azure/login`) run through `deploy-all.yml` fails.
- Adds a job-level `permissions: {id-token: write, contents: read}` block to each of the four caller jobs: `deploy-aws-lambda`, `deploy-aws-fargate`, `deploy-gcp`, `deploy-azure`.
- `determine-deployment` and `notify` are untouched: neither calls a reusable workflow or authenticates to anything, so neither should hold `id-token: write`.

## Duplicate issues

**#1665 and #1587 are duplicates of the same defect** (same file, same missing permissions, same OIDC failure on the multi-cloud path). They differ only in the fix shape they each proposed:

- #1665 recommends job-level `permissions:` on the four caller jobs specifically to avoid granting `id-token: write` to `determine-deployment`/`notify`.
- #1587 initially suggests a workflow-level block, but its own "Related" section explicitly separates this functional break from the general default-token hygiene question (that's tracked separately in #1196, rated P3/informational) — so the two issues converge on the same fix once you read past the first suggestion.

This PR fixes it once, per #1665's job-level shape, and closes both.

## Caller -> callee permission mapping

Verified each callee's actual requirement by reading its own `permissions:` blocks on `origin/main`:

| Caller job in `deploy-all.yml` | Callee workflow | Callee's own requirement | Granted here |
|---|---|---|---|
| `deploy-aws-lambda` | `deploy-aws-lambda.yml` | Workflow-level floor `contents: read`; its actual deploy job additionally declares `id-token: write, contents: read` (job-level, scoped to the job that assumes the AWS role) | `id-token: write, contents: read` |
| `deploy-aws-fargate` | `deploy-aws-fargate.yml` | Workflow-level `id-token: write, contents: read` | `id-token: write, contents: read` |
| `deploy-gcp` | `deploy-gcp.yml` | Workflow-level `id-token: write, contents: read` | `id-token: write, contents: read` |
| `deploy-azure` | `deploy-azure.yml` | Workflow-level `id-token: write, contents: read` | `id-token: write, contents: read` |

GitHub's reusable-workflow contract: the effective permission set for a called workflow is the **intersection** of what the caller job grants and what the callee itself declares — a callee can only narrow, never escalate, what its caller passed down. Each of the four callees needs `id-token: write` for at least one of its own jobs, and none of them needs more than `contents: read` besides that, so granting exactly `{id-token: write, contents: read}` at the caller-job level is both necessary and sufficient — nothing is left under-provisioned, and nothing is over-granted.

`determine-deployment` and `notify` call no reusable workflow and perform no `actions/checkout` or cloud auth (both jobs just build a `$GITHUB_STEP_SUMMARY` from shell echoes), so they are left with no explicit `permissions:` block, unchanged from today. Locking down their ambient default-token scope is the separate least-privilege hygiene question tracked in #1196 (P3) and out of scope here.

## Verification

- `actionlint` (v1.7.12) on the changed file: same 44 pre-existing shellcheck notices as the unmodified `origin/main` version (confirmed by diffing actionlint output with/without this change via `git stash`), zero new findings — the added `permissions:` blocks parse correctly and introduce nothing new.
- `act -l -W .github/workflows/deploy-all.yml` (workflow_dispatch) correctly parses the job graph with the new permissions in place:
  ```
  Stage  Job ID                Job name                       Workflow name         Events
  0      determine-deployment  Determine Deployment Strategy  Deploy to All Clouds  workflow_dispatch,release
  1      deploy-aws-lambda     Deploy AWS Lambda              Deploy to All Clouds  workflow_dispatch,release
  1      deploy-aws-fargate    Deploy AWS Fargate             Deploy to All Clouds  workflow_dispatch,release
  1      deploy-gcp            Deploy GCP Cloud Run           Deploy to All Clouds  release,workflow_dispatch
  1      deploy-azure          Deploy Azure Container Apps    Deploy to All Clouds  workflow_dispatch,release
  2      notify                Deployment Results             Deploy to All Clouds  workflow_dispatch,release
  ```
- Did not dispatch a real multi-cloud deploy (no cloud credentials available in this environment) — the caller/callee permission-intersection reasoning above is the primary verification, as requested.

## Scope

`permissions:` blocks only. No restructuring, no concurrency groups (#1593), no other workflow files touched.

Closes #1665
Closes #1587
