### PR TITLE
chore(frontend): patch js-yaml and nanoid advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2041,9 +2041,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8331,9 +8331,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -8903,9 +8903,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Two new high-severity npm advisories have appeared since #1716 patched `brace-expansion` and `fast-uri`, reddening `npm audit --audit-level=high` on `main` and every open PR (same time-dependent pattern: `npm audit` queries the live advisory database, so the same commit goes red the moment an advisory publishes):

- **js-yaml** — [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (quadratic CPU consumption in `!!omap` resolution)
- **nanoid** — [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (custom generators can loop indefinitely when size is zero)

## Fix

Lockfile-only, per the same approach as #1716. Neither package is a direct dependency:

- `js-yaml` comes in transitively via `eslint` and via `ts-jest` -> `@jest/transform` -> `babel-plugin-istanbul` -> `@istanbuljs/load-nyc-config`.
- `nanoid` comes in transitively via `css-loader` -> `postcss`.

Both resolve within the semver ranges their parents already declare, so `npm audit fix` bumped only the three affected lockfile entries with **no change to `package.json`**:

| Package | Before | After |
|---|---|---|
| js-yaml (eslint's copy) | 4.3.0 | 4.3.1 |
| js-yaml (@istanbuljs/load-nyc-config's copy) | 3.15.0 | 3.15.1 |
| nanoid | 3.3.16 | 3.3.18 |

`git diff package.json` is empty; `git diff package-lock.json` touches exactly these three `version`/`resolved`/`integrity` triples (24 lines).

## Verification

**Before** (`npm audit --audit-level=high`, exit 1):
```
js-yaml  3.0.0 - 3.15.0 || 4.0.0 - 4.3.0
Severity: high
JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported - https://github.com/advisories/GHSA-5p4m-2wfm-xmqj
fix available via `npm audit fix`
node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml
node_modules/js-yaml

nanoid  <3.3.17
Severity: high
nanoid: custom generators can loop indefinitely when size is zero - https://github.com/advisories/GHSA-2v37-7h3g-55p8
fix available via `npm audit fix`
node_modules/nanoid

2 high severity vulnerabilities
```

**After** (`npm audit --audit-level=high`, exit 0):
```
found 0 vulnerabilities
```

- `npm run build`: succeeds (webpack compiles with the pre-existing entrypoint-size warning only, no errors).
- `npm test`: **8 failed / 2773 passed / 1 skipped**, both on this branch and reproduced identically on unmodified `origin/main` in a separate clean worktree (before touching anything). Same failures, same counts, same locale-formatting mismatches (`$1.200` vs `$1,200`, `$4.568` vs `$4,568`, `$30,00/mo` vs `$30.00/mo`) — pre-existing, filed as #1728, not affected by this change.

## Dependency-hygiene observation (reporting only, not fixing here)

This is the second advisory pair in three days (after #1716's `brace-expansion`/`fast-uri`). All four advisories so far have landed on **dev-only transitive dependencies** (eslint, ts-jest/istanbul, css-loader/postcss, and #1716's pair) rather than anything in the production bundle — none are direct dependencies of `cudly-frontend`. Worth keeping an eye on whether this keeps recurring at this cadence; if it does, `#1712` (where the scanner-decoupling work lives) might be the right place to consider decoupling `npm audit`'s live-advisory-DB dependency from the PR-blocking gate (e.g. running it as a non-blocking scheduled check instead), rather than each new advisory needing an emergency same-day lockfile PR to unblock the merge queue. Not attempting that here — flagging per your request, staying inside the blocking fix.

## Scope

`frontend/package-lock.json` only. `package.json` untouched (no direct dependency range needed to move). No `frontend/src/**` changes.

Refs #1712
