### PR TITLE
sec(frontend): stop group edit from dropping/widening permissions

### DIFF
--- a/frontend/src/__tests__/group-edit-unrepresentable-permissions.test.ts
+++ b/frontend/src/__tests__/group-edit-unrepresentable-permissions.test.ts
@@ -52,6 +52,7 @@ jest.mock('../confirmDialog', () => ({
 import * as api from '../api';
 import * as groupState from '../groups/state';
 import * as groupModals from '../groups/groupModals';
+import { ALL_ACTIONS, ALL_RESOURCES } from '../permissions';
 
 // The exact seeded Purchaser group permission set (PURCHASER_PERMS in
 // permissions.generated.ts), reproduced here as a fixture so the test
@@ -201,5 +202,85 @@ describe('regression: group edit no longer drops/widens unrepresentable permissi
     // sees something is off before ever opening the dropdown.
     expect(actionSelect.selectedOptions[0]?.textContent).toContain('not recognized');
     expect(resourceSelect.selectedOptions[0]?.textContent).toContain('not recognized');
+  });
+
+  // F2 (adversarial review of this PR): the escaping above is correct today
+  // but nothing was pinning it. buildActionOptions/buildResourceOptions in
+  // groupModals.ts interpolate the raw stored permission value into both an
+  // HTML attribute (`value="..."`) and a text label (`⚠ ... (not
+  // recognized...)`) for any value outside ALL_ACTIONS/ALL_RESOURCES --
+  // exactly the "API string reaching innerHTML" pattern #1727 fixed twice
+  // elsewhere in this codebase a few hours before this file was written.
+  // These five breakout payloads (from the reviewer) pin the strong
+  // properties rather than just "the string appears somewhere": no element
+  // was parsed out of the payload, the selected <option> gained no
+  // attributes beyond value/selected, its label has zero child elements,
+  // and the value is preserved byte-for-byte through the DOM and through
+  // an actual save.
+  describe('F2: unrecognised-value option escaping holds under XSS breakout payloads', () => {
+    const BREAKOUT_PAYLOADS: Array<[string, string]> = [
+      ['element injection', '"><img src=x onerror=alert(1)>'],
+      ['attribute injection onto the <option> tag', '" autofocus onfocus=alert(1) x="'],
+      ['raw script tag', '<script>alert(1)</script>'],
+      ['single-quote context breakout', "'><svg onload=alert(1)>"],
+      ['closing-tag option injection', '</option><option value="x" selected>evil</option>'],
+    ];
+
+    test.each(BREAKOUT_PAYLOADS)('%s does not inject markup and round-trips unchanged', async (_label, payload) => {
+      const group: api.APIGroup = {
+        id: 'breakout-group-id',
+        name: 'Breakout',
+        description: 'Old description',
+        permissions: [{ action: payload, resource: payload }],
+        created_at: '2024-01-01T00:00:00Z',
+      };
+
+      (api.getGroup as jest.Mock).mockResolvedValue(group);
+      await groupModals.openEditGroupModal(group.id);
+
+      const actionSelect = document.querySelector('.perm-action') as HTMLSelectElement;
+      const resourceSelect = document.querySelector('.perm-resource') as HTMLSelectElement;
+
+      // No breakout payload parsed as a live element anywhere in the modal.
+      expect(document.querySelectorAll('img, script, svg, iframe, style').length).toBe(0);
+
+      // No extra <option> was smuggled in via the closing-tag breakout: the
+      // action select is ALL_ACTIONS + the empty placeholder + the one
+      // fallback option for this unrecognised value; the resource select is
+      // ALL_RESOURCES + the one fallback (it has no placeholder).
+      expect(actionSelect.options.length).toBe(ALL_ACTIONS.length + 1 + 1);
+      expect(resourceSelect.options.length).toBe(ALL_RESOURCES.length + 1);
+
+      const selectedAction = actionSelect.selectedOptions[0];
+      const selectedResource = resourceSelect.selectedOptions[0];
+      expect(selectedAction).toBeDefined();
+      expect(selectedResource).toBeDefined();
+
+      // The attribute-injection payload gained no new attributes on the
+      // <option> element itself: exactly value + selected, nothing else
+      // (no autofocus/onfocus/etc smuggled in).
+      expect(Array.from(selectedAction!.attributes).map(a => a.name).sort()).toEqual(['selected', 'value']);
+      expect(Array.from(selectedResource!.attributes).map(a => a.name).sort()).toEqual(['selected', 'value']);
+
+      // The label rendered as text, not markup: zero child elements.
+      expect(selectedAction!.children.length).toBe(0);
+      expect(selectedResource!.children.length).toBe(0);
+
+      // The value round-trips byte-identically through the DOM.
+      expect(actionSelect.value).toBe(payload);
+      expect(resourceSelect.value).toBe(payload);
+
+      // ...and through an actual save: the exact payload reaches the API
+      // call, neither dropped nor mangled by an unrelated description edit.
+      (document.getElementById('group-description') as HTMLTextAreaElement).value = 'New description';
+      const event = { preventDefault: jest.fn() } as unknown as Event;
+      await groupModals.saveGroup(event);
+
+      expect(api.updateGroup).toHaveBeenCalledWith('breakout-group-id', {
+        name: 'Breakout',
+        description: 'New description',
+        permissions: [{ action: payload, resource: payload }],
+      });
+    });
   });
 });

--- a/frontend/src/__tests__/group-edit-unrepresentable-permissions.test.ts
+++ b/frontend/src/__tests__/group-edit-unrepresentable-permissions.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Regression tests for issue #1629: editing a group through the Admin UI
+ * silently dropped permissions the perm-action <select> couldn't render
+ * and silently widened the resource of every such permission to `*`.
+ *
+ * groupModals.ts's addPermission() used to hardcode the action list to 7
+ * of the backend's 20 actions and the resource list to 9 of its 11
+ * resources (internal/auth/types.go). When a stored permission's value
+ * matched no <option>, the browser fell back to index 0:
+ *   - action select index 0 is the empty "Select Action" placeholder ->
+ *     collectPermissions() treats a falsy action as "skip this row", so
+ *     the permission was DROPPED.
+ *   - resource select index 0 is "All (*)" -> the permission was WIDENED
+ *     to the wildcard resource.
+ *
+ * Concretely, the seeded Purchaser group (PURCHASER_PERMS in
+ * permissions.generated.ts) held approve-any:purchases, execute:purchases,
+ * retry-any:purchases, view:history, view:plans, view:purchases,
+ * view:recommendations. Of these, approve-any and retry-any are not base
+ * actions (dropped) and history is not a base resource (widened to *).
+ * Opening that group, changing only the description, and clicking Save
+ * silently deleted the two purchase-approval verbs tenant-wide (they are
+ * carved out of admin:*, so no admin could approve or retry a purchase
+ * either) and gave every Purchaser read access to users/groups/accounts/
+ * config via the widened view:* grant.
+ *
+ * The fix builds both <option> lists from permissions.ts's ALL_ACTIONS /
+ * ALL_RESOURCES (the same closed-union vocabulary the rest of the
+ * frontend already mirrors from internal/auth/types.go, now exhaustiveness
+ * -checked against it at compile time), and additionally preserves any
+ * value that still isn't recognised -- visibly flagged rather than
+ * silently coerced -- so a future backend verb the frontend hasn't been
+ * taught yet fails loud instead of reintroducing this bug.
+ */
+
+import './setup';
+
+jest.mock('../api', () => ({
+  getGroup: jest.fn(),
+  updateGroup: jest.fn(),
+  createGroup: jest.fn(),
+}));
+
+jest.mock('../users/userActions', () => ({
+  loadUsers: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../confirmDialog', () => ({
+  confirmDialog: jest.fn().mockResolvedValue(true),
+}));
+
+import * as api from '../api';
+import * as groupState from '../groups/state';
+import * as groupModals from '../groups/groupModals';
+
+// The exact seeded Purchaser group permission set (PURCHASER_PERMS in
+// permissions.generated.ts), reproduced here as a fixture so the test
+// exercises the real failure scenario rather than a synthetic one.
+const PURCHASER_PERMISSIONS: api.Permission[] = [
+  { action: 'approve-any', resource: 'purchases' },
+  { action: 'execute', resource: 'purchases' },
+  { action: 'retry-any', resource: 'purchases' },
+  { action: 'view', resource: 'history' },
+  { action: 'view', resource: 'plans' },
+  { action: 'view', resource: 'purchases' },
+  { action: 'view', resource: 'recommendations' },
+];
+
+function setUpModalDom(): void {
+  document.body.innerHTML = `
+    <div id="group-modal" class="hidden">
+      <span id="group-modal-title"></span>
+      <form id="group-form">
+        <input id="group-id" />
+        <input id="group-name" />
+        <textarea id="group-description"></textarea>
+        <div id="permissions-list"></div>
+      </form>
+    </div>
+  `;
+}
+
+// Simulates opening a group for edit, then saving after ONLY the
+// description changed (the exact scenario from the issue: "an admin
+// opens a group, changes only the description, and clicks Save").
+async function openEditDescriptionOnlyAndSave(group: api.APIGroup, newDescription: string): Promise<void> {
+  (api.getGroup as jest.Mock).mockResolvedValue(group);
+  await groupModals.openEditGroupModal(group.id);
+
+  (document.getElementById('group-description') as HTMLTextAreaElement).value = newDescription;
+
+  const event = { preventDefault: jest.fn() } as unknown as Event;
+  await groupModals.saveGroup(event);
+}
+
+describe('regression: group edit no longer drops/widens unrepresentable permissions (#1629)', () => {
+  beforeEach(() => {
+    setUpModalDom();
+    groupState.setCurrentEditingGroup(null);
+    jest.clearAllMocks();
+  });
+
+  test('seeded Purchaser permissions survive an edit that only changes the description', async () => {
+    const group: api.APIGroup = {
+      id: 'purchaser-group-id',
+      name: 'Purchaser',
+      description: 'Old description',
+      permissions: PURCHASER_PERMISSIONS,
+      created_at: '2024-01-01T00:00:00Z',
+    };
+
+    await openEditDescriptionOnlyAndSave(group, 'New description');
+
+    expect(api.updateGroup).toHaveBeenCalledWith('purchaser-group-id', {
+      name: 'Purchaser',
+      description: 'New description',
+      // Byte-identical to the input: same 7 permissions, same order, same
+      // action/resource values. Neither approve-any/retry-any dropped nor
+      // history widened to '*'.
+      permissions: PURCHASER_PERMISSIONS,
+    });
+  });
+
+  test('approve-any:purchases specifically is not dropped (the four-eyes approval verb)', async () => {
+    const group: api.APIGroup = {
+      id: 'purchaser-group-id',
+      name: 'Purchaser',
+      description: 'Old description',
+      permissions: PURCHASER_PERMISSIONS,
+      created_at: '2024-01-01T00:00:00Z',
+    };
+
+    await openEditDescriptionOnlyAndSave(group, 'New description');
+
+    const call = (api.updateGroup as jest.Mock).mock.calls[0];
+    const saved = call[1].permissions as api.Permission[];
+    expect(saved).toContainEqual({ action: 'approve-any', resource: 'purchases' });
+    expect(saved).toContainEqual({ action: 'retry-any', resource: 'purchases' });
+  });
+
+  test('view:history specifically is not widened to view:* (would leak users/groups/config/accounts read access)', async () => {
+    const group: api.APIGroup = {
+      id: 'purchaser-group-id',
+      name: 'Purchaser',
+      description: 'Old description',
+      permissions: PURCHASER_PERMISSIONS,
+      created_at: '2024-01-01T00:00:00Z',
+    };
+
+    await openEditDescriptionOnlyAndSave(group, 'New description');
+
+    const call = (api.updateGroup as jest.Mock).mock.calls[0];
+    const saved = call[1].permissions as api.Permission[];
+    expect(saved).toContainEqual({ action: 'view', resource: 'history' });
+    // No permission was widened to the wildcard resource as a side effect.
+    expect(saved.some(p => p.action === 'view' && p.resource === '*')).toBe(false);
+  });
+
+  test('a genuinely unrecognised action/resource pair round-trips unchanged instead of being dropped or widened', async () => {
+    // Simulates a future backend verb the frontend's ALL_ACTIONS/
+    // ALL_RESOURCES hasn't been taught yet (or legacy/foreign data) --
+    // the defense-in-depth path, independent of whether the known-vocabulary
+    // list is currently complete.
+    const foreignPermission: api.Permission = { action: 'time-travel', resource: 'flux-capacitor' };
+    const group: api.APIGroup = {
+      id: 'exotic-group-id',
+      name: 'Exotic',
+      description: 'Old description',
+      permissions: [foreignPermission],
+      created_at: '2024-01-01T00:00:00Z',
+    };
+
+    await openEditDescriptionOnlyAndSave(group, 'New description');
+
+    expect(api.updateGroup).toHaveBeenCalledWith('exotic-group-id', {
+      name: 'Exotic',
+      description: 'New description',
+      permissions: [foreignPermission],
+    });
+  });
+
+  test('the unrecognised value is visibly flagged in the select, not silently presented as a normal option', async () => {
+    const foreignPermission: api.Permission = { action: 'time-travel', resource: 'flux-capacitor' };
+    const group: api.APIGroup = {
+      id: 'exotic-group-id',
+      name: 'Exotic',
+      description: 'Old description',
+      permissions: [foreignPermission],
+      created_at: '2024-01-01T00:00:00Z',
+    };
+
+    (api.getGroup as jest.Mock).mockResolvedValue(group);
+    await groupModals.openEditGroupModal(group.id);
+
+    const actionSelect = document.querySelector('.perm-action') as HTMLSelectElement;
+    const resourceSelect = document.querySelector('.perm-resource') as HTMLSelectElement;
+    expect(actionSelect.value).toBe('time-travel');
+    expect(resourceSelect.value).toBe('flux-capacitor');
+    // The selected option's own label carries a visible warning, not a
+    // plain/normal-looking label, so an admin scanning the closed <select>
+    // sees something is off before ever opening the dropdown.
+    expect(actionSelect.selectedOptions[0]?.textContent).toContain('not recognized');
+    expect(resourceSelect.selectedOptions[0]?.textContent).toContain('not recognized');
+  });
+});

--- a/frontend/src/groups/groupModals.ts
+++ b/frontend/src/groups/groupModals.ts
@@ -9,6 +9,8 @@ import { availableGroups } from '../users/state';
 import { escapeHtml, showError, showSuccess } from '../users/utils';
 import { loadUsers } from '../users/userActions';
 import { openModal, closeModal } from '../modal';
+import { ALL_ACTIONS, ALL_RESOURCES } from '../permissions';
+import type { Action, Resource } from '../permissions';
 
 // Module-level state for the duplicate modal — holds the source group so
 // saveDuplicateGroup doesn't need another lookup.
@@ -116,6 +118,83 @@ export async function saveGroup(e: Event): Promise<void> {
   }
 }
 
+// Human-readable <option> labels for the action/resource vocabulary.
+// Falls back to a generic title-case of the raw value ("cancel-own" ->
+// "Cancel Own") for every entry that doesn't need a special-cased
+// override; only acronyms and the symbolic "*" need one.
+const ACTION_LABEL_OVERRIDES: Partial<Record<Action, string>> = {
+  admin: 'Admin (full)',
+};
+
+const RESOURCE_LABEL_OVERRIDES: Partial<Record<Resource, string>> = {
+  '*': 'All (*)',
+  'api-keys': 'API Keys',
+  'ri-exchange': 'RI Exchange',
+};
+
+function titleCase(value: string): string {
+  return value
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function actionOptionLabel(action: string): string {
+  return ACTION_LABEL_OVERRIDES[action as Action] ?? titleCase(action);
+}
+
+function resourceOptionLabel(resource: string): string {
+  return RESOURCE_LABEL_OVERRIDES[resource as Resource] ?? titleCase(resource);
+}
+
+// Builds the <option> list for the perm-action / perm-resource <select>
+// elements (issue #1629). This list used to be hardcoded to 7 of the 20
+// actions and 9 of the 11 resources the backend can store. A stored
+// permission carrying one of the missing values had no matching <option>,
+// so the browser fell back to the first entry in the list -- silently
+// DROPPING the permission on the action select (index 0 was the empty
+// "Select Action" placeholder; collectPermissions() skips a falsy action)
+// and silently WIDENING it to the `*` wildcard on the resource select
+// (index 0 there was "All (*)"). Editing any group that held one of those
+// permissions and clicking Save re-submitted a materially different
+// permission list than the one shown, with no error.
+//
+// Building the lists from permissions.ts's ALL_ACTIONS / ALL_RESOURCES
+// (which mirror the backend's full vocabulary, and are exhaustiveness
+// -checked against it at compile time) closes that gap for every value
+// currently known to the frontend. `currentValue` is still handled
+// defensively beyond the known list: if a stored permission's value isn't
+// one of them (a future backend verb this form hasn't been taught yet, or
+// legacy/foreign data), an extra option is appended for that *exact*
+// value, selected and visibly flagged, instead of silently falling back
+// to a different one. The select then still represents -- and
+// round-trips unchanged through collectPermissions() -- the real stored
+// permission rather than corrupting it.
+function buildActionOptions(currentValue: string | undefined): string {
+  const options = ['<option value="">Select Action</option>'];
+  for (const action of ALL_ACTIONS) {
+    const selected = currentValue === action ? ' selected' : '';
+    options.push(`<option value="${escapeHtml(action)}"${selected}>${escapeHtml(actionOptionLabel(action))}</option>`);
+  }
+  if (currentValue && !(ALL_ACTIONS as readonly string[]).includes(currentValue)) {
+    options.push(`<option value="${escapeHtml(currentValue)}" selected>⚠ ${escapeHtml(currentValue)} (not recognized by this form)</option>`);
+  }
+  return options.join('');
+}
+
+function buildResourceOptions(currentValue: string | undefined): string {
+  const options: string[] = [];
+  for (const resource of ALL_RESOURCES) {
+    const isDefault = !currentValue && resource === '*';
+    const selected = currentValue === resource || isDefault ? ' selected' : '';
+    options.push(`<option value="${escapeHtml(resource)}"${selected}>${escapeHtml(resourceOptionLabel(resource))}</option>`);
+  }
+  if (currentValue && !(ALL_RESOURCES as readonly string[]).includes(currentValue)) {
+    options.push(`<option value="${escapeHtml(currentValue)}" selected>⚠ ${escapeHtml(currentValue)} (not recognized by this form)</option>`);
+  }
+  return options.join('');
+}
+
 /**
  * Add a new permission to the form
  */
@@ -129,27 +208,12 @@ export function addPermission(permission?: Permission): void {
     <div class="form-row">
       <label>Action:
         <select class="perm-action" required>
-          <option value="">Select Action</option>
-          <option value="view" ${permission?.action === 'view' ? 'selected' : ''}>View</option>
-          <option value="create" ${permission?.action === 'create' ? 'selected' : ''}>Create</option>
-          <option value="update" ${permission?.action === 'update' ? 'selected' : ''}>Update</option>
-          <option value="delete" ${permission?.action === 'delete' ? 'selected' : ''}>Delete</option>
-          <option value="execute" ${permission?.action === 'execute' ? 'selected' : ''}>Execute</option>
-          <option value="approve" ${permission?.action === 'approve' ? 'selected' : ''}>Approve</option>
-          <option value="admin" ${permission?.action === 'admin' ? 'selected' : ''}>Admin (full)</option>
+          ${buildActionOptions(permission?.action)}
         </select>
       </label>
       <label>Resource:
         <select class="perm-resource" required>
-          <option value="*" ${(!permission?.resource || permission?.resource === '*') ? 'selected' : ''}>All (*)</option>
-          <option value="recommendations" ${permission?.resource === 'recommendations' ? 'selected' : ''}>Recommendations</option>
-          <option value="plans" ${permission?.resource === 'plans' ? 'selected' : ''}>Plans</option>
-          <option value="purchases" ${permission?.resource === 'purchases' ? 'selected' : ''}>Purchases</option>
-          <option value="accounts" ${permission?.resource === 'accounts' ? 'selected' : ''}>Accounts</option>
-          <option value="config" ${permission?.resource === 'config' ? 'selected' : ''}>Config</option>
-          <option value="users" ${permission?.resource === 'users' ? 'selected' : ''}>Users</option>
-          <option value="groups" ${permission?.resource === 'groups' ? 'selected' : ''}>Groups</option>
-          <option value="api-keys" ${permission?.resource === 'api-keys' ? 'selected' : ''}>API Keys</option>
+          ${buildResourceOptions(permission?.resource)}
         </select>
       </label>
       <button type="button" class="btn-small btn-danger remove-permission-btn">Remove</button>

--- a/frontend/src/permissions.ts
+++ b/frontend/src/permissions.ts
@@ -82,6 +82,60 @@ export type Resource =
   | 'ri-exchange'
   | '*';
 
+// ALL_ACTIONS / ALL_RESOURCES: runtime enumeration of the Action / Resource
+// unions above, for UI surfaces that must be able to represent every
+// permission the backend can store -- the group-edit form's action/resource
+// <select> lists (issue #1629). Before this, those lists were a *third*,
+// independently hand-maintained copy of the vocabulary in groupModals.ts
+// that had drifted 13 actions and 2 resources behind this file, so any
+// group edit silently dropped or widened permissions the form couldn't
+// represent. Deriving from Action/Resource instead of hand-writing this
+// array again keeps there being exactly one place to update.
+//
+// The Record<Action, true> / Record<Resource, true> assignments below are a
+// compile-time exhaustiveness check: TS rejects the assignment if a key is
+// missing OR if a key doesn't belong to the union, so adding a new Action
+// or Resource variant without updating these objects fails the build
+// instead of silently reintroducing the drift this issue closes.
+const ACTION_EXHAUSTIVENESS_CHECK: Record<Action, true> = {
+  view: true,
+  create: true,
+  update: true,
+  delete: true,
+  execute: true,
+  approve: true,
+  'cancel-own': true,
+  'cancel-any': true,
+  'retry-own': true,
+  'retry-any': true,
+  'approve-own': true,
+  'approve-any': true,
+  'execute-own': true,
+  'execute-any': true,
+  'update-any': true,
+  'revoke-own': true,
+  'revoke-any': true,
+  'sell-own': true,
+  'sell-any': true,
+  admin: true,
+};
+export const ALL_ACTIONS: readonly Action[] = Object.keys(ACTION_EXHAUSTIVENESS_CHECK) as Action[];
+
+const RESOURCE_EXHAUSTIVENESS_CHECK: Record<Resource, true> = {
+  '*': true,
+  recommendations: true,
+  plans: true,
+  purchases: true,
+  history: true,
+  accounts: true,
+  config: true,
+  users: true,
+  groups: true,
+  'api-keys': true,
+  'ri-exchange': true,
+};
+export const ALL_RESOURCES: readonly Resource[] = Object.keys(RESOURCE_EXHAUSTIVENESS_CHECK) as Resource[];
+
 /**
  * Well-known group UUID for the Administrators group seeded by
  * migration 000057. Being a member of this group is the frontend


### PR DESCRIPTION
## Summary

**This closes only the frontend half of #1629.** The issue explicitly requires two halves ("Two halves, both needed. Please do not ship only the first"): this PR fixes the Admin UI's silent data corruption, but `UpdateGroupAPI`/`CreateGroupAPI` (`internal/api`) still has no grant ceiling and no `system_managed` check, so a direct API call bypassing this form can still widen or escalate a group's permissions. That backend half is tracked in **#1550** (open, unassigned), out of scope here and outside this PR's footprint (`frontend/src/**`). Not using a closing keyword; #1629 should stay open until #1550 also lands.

## The bug

`groupModals.ts`'s `addPermission()` hardcoded the action `<select>` to 7 of the backend's 20 actions and the resource `<select>` to 9 of its 11 resources (`internal/auth/types.go`). When a stored permission's value matched no `<option>`, the browser fell back to index 0 of each select:

- **Action select** index 0 is the empty `Select Action` placeholder. `collectPermissions()` treats a falsy action as "skip this row" -> the permission is silently **dropped**.
- **Resource select** index 0 is `All (*)`. -> the permission is silently **widened to the wildcard**.

Concretely, on the seeded Purchaser group (`PURCHASER_PERMS`): `approve-any:purchases` and `retry-any:purchases` vanish entirely (both are carved out of `admin:*`, so no admin can approve or retry a purchase either until someone re-seeds the group by hand), and **`view:history` silently becomes `view:*`** — every Purchaser gains read access to users, groups, cloud accounts and config. An admin who opens that group, changes only the description, and clicks Save performs an unintended privilege escalation without any error or warning. This is the sentence that justifies HIGH severity: the failure isn't just data loss, it's a widening path triggered by a cosmetic edit.

## The fix

`frontend/src/permissions.ts` already hand-maintains closed-union `Action`/`Resource` TS types mirroring `internal/auth/types.go`'s constants (used by `canAccess`/`isAdmin` elsewhere). Rather than hardcoding a *third* independently-drifting copy of the vocabulary in `groupModals.ts` — which is how this bug happened — this adds `ALL_ACTIONS`/`ALL_RESOURCES` runtime exports derived from those same union types, via a compile-time exhaustiveness check (`Record<Action, true>` / `Record<Resource, true>` literals: TS rejects the assignment if a member is missing or extra). `groupModals.ts` now builds both `<select>` option lists from these. One source of truth; future drift between the union type and this array fails the build instead of silently reintroducing the bug.

**Defense in depth beyond the currently-known vocabulary**: if a stored permission's value still isn't recognised (a future backend verb the frontend hasn't been taught yet, or legacy/foreign data), an extra `<option>` is appended for that *exact* value — selected, and visibly labeled `⚠ <value> (not recognized by this form)`. Because it's the selected option, that warning text is visible in the closed `<select>` itself, not just on dropdown-open. The permission still round-trips unchanged through `collectPermissions()` instead of being coerced to a different value. This never drops, never widens, never silently hides, and never blocks saving an unrelated change.

## Regression tests

New file `frontend/src/__tests__/group-edit-unrepresentable-permissions.test.ts` (5 tests), using the real seeded `PURCHASER_PERMS` fixture:

- Opens edit on a group holding the exact Purchaser permission set, changes **only the description**, saves, and asserts the permission list sent to `api.updateGroup` is byte-identical to the input (order and all).
- Specifically asserts `approve-any:purchases` / `retry-any:purchases` are not dropped.
- Specifically asserts `view:history` is not widened to `view:*`.
- A genuinely-unrecognised action/resource pair (simulating future backend drift) round-trips unchanged rather than collapsing to an empty permission list.
- The unrecognised value's `<option>` carries the visible "not recognized" warning text, confirmed via `selectedOptions[0].textContent`.

**Verified fail-then-pass**: stashed just the two source-file edits (kept the new tests), ran against pre-fix code — all 5 failed exactly as predicted:
- `approve-any` and `retry-any` missing from the saved permissions array
- `view:history` -> `view:*` in the saved array
- the fully-foreign permission collapsed the saved array to `[]`

Restored the fix: all 5 pass. All 95 pre-existing `groups.test.ts` tests also still pass (100/100 combined).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] New regression tests fail pre-fix, pass post-fix (evidence above)
- [x] `npx jest` full suite — no new failures (8 pre-existing failures in `riexchange.test.ts`/`utils.test.ts` are the known `toLocaleString()` locale mismatch, tracked separately as #1728; unrelated to this diff)
- [x] `npm run build` — clean production build

Part of #1629
