### PR TITLE
sec(auth): enforce a grant ceiling and system-managed guard on group writes

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -222,7 +222,10 @@ func NewHandler(cfg HandlerConfig) *Handler {
 // that would otherwise resolve group-derived permissions for it must treat it
 // as full-access up front (the API key is an infrastructure credential, not a
 // user). See requirePermission / requireAdmin / getAllowedAccounts.
-const apiKeyAdminUserID = "admin-api-key"
+// It is also the actor identity threaded into the group-write grant ceiling,
+// which recognizes it and measures the key against a bare {admin, *} holding
+// (auth.AdminAPIKeyActorID) rather than failing the user lookup.
+const apiKeyAdminUserID = auth.AdminAPIKeyActorID
 
 // requirePermission validates authentication and checks if the user holds the
 // specified permission. The stateless admin API key bypasses the per-user

--- a/internal/api/handler_coverage_test.go
+++ b/internal/api/handler_coverage_test.go
@@ -502,7 +502,7 @@ func TestRouter_Handlers_Coverage(t *testing.T) {
 		mockAuth := new(MockAuthService)
 		mockAuth.On("ValidateSession", ctx, "admin-token").Return(&Session{UserID: "admin"}, nil)
 		mockAuth.grantAdmin()
-		mockAuth.On("CreateGroupAPI", ctx, mock.Anything).Return(map[string]string{"id": "new-group"}, nil)
+		mockAuth.On("CreateGroupAPI", ctx, "admin", mock.Anything).Return(map[string]string{"id": "new-group"}, nil)
 
 		h := &Handler{auth: mockAuth}
 		router := NewRouter(h)
@@ -540,7 +540,7 @@ func TestRouter_Handlers_Coverage(t *testing.T) {
 		mockAuth := new(MockAuthService)
 		mockAuth.On("ValidateSession", ctx, "admin-token").Return(&Session{UserID: "admin"}, nil)
 		mockAuth.grantAdmin()
-		mockAuth.On("UpdateGroupAPI", ctx, "11111111-1111-1111-1111-111111111111", mock.Anything).Return(map[string]string{}, nil)
+		mockAuth.On("UpdateGroupAPI", ctx, "admin", "11111111-1111-1111-1111-111111111111", mock.Anything).Return(map[string]string{}, nil)
 
 		h := &Handler{auth: mockAuth}
 		router := NewRouter(h)

--- a/internal/api/handler_groups.go
+++ b/internal/api/handler_groups.go
@@ -4,6 +4,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/LeanerCloud/CUDly/internal/auth"
 	"github.com/LeanerCloud/CUDly/pkg/logging"
@@ -49,12 +50,27 @@ func (h *Handler) createGroup(ctx context.Context, req *events.LambdaFunctionURL
 		return nil, NewClientError(400, "invalid request body")
 	}
 
-	group, err := h.auth.CreateGroupAPI(ctx, createReq)
+	group, err := h.auth.CreateGroupAPI(ctx, session.UserID, createReq)
 	if err != nil {
-		return nil, err
+		return nil, mapGroupAuthError(err)
 	}
 
 	return group, nil
+}
+
+// mapGroupAuthError maps the group-write sentinels to 403 ClientErrors so a
+// refused grant surfaces the specific permission that was refused instead of
+// a generic 500. Kept separate from mapAuthError (handler_users.go) because
+// that switch is already at the cyclomatic limit and the two sentinel sets
+// are disjoint. Unrecognized errors pass through for handleRequestError.
+func mapGroupAuthError(err error) error {
+	switch {
+	case errors.Is(err, auth.ErrPermissionCeiling),
+		errors.Is(err, auth.ErrPermissionNotGrantable),
+		errors.Is(err, auth.ErrSystemManagedGroup):
+		return NewClientError(403, err.Error())
+	}
+	return err
 }
 
 // getGroup handles GET /api/groups/{id}.
@@ -83,18 +99,19 @@ func (h *Handler) updateGroup(ctx context.Context, req *events.LambdaFunctionURL
 		return nil, err
 	}
 
-	if _, err := h.requirePermission(ctx, req, "update", "groups"); err != nil {
+	session, err := h.requirePermission(ctx, req, "update", "groups")
+	if err != nil {
 		return nil, err
 	}
 
 	var updateReq auth.APIUpdateGroupRequest
-	if err := json.Unmarshal([]byte(req.Body), &updateReq); err != nil {
+	if unmarshalErr := json.Unmarshal([]byte(req.Body), &updateReq); unmarshalErr != nil {
 		return nil, NewClientError(400, "invalid request body")
 	}
 
-	group, err := h.auth.UpdateGroupAPI(ctx, groupID, updateReq)
+	group, err := h.auth.UpdateGroupAPI(ctx, session.UserID, groupID, updateReq)
 	if err != nil {
-		return nil, err
+		return nil, mapGroupAuthError(err)
 	}
 
 	return group, nil
@@ -112,7 +129,7 @@ func (h *Handler) deleteGroup(ctx context.Context, req *events.LambdaFunctionURL
 	}
 
 	if err := h.auth.DeleteGroup(ctx, groupID); err != nil {
-		return nil, err
+		return nil, mapGroupAuthError(err)
 	}
 
 	return map[string]string{"status": "group deleted"}, nil

--- a/internal/api/handler_groups.go
+++ b/internal/api/handler_groups.go
@@ -65,6 +65,9 @@ func (h *Handler) createGroup(ctx context.Context, req *events.LambdaFunctionURL
 // are disjoint. Unrecognized errors pass through for handleRequestError.
 func mapGroupAuthError(err error) error {
 	switch {
+	case errors.Is(err, auth.ErrInvalidPermission):
+		// Malformed input, not an authorization failure.
+		return NewClientError(400, err.Error())
 	case errors.Is(err, auth.ErrPermissionCeiling),
 		errors.Is(err, auth.ErrPermissionNotGrantable),
 		errors.Is(err, auth.ErrSystemManagedGroup):

--- a/internal/api/handler_groups_ceiling_test.go
+++ b/internal/api/handler_groups_ceiling_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/LeanerCloud/CUDly/internal/auth"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Handler-level coverage for the group grant ceiling (issues #1550, #1629).
+//
+// The ceiling itself is enforced in internal/auth; what these tests pin is
+// the wiring the auth package cannot see: that the AUTHENTICATED session's
+// user ID reaches the service as the actor (a ceiling measured against the
+// wrong principal is no ceiling), and that a refusal surfaces as a 403
+// naming the permission rather than a generic 500.
+
+const ceilingGroupID = "11111111-1111-1111-1111-111111111111"
+
+func TestUpdateGroup_ThreadsSessionActorAndMaps403(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	t.Cleanup(func() { mockAuth.AssertExpectations(t) })
+
+	session := &Session{UserID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}
+	mockAuth.On("ValidateSession", ctx, "admin-token").Return(session, nil)
+	mockAuth.grantAdmin()
+
+	refusal := fmt.Errorf("%w: execute:purchases is reserved for separation of duties (issue #923) and cannot be granted through the API",
+		auth.ErrPermissionNotGrantable)
+	// The actor argument is asserted EXACTLY: if updateGroup passed anything
+	// other than the validated session's user ID, this expectation would not
+	// match and the mock would fail the test.
+	mockAuth.On("UpdateGroupAPI", ctx, session.UserID, ceilingGroupID, mock.Anything).
+		Return(nil, refusal).Once()
+
+	h := &Handler{auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"Authorization": "Bearer admin-token"},
+		Body:    `{"permissions":[{"action":"execute","resource":"purchases"}]}`,
+	}
+
+	result, err := h.updateGroup(ctx, req, ceilingGroupID)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "a refused grant must map to a client error, not a 500")
+	assert.Equal(t, 403, ce.code)
+	assert.Contains(t, err.Error(), "execute:purchases")
+}
+
+func TestCreateGroup_ThreadsSessionActorAndMaps403(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	t.Cleanup(func() { mockAuth.AssertExpectations(t) })
+
+	session := &Session{UserID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}
+	mockAuth.On("ValidateSession", ctx, "admin-token").Return(session, nil)
+	mockAuth.grantAdmin()
+
+	refusal := fmt.Errorf("%w: cannot grant delete:accounts because your own permissions do not include it (or not at the requested scope)",
+		auth.ErrPermissionCeiling)
+	mockAuth.On("CreateGroupAPI", ctx, session.UserID, mock.Anything).
+		Return(nil, refusal).Once()
+
+	h := &Handler{auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"Authorization": "Bearer admin-token"},
+		Body:    `{"name":"Escalated","permissions":[{"action":"delete","resource":"accounts"}]}`,
+	}
+
+	result, err := h.createGroup(ctx, req)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "a refused grant must map to a client error, not a 500")
+	assert.Equal(t, 403, ce.code)
+	assert.Contains(t, err.Error(), "delete:accounts")
+}
+
+func TestDeleteGroup_SystemManagedMaps403(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	t.Cleanup(func() { mockAuth.AssertExpectations(t) })
+
+	session := &Session{UserID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}
+	mockAuth.On("ValidateSession", ctx, "admin-token").Return(session, nil)
+	mockAuth.grantAdmin()
+
+	refusal := fmt.Errorf("%w: %q is seeded and maintained by migrations", auth.ErrSystemManagedGroup, "Purchaser")
+	mockAuth.On("DeleteGroup", ctx, ceilingGroupID).Return(refusal).Once()
+
+	h := &Handler{auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"Authorization": "Bearer admin-token"},
+	}
+
+	result, err := h.deleteGroup(ctx, req, ceilingGroupID)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "a system-managed refusal must map to a client error, not a 500")
+	assert.Equal(t, 403, ce.code)
+	assert.Contains(t, err.Error(), "Purchaser")
+}
+
+// TestUpdateGroup_AdminAPIKeyActorIsSentinel pins the admin-API-key branch:
+// the key has no user row, so the handler must hand the auth service the
+// sentinel the ceiling recognizes. Passing an empty string here would make
+// the ceiling fail closed on every admin-key group write instead.
+func TestUpdateGroup_AdminAPIKeyActorIsSentinel(t *testing.T) {
+	assert.Equal(t, auth.AdminAPIKeyActorID, apiKeyAdminUserID,
+		"the admin-API-key session identity must be the sentinel auth.grantCeilingPermissions recognizes")
+
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	t.Cleanup(func() { mockAuth.AssertExpectations(t) })
+
+	updated := map[string]any{"id": ceilingGroupID}
+	mockAuth.On("UpdateGroupAPI", ctx, apiKeyAdminUserID, ceilingGroupID, mock.Anything).
+		Return(updated, nil).Once()
+
+	h := &Handler{auth: mockAuth, apiKey: "super-secret-admin-key"}
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"x-api-key": "super-secret-admin-key"},
+		Body:    `{"name":"Renamed"}`,
+	}
+
+	result, err := h.updateGroup(ctx, req, ceilingGroupID)
+	require.NoError(t, err)
+	assert.Equal(t, updated, result)
+}

--- a/internal/api/handler_groups_test.go
+++ b/internal/api/handler_groups_test.go
@@ -59,7 +59,7 @@ func TestHandler_createGroup_Success(t *testing.T) {
 
 	mockAuth.On("ValidateSession", ctx, "admin-token").Return(adminSession, nil)
 	mockAuth.grantAdmin()
-	mockAuth.On("CreateGroupAPI", ctx, mock.Anything).Return(createdGroup, nil)
+	mockAuth.On("CreateGroupAPI", ctx, adminSession.UserID, mock.Anything).Return(createdGroup, nil)
 
 	handler := &Handler{auth: mockAuth}
 
@@ -122,7 +122,7 @@ func TestHandler_updateGroup_Success(t *testing.T) {
 
 	mockAuth.On("ValidateSession", ctx, "admin-token").Return(adminSession, nil)
 	mockAuth.grantAdmin()
-	mockAuth.On("UpdateGroupAPI", ctx, "11111111-1111-1111-1111-111111111111", mock.Anything).Return(updatedGroup, nil)
+	mockAuth.On("UpdateGroupAPI", ctx, adminSession.UserID, "11111111-1111-1111-1111-111111111111", mock.Anything).Return(updatedGroup, nil)
 
 	handler := &Handler{auth: mockAuth}
 

--- a/internal/api/handler_ri_exchange_test.go
+++ b/internal/api/handler_ri_exchange_test.go
@@ -1218,8 +1218,10 @@ func (m *mockAuthForExchange) UpdateUserAPI(_ context.Context, _, _ string, _ an
 func (m *mockAuthForExchange) DeleteUser(_ context.Context, _ string) error              { return nil }
 func (m *mockAuthForExchange) ListUsersAPI(_ context.Context) (any, error)               { return nil, nil }
 func (m *mockAuthForExchange) ChangePasswordAPI(_ context.Context, _, _, _ string) error { return nil }
-func (m *mockAuthForExchange) CreateGroupAPI(_ context.Context, _ any) (any, error)      { return nil, nil }
-func (m *mockAuthForExchange) UpdateGroupAPI(_ context.Context, _ string, _ any) (any, error) {
+func (m *mockAuthForExchange) CreateGroupAPI(_ context.Context, _ string, _ any) (any, error) {
+	return nil, nil
+}
+func (m *mockAuthForExchange) UpdateGroupAPI(_ context.Context, _, _ string, _ any) (any, error) {
 	return nil, nil
 }
 func (m *mockAuthForExchange) DeleteGroup(_ context.Context, _ string) error        { return nil }

--- a/internal/api/handler_router_test.go
+++ b/internal/api/handler_router_test.go
@@ -38,7 +38,7 @@ func TestHandler_updateGroup_Error(t *testing.T) {
 	adminSession := &Session{UserID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}
 	mockAuth.On("ValidateSession", ctx, "admin-token").Return(adminSession, nil)
 	mockAuth.grantAdmin()
-	mockAuth.On("UpdateGroupAPI", ctx, "11111111-1111-1111-1111-111111111111", mock.Anything).Return(nil, assert.AnError)
+	mockAuth.On("UpdateGroupAPI", ctx, adminSession.UserID, "11111111-1111-1111-1111-111111111111", mock.Anything).Return(nil, assert.AnError)
 
 	handler := &Handler{auth: mockAuth}
 
@@ -79,7 +79,7 @@ func TestHandler_createGroup_Error(t *testing.T) {
 	adminSession := &Session{UserID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}
 	mockAuth.On("ValidateSession", ctx, "admin-token").Return(adminSession, nil)
 	mockAuth.grantAdmin()
-	mockAuth.On("CreateGroupAPI", ctx, mock.Anything).Return(nil, assert.AnError)
+	mockAuth.On("CreateGroupAPI", ctx, adminSession.UserID, mock.Anything).Return(nil, assert.AnError)
 
 	handler := &Handler{auth: mockAuth}
 

--- a/internal/api/mocks_test.go
+++ b/internal/api/mocks_test.go
@@ -250,13 +250,13 @@ func (m *MockAuthService) MFARegenerateRecoveryCodesAPI(ctx context.Context, use
 }
 
 // Group management mock methods.
-func (m *MockAuthService) CreateGroupAPI(ctx context.Context, req interface{}) (interface{}, error) {
-	args := m.Called(ctx, req)
+func (m *MockAuthService) CreateGroupAPI(ctx context.Context, actorUserID string, req interface{}) (interface{}, error) {
+	args := m.Called(ctx, actorUserID, req)
 	return args.Get(0), args.Error(1)
 }
 
-func (m *MockAuthService) UpdateGroupAPI(ctx context.Context, groupID string, req interface{}) (interface{}, error) {
-	args := m.Called(ctx, groupID, req)
+func (m *MockAuthService) UpdateGroupAPI(ctx context.Context, actorUserID, groupID string, req interface{}) (interface{}, error) {
+	args := m.Called(ctx, actorUserID, groupID, req)
 	return args.Get(0), args.Error(1)
 }
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -186,8 +186,13 @@ type AuthServiceInterface interface {
 	MFADisableAPI(ctx context.Context, userID, password, codeOrRecovery string) error
 	MFARegenerateRecoveryCodesAPI(ctx context.Context, userID, code string) (recoveryCodes []string, err error)
 	// Group management - uses auth.API* types
-	CreateGroupAPI(ctx context.Context, req any) (any, error)
-	UpdateGroupAPI(ctx context.Context, groupID string, req any) (any, error)
+	// CreateGroupAPI / UpdateGroupAPI take the acting principal so the
+	// service can enforce the grant ceiling: a caller may not write a
+	// permission onto a group that their own effective permissions do not
+	// hold, and the money verbs carved out of admin:* are not grantable at
+	// all (issues #1550, #1629).
+	CreateGroupAPI(ctx context.Context, actorUserID string, req any) (any, error)
+	UpdateGroupAPI(ctx context.Context, actorUserID, groupID string, req any) (any, error)
 	DeleteGroup(ctx context.Context, groupID string) error
 	GetGroupAPI(ctx context.Context, groupID string) (any, error)
 	ListGroupsAPI(ctx context.Context) (any, error)

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -34,6 +34,26 @@ var (
 	// permission. Mapped to 403 (issue #907).
 	ErrSelfEscalation = errors.New("cannot escalate your own group membership")
 
+	// ErrPermissionCeiling is returned by a group write that would grant a
+	// permission the acting user does not themselves hold (or holds only at
+	// a narrower constraint scope), and by the fail-closed paths where the
+	// acting user's own permissions cannot be resolved at all. Mapped to 403
+	// (issue #1550).
+	ErrPermissionCeiling = errors.New("permission ceiling exceeded")
+
+	// ErrPermissionNotGrantable is returned by a group write that would ADD
+	// one of the money-spending verbs carved out of the admin:* wildcard
+	// (adminCarvedOuts). Those are reserved for separation of duties and are
+	// provisioned by migration, never through the API. Mapped to 403
+	// (issues #923, #1550).
+	ErrPermissionNotGrantable = errors.New("permission not grantable")
+
+	// ErrSystemManagedGroup is returned when a write targets one of the
+	// seeded, system-managed groups. Their contents are owned by migrations;
+	// an API edit that reshapes them can silently disable a whole capability
+	// tenant-wide. Mapped to 403 (issue #1629).
+	ErrSystemManagedGroup = errors.New("system-managed group cannot be modified")
+
 	// ErrCurrentPasswordIncorrect is returned by UpdateUserProfile when the
 	// caller-supplied current password does not match the stored hash. Mapped
 	// to 401 at the API layer (the acting user is verifying their own

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -48,6 +48,15 @@ var (
 	// (issues #923, #1550).
 	ErrPermissionNotGrantable = errors.New("permission not grantable")
 
+	// ErrInvalidPermission is returned when a group write carries a
+	// permission entry with a blank action or resource. A blank resource is
+	// malformed input, NOT a request for the "*" wildcard: the group-edit
+	// form renders an empty stored resource as the selected "All (*)" option
+	// and saves it back as view:*, and the same widening is reachable
+	// directly through the API because nothing validated the list. Mapped to
+	// 400 (issues #1730, #1550).
+	ErrInvalidPermission = errors.New("invalid permission")
+
 	// ErrSystemManagedGroup is returned when a write targets one of the
 	// seeded, system-managed groups. Their contents are owned by migrations;
 	// an API edit that reshapes them can silently disable a whole capability

--- a/internal/auth/group_account_ceiling_test.go
+++ b/internal/auth/group_account_ceiling_test.go
@@ -322,8 +322,122 @@ func TestAccountCeiling_FailsClosedWhenActorScopeUnresolvable(t *testing.T) {
 
 			require.Error(t, err, "an unresolvable scope must refuse the widening, not permit it")
 			assert.ErrorIs(t, err, ErrPermissionCeiling)
-			assert.Contains(t, err.Error(), "could not be established")
+			// Total failure is the degenerate case of a partial one -- every
+			// group skipped -- so it is caught by the skipped-group guard and
+			// carries that message. Assert the sentinel plus the shared
+			// substring rather than one guard's exact wording.
+			assert.Contains(t, err.Error(), "could not be resolved")
 			mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
 		})
 	}
+}
+
+// A PARTIAL group resolution can WIDEN the actor's own scope, letting them
+// grant what their real configuration forbids (#1737 A1, same defect as the
+// read path in #1752).
+//
+// Needs TWO groups: one granting update:groups with no allowed_accounts
+// (unrestricted alone), one carrying the restriction. The union is
+// restricted; lose the restricting group and it collapses to empty = every
+// account, and the ceiling then permits widening a group to ["*"].
+func TestAccountCeiling_PartialActorResolutionThatWidensIsRefused(t *testing.T) {
+	ctx := context.Background()
+	const permGroup, scopeGroup = "g-perm", "g-scope"
+
+	for _, tc := range []struct {
+		name      string
+		scopeResp func(*MockStore)
+	}{
+		{"restricting group missing (ErrNoRows)", func(ms *MockStore) {
+			ms.On("GetGroup", ctx, scopeGroup).Return(nil, pgx.ErrNoRows)
+		}},
+		{"restricting group resolves to (nil, nil)", func(ms *MockStore) {
+			ms.On("GetGroup", ctx, scopeGroup).Return(nil, nil)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mockStore := new(MockStore)
+			t.Cleanup(func() { mockStore.AssertExpectations(t) })
+			svc := createTestService(mockStore, new(MockEmailSender))
+
+			mockStore.On("GetUserByID", ctx, ceilingActorID).
+				Return(&User{ID: ceilingActorID, GroupIDs: []string{permGroup, scopeGroup}}, nil)
+			mockStore.On("GetGroup", ctx, permGroup).Return(&Group{
+				ID:          permGroup,
+				Permissions: []Permission{{Action: ActionUpdate, Resource: ResourceGroups}},
+			}, nil)
+			tc.scopeResp(mockStore)
+			mockStore.On("GetGroup", ctx, ceilingTargetID).Return(&Group{
+				ID: ceilingTargetID, Name: "Team", AllowedAccounts: []string{scopedAccountA},
+			}, nil)
+
+			_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+				APIUpdateGroupRequest{AllowedAccounts: []string{"*"}})
+
+			require.Error(t, err, "a widened actor scope must not authorize widening a group")
+			assert.ErrorIs(t, err, ErrPermissionCeiling)
+			mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+		})
+	}
+}
+
+// Baseline control: both groups resolving, the same actor is correctly
+// refused for a DIFFERENT reason (their real scope does not cover "*"), which
+// is what makes the partial case a genuine bypass rather than a no-op.
+func TestAccountCeiling_PartialActorBaselineIsRefusedOnRealScope(t *testing.T) {
+	ctx := context.Background()
+	const permGroup, scopeGroup = "g-perm", "g-scope"
+
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	mockStore.On("GetUserByID", ctx, ceilingActorID).
+		Return(&User{ID: ceilingActorID, GroupIDs: []string{permGroup, scopeGroup}}, nil)
+	mockStore.On("GetGroup", ctx, permGroup).Return(&Group{
+		ID: permGroup, Permissions: []Permission{{Action: ActionUpdate, Resource: ResourceGroups}},
+	}, nil)
+	mockStore.On("GetGroup", ctx, scopeGroup).Return(&Group{
+		ID: scopeGroup, AllowedAccounts: []string{scopedAccountA},
+	}, nil)
+	mockStore.On("GetGroup", ctx, ceilingTargetID).Return(&Group{
+		ID: ceilingTargetID, Name: "Team", AllowedAccounts: []string{scopedAccountA},
+	}, nil)
+
+	_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+		APIUpdateGroupRequest{AllowedAccounts: []string{"*"}})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPermissionCeiling)
+}
+
+// An actor whose surviving union carries "*" was already maximally wide, so a
+// lost group cannot widen them. Refusing them would be pure availability cost
+// -- and all seven seeded groups ship allowed_accounts = ARRAY['*'].
+func TestAccountCeiling_WildcardActorToleratesSkippedGroup(t *testing.T) {
+	ctx := context.Background()
+	const seededGroup, scopeGroup = "g-seeded", "g-scope"
+
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	mockStore.On("GetUserByID", ctx, ceilingActorID).
+		Return(&User{ID: ceilingActorID, GroupIDs: []string{seededGroup, scopeGroup}}, nil)
+	mockStore.On("GetGroup", ctx, seededGroup).Return(&Group{
+		ID:              seededGroup,
+		Permissions:     []Permission{{Action: ActionUpdate, Resource: ResourceGroups}},
+		AllowedAccounts: []string{"*"},
+	}, nil)
+	mockStore.On("GetGroup", ctx, scopeGroup).Return(nil, pgx.ErrNoRows)
+	mockStore.On("GetGroup", ctx, ceilingTargetID).Return(&Group{
+		ID: ceilingTargetID, Name: "Team", AllowedAccounts: []string{scopedAccountA},
+	}, nil)
+	mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Once()
+
+	_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+		APIUpdateGroupRequest{AllowedAccounts: []string{"*"}})
+
+	require.NoError(t, err,
+		"an actor already unrestricted at baseline must not be refused for a lost group")
 }

--- a/internal/auth/group_account_ceiling_test.go
+++ b/internal/auth/group_account_ceiling_test.go
@@ -1,0 +1,282 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Account-scope ceiling on group writes (issue #1738, folded into #1737).
+//
+// EVERY refusal case here sends allowed_accounts with NO "permissions" key.
+// That shape is the whole finding: checkGrantCeiling returns early when no
+// permissions are sent, so a test that includes permissions alongside would
+// PASS WITH THE BUG PRESENT, because the permission ceiling then runs and
+// refuses for an unrelated reason.
+
+const scopedAccountA = "acct-A"
+
+// scopedActorService wires an actor holding only update:groups, scoped to
+// exactly one cloud account, editing a group scoped to that same account.
+func scopedActorService(t *testing.T, ctx context.Context, mockStore *MockStore) *Service {
+	t.Helper()
+	mockStore.On("GetUserByID", ctx, ceilingActorID).
+		Return(&User{ID: ceilingActorID, GroupIDs: []string{ceilingActorGroupID}}, nil)
+	mockStore.On("GetGroup", ctx, ceilingActorGroupID).Return(&Group{
+		ID:              ceilingActorGroupID,
+		Name:            "Scoped Group Managers",
+		Permissions:     []Permission{{Action: ActionUpdate, Resource: ResourceGroups}},
+		AllowedAccounts: []string{scopedAccountA},
+	}, nil)
+	mockStore.On("GetGroup", ctx, ceilingTargetID).Return(&Group{
+		ID:              ceilingTargetID,
+		Name:            "Team",
+		AllowedAccounts: []string{scopedAccountA},
+	}, nil)
+	return createTestService(mockStore, new(MockEmailSender))
+}
+
+func TestAccountCeiling_RefusesWideningWithNoPermissionsSent(t *testing.T) {
+	ctx := context.Background()
+
+	widenings := []struct {
+		name     string
+		accounts []string
+		wantIn   string
+	}{
+		{"to additional accounts", []string{scopedAccountA, "acct-B"}, `"acct-B"`},
+		// The two unrestricted spellings. An empty list is NOT a narrowing:
+		// IsUnrestrictedAccess reads it as "all accounts".
+		{"to the empty list (unrestricted)", []string{}, "unrestricted"},
+		{"to the wildcard", []string{"*"}, "unrestricted"},
+	}
+
+	for _, w := range widenings {
+		t.Run(w.name, func(t *testing.T) {
+			mockStore := new(MockStore)
+			t.Cleanup(func() { mockStore.AssertExpectations(t) })
+			svc := scopedActorService(t, ctx, mockStore)
+
+			// NOTE: no Permissions field. This is the request shape the bug
+			// lives in; adding permissions here would mask it entirely.
+			result, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+				APIUpdateGroupRequest{AllowedAccounts: w.accounts})
+
+			require.Error(t, err)
+			assert.Nil(t, result)
+			assert.ErrorIs(t, err, ErrPermissionCeiling)
+			assert.Contains(t, err.Error(), w.wantIn)
+			mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+		})
+	}
+}
+
+// Negative control 1: a write that WIDENS the group but stays inside the
+// actor's own scope succeeds.
+//
+// This deliberately widens rather than repeating the group's current scope. A
+// same-value write returns on the not-a-widening branch without ever
+// resolving the actor, so it would prove only that the early return works --
+// not that the actor-scope branch actually grants anything.
+func TestAccountCeiling_AllowsInScopeWidening(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	// Actor may reach A and B; the group currently reaches only A.
+	mockStore.On("GetUserByID", ctx, ceilingActorID).
+		Return(&User{ID: ceilingActorID, GroupIDs: []string{ceilingActorGroupID}}, nil)
+	mockStore.On("GetGroup", ctx, ceilingActorGroupID).Return(&Group{
+		ID:              ceilingActorGroupID,
+		Permissions:     []Permission{{Action: ActionUpdate, Resource: ResourceGroups}},
+		AllowedAccounts: []string{scopedAccountA, "acct-B"},
+	}, nil)
+	mockStore.On("GetGroup", ctx, ceilingTargetID).Return(&Group{
+		ID: ceilingTargetID, Name: "Team", AllowedAccounts: []string{scopedAccountA},
+	}, nil)
+
+	var saved *Group
+	mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).
+		Run(func(a mock.Arguments) {
+			g, ok := a.Get(1).(*Group)
+			require.True(t, ok)
+			saved = g
+		}).Return(nil).Once()
+
+	_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+		APIUpdateGroupRequest{AllowedAccounts: []string{scopedAccountA, "acct-B"}})
+
+	require.NoError(t, err)
+	require.NotNil(t, saved)
+	assert.Equal(t, []string{scopedAccountA, "acct-B"}, saved.AllowedAccounts)
+}
+
+// Negative control 1b: repeating the group's current scope is not a widening
+// and must not require an authorization round-trip at all.
+func TestAccountCeiling_UnchangedScopeSkipsActorLookup(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	mockStore.On("GetGroup", ctx, ceilingTargetID).Return(&Group{
+		ID: ceilingTargetID, Name: "Team", AllowedAccounts: []string{scopedAccountA},
+	}, nil)
+	mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Once()
+
+	_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+		APIUpdateGroupRequest{AllowedAccounts: []string{scopedAccountA}})
+
+	require.NoError(t, err)
+	mockStore.AssertNotCalled(t, "GetUserByID", mock.Anything, mock.Anything)
+}
+
+// Negative control 2: an UNRESTRICTED actor may still widen a group, so the
+// refusals above come from the actor's scope and not from the check refusing
+// all widenings outright.
+func TestAccountCeiling_UnrestrictedActorMayWiden(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	stubActorPermissions(ctx, mockStore, adminOnly) // no AllowedAccounts -> unrestricted
+	stubTargetGroup(ctx, mockStore, &Group{
+		ID: ceilingTargetID, Name: "Team", AllowedAccounts: []string{scopedAccountA},
+	})
+	mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Once()
+
+	_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+		APIUpdateGroupRequest{AllowedAccounts: []string{"*"}})
+	require.NoError(t, err)
+}
+
+// Negative control 3: omitting allowed_accounts entirely (nil, "not sent")
+// must not be treated as a write, or every name-only edit would be refused.
+func TestAccountCeiling_NotSentIsNotAWrite(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	// Only the target group is stubbed. Neither ceiling resolves the actor
+	// for a request that sends nothing they gate, and asserting that here
+	// (via AssertExpectations on an actor-free mock) is the point: a
+	// name-only edit must not become an authorization round-trip.
+	mockStore.On("GetGroup", ctx, ceilingTargetID).Return(&Group{
+		ID: ceilingTargetID, Name: "Team", AllowedAccounts: []string{scopedAccountA},
+	}, nil)
+
+	var saved *Group
+	mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).
+		Run(func(a mock.Arguments) {
+			g, ok := a.Get(1).(*Group)
+			require.True(t, ok)
+			saved = g
+		}).Return(nil).Once()
+
+	_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+		APIUpdateGroupRequest{Name: "Renamed"})
+
+	require.NoError(t, err)
+	require.NotNil(t, saved)
+	assert.Equal(t, "Renamed", saved.Name)
+	assert.Equal(t, []string{scopedAccountA}, saved.AllowedAccounts, "scope must be untouched")
+}
+
+// Narrowing is always allowed, whoever the actor is: it cannot widen anything.
+func TestAccountCeiling_NarrowingIsAllowed(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	mockStore.On("GetUserByID", ctx, ceilingActorID).
+		Return(&User{ID: ceilingActorID, GroupIDs: []string{ceilingActorGroupID}}, nil).Maybe()
+	mockStore.On("GetGroup", ctx, ceilingActorGroupID).Return(&Group{
+		ID:              ceilingActorGroupID,
+		Permissions:     []Permission{{Action: ActionUpdate, Resource: ResourceGroups}},
+		AllowedAccounts: []string{"acct-Z"},
+	}, nil).Maybe()
+	mockStore.On("GetGroup", ctx, ceilingTargetID).Return(&Group{
+		ID: ceilingTargetID, Name: "Team", AllowedAccounts: []string{scopedAccountA, "acct-B"},
+	}, nil)
+	mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Once()
+
+	_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+		APIUpdateGroupRequest{AllowedAccounts: []string{scopedAccountA}})
+	require.NoError(t, err, "narrowing the group's own scope is never a widening")
+}
+
+// CreateGroupAPI has no existing scope to compare against, so any
+// allowed_accounts value must sit inside the creator's own.
+func TestAccountCeiling_CreateIsBounded(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("out of scope is refused", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := createTestService(mockStore, new(MockEmailSender))
+
+		mockStore.On("GetUserByID", ctx, ceilingActorID).
+			Return(&User{ID: ceilingActorID, GroupIDs: []string{ceilingActorGroupID}}, nil)
+		mockStore.On("GetGroup", ctx, ceilingActorGroupID).Return(&Group{
+			ID:              ceilingActorGroupID,
+			Permissions:     []Permission{{Action: ActionCreate, Resource: ResourceGroups}},
+			AllowedAccounts: []string{scopedAccountA},
+		}, nil)
+
+		_, err := svc.CreateGroupAPI(ctx, ceilingActorID, APICreateGroupRequest{
+			Name:            "Wider",
+			AllowedAccounts: []string{"acct-B"},
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrPermissionCeiling)
+		mockStore.AssertNotCalled(t, "CreateGroup", mock.Anything, mock.Anything)
+	})
+
+	t.Run("in scope is allowed", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := createTestService(mockStore, new(MockEmailSender))
+
+		mockStore.On("GetUserByID", ctx, ceilingActorID).
+			Return(&User{ID: ceilingActorID, GroupIDs: []string{ceilingActorGroupID}}, nil)
+		mockStore.On("GetGroup", ctx, ceilingActorGroupID).Return(&Group{
+			ID:              ceilingActorGroupID,
+			Permissions:     []Permission{{Action: ActionCreate, Resource: ResourceGroups}},
+			AllowedAccounts: []string{scopedAccountA},
+		}, nil)
+		mockStore.On("CreateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Once()
+
+		_, err := svc.CreateGroupAPI(ctx, ceilingActorID, APICreateGroupRequest{
+			Name:            "Narrower",
+			AllowedAccounts: []string{scopedAccountA},
+		})
+		require.NoError(t, err)
+	})
+}
+
+// Fail closed: an actor whose scope cannot be resolved cannot widen.
+func TestAccountCeiling_FailsClosedOnUnidentifiedActor(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	stubTargetGroup(ctx, mockStore, &Group{
+		ID: ceilingTargetID, Name: "Team", AllowedAccounts: []string{scopedAccountA},
+	})
+
+	_, err := svc.UpdateGroupAPI(ctx, "", ceilingTargetID,
+		APIUpdateGroupRequest{AllowedAccounts: []string{"*"}})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPermissionCeiling)
+	mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+}

--- a/internal/auth/group_account_ceiling_test.go
+++ b/internal/auth/group_account_ceiling_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -279,4 +281,49 @@ func TestAccountCeiling_FailsClosedOnUnidentifiedActor(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrPermissionCeiling)
 	mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+}
+
+// An actor whose groups do not resolve has an UNKNOWN scope, not an
+// unrestricted one. collectGroupsAndAccounts skips a missing or deleted group
+// silently, so before this guard a total resolution failure produced an empty
+// list -- read as "all accounts" -- and the ceiling became a no-op on exactly
+// the path it guards.
+//
+// The permission ceiling already failed closed on the same input (an empty
+// permission set grants nothing); this closes the asymmetry.
+func TestAccountCeiling_FailsClosedWhenActorScopeUnresolvable(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name      string
+		groupResp func(*MockStore)
+	}{
+		{"actor's only group is missing", func(ms *MockStore) {
+			ms.On("GetGroup", ctx, ceilingActorGroupID).Return(nil, pgx.ErrNoRows)
+		}},
+		{"actor's only group resolves to nil", func(ms *MockStore) {
+			ms.On("GetGroup", ctx, ceilingActorGroupID).Return(nil, nil)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mockStore := new(MockStore)
+			t.Cleanup(func() { mockStore.AssertExpectations(t) })
+			svc := createTestService(mockStore, new(MockEmailSender))
+
+			mockStore.On("GetUserByID", ctx, ceilingActorID).
+				Return(&User{ID: ceilingActorID, GroupIDs: []string{ceilingActorGroupID}}, nil)
+			tc.groupResp(mockStore)
+			mockStore.On("GetGroup", ctx, ceilingTargetID).Return(&Group{
+				ID: ceilingTargetID, Name: "Team", AllowedAccounts: []string{scopedAccountA},
+			}, nil)
+
+			_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+				APIUpdateGroupRequest{AllowedAccounts: []string{"*"}})
+
+			require.Error(t, err, "an unresolvable scope must refuse the widening, not permit it")
+			assert.ErrorIs(t, err, ErrPermissionCeiling)
+			assert.Contains(t, err.Error(), "could not be established")
+			mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+		})
+	}
 }

--- a/internal/auth/group_ceiling.go
+++ b/internal/auth/group_ceiling.go
@@ -155,6 +155,25 @@ func (s *Service) grantCeilingAccounts(ctx context.Context, actorUserID string) 
 	if err != nil {
 		return nil, fmt.Errorf("%w: could not resolve the acting user's account scope: %w", ErrPermissionCeiling, err)
 	}
+	// A PARTIAL resolution can WIDEN the actor's scope, which is the case that
+	// matters and the one an earlier version of this guard missed.
+	//
+	// AllowedAccounts is a union in which the empty set means EVERYTHING, so
+	// dropping a contributing group does not narrow it. The union of [] and
+	// ["acct-A"] is restricted; lose the group carrying ["acct-A"] and it
+	// collapses to [] = unrestricted, and the actor can then widen any group
+	// to ["*"]. Verified by execution against the write path: baseline
+	// REFUSED, one skipped group ACCEPTED.
+	//
+	// The test is len(AllowedAccounts) == 0, NOT IsUnrestrictedAccess. A union
+	// containing "*" was already maximally wide at baseline, so no loss can
+	// widen it; refusing it would be zero security benefit and pure
+	// availability cost, and all seven seeded groups ship ARRAY['*'].
+	if len(authCtx.AllowedAccounts) == 0 && authCtx.SkippedGroups > 0 {
+		return nil, fmt.Errorf(
+			"%w: %d group(s) could not be resolved and the acting user's remaining scope is unrestricted",
+			ErrPermissionCeiling, authCtx.SkippedGroups)
+	}
 	// An unresolved scope is UNKNOWN, not unrestricted.
 	//
 	// collectGroupsAndAccounts skips a missing or deleted group silently

--- a/internal/auth/group_ceiling.go
+++ b/internal/auth/group_ceiling.go
@@ -1,0 +1,202 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Grant ceiling for group-permission writes (issues #1550, #1629).
+//
+// Before this, CreateGroupAPI / UpdateGroupAPI wrote the client-supplied
+// permission list onto a group verbatim. Because update:groups is NOT one of
+// the pairs carved out of the admin:* wildcard, any admin could, in a single
+// request, write execute:purchases / approve-any:purchases /
+// retry-any:purchases onto their own group and void the #923 money
+// separation-of-duties control tenant-wide.
+//
+// Two rules close that, and both are enforced here:
+//
+//  1. Ceiling: a caller may only grant permissions their own effective set
+//     already holds, at constraints no broader than their own.
+//  2. Non-grantable: the money verbs in adminCarvedOuts may never be ADDED to
+//     a group at all, whoever the caller is. This second rule is load-bearing
+//     rather than belt-and-braces: migrations 000059/000064 backfill every
+//     Administrators member into the Purchaser group, so in a default
+//     deployment a typical admin DOES explicitly hold the money verbs and
+//     rule 1 alone would let them relay those verbs onto the Administrators
+//     group. The only group granting these verbs today is seeded by SQL and
+//     is system-managed, so nothing legitimate needs the API to grant them.
+
+// AdminAPIKeyActorID is the sentinel actor identifier carried by the
+// stateless admin API-key session. The key is an infrastructure credential
+// with no backing user row, so a group-derived permission lookup cannot
+// resolve it. The ceiling treats it as holding exactly {admin, *} -- what it
+// is authorized as everywhere else -- which subjects it to the same
+// carve-out as a human admin: it can seed ordinary groups but cannot grant
+// the money-spending verbs (issue #1550's third vector).
+//
+// internal/api's apiKeyAdminUserID aliases this constant; keep them equal.
+const AdminAPIKeyActorID = "admin-api-key"
+
+// grantCeilingPermissions returns the permission set a group write is
+// measured against. Fails closed: an unidentified actor, or any error
+// resolving the actor's groups, refuses the write rather than falling
+// through to "allow".
+func (s *Service) grantCeilingPermissions(ctx context.Context, actorUserID string) ([]Permission, error) {
+	if actorUserID == "" {
+		return nil, fmt.Errorf("%w: the acting user could not be identified", ErrPermissionCeiling)
+	}
+	if actorUserID == AdminAPIKeyActorID {
+		return []Permission{{Action: ActionAdmin, Resource: ResourceAll}}, nil
+	}
+	perms, err := s.GetUserPermissions(ctx, actorUserID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: could not resolve the acting user's permissions: %w", ErrPermissionCeiling, err)
+	}
+	return perms, nil
+}
+
+// checkGrantCeiling validates a requested group-permission list against the
+// two rules above.
+//
+// existing is the target group's CURRENT permission list (nil on create). A
+// carved-out permission already on the group may be carried through an
+// unrelated edit -- a rename must not be forced to strip it -- but only at
+// constraints no broader than the ones already stored, so an edit cannot
+// raise an existing MaxPurchaseAmount either.
+//
+// A refusal names the offending permission and returns an error: the list is
+// never silently narrowed to the subset that would have been allowed, which
+// is exactly the silent-corruption failure mode #1629 reports on the
+// frontend side.
+func (s *Service) checkGrantCeiling(ctx context.Context, actorUserID string, requested, existing []Permission) error {
+	if len(requested) == 0 {
+		return nil
+	}
+	actorPerms, err := s.grantCeilingPermissions(ctx, actorUserID)
+	if err != nil {
+		return err
+	}
+	for _, req := range requested {
+		if adminCarvedOuts[[2]string{req.Action, req.Resource}] {
+			if permissionCoveredBy(existing, req) {
+				continue
+			}
+			return fmt.Errorf(
+				"%w: %s:%s is reserved for separation of duties (issue #923) and cannot be granted through the API",
+				ErrPermissionNotGrantable, req.Action, req.Resource)
+		}
+		if !grantCeilingAllows(actorPerms, req) {
+			return fmt.Errorf(
+				"%w: cannot grant %s:%s because your own permissions do not include it (or not at the requested scope)",
+				ErrPermissionCeiling, req.Action, req.Resource)
+		}
+	}
+	return nil
+}
+
+// grantCeilingAllows reports whether actorPerms holds req in full. Action and
+// resource matching mirrors permissionsAllow exactly, including the admin:*
+// carve-out, so the ceiling can never be looser than enforcement. It adds one
+// requirement enforcement does not need: a constrained holder cannot hand out
+// an unconstrained (or differently scoped) copy of their own permission.
+func grantCeilingAllows(actorPerms []Permission, req Permission) bool {
+	for _, held := range actorPerms {
+		if checkAdminPermission(held) {
+			// admin:* carries no constraints, so it covers any requested
+			// constraint set. Carved-out pairs never reach here (the caller
+			// rejects them first), but mirror permissionsAllow anyway so the
+			// two stay in lockstep if the carve-out set grows (#1644).
+			if adminCarvedOuts[[2]string{req.Action, req.Resource}] {
+				continue
+			}
+			return true
+		}
+		if !checkPermissionMatch(held, req.Action, req.Resource) {
+			continue
+		}
+		if !constraintsCover(held.Constraints, req.Constraints) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// permissionCoveredBy reports whether set already contains a permission with
+// req's exact action and resource, at constraints no narrower than req's. It
+// distinguishes "this write KEEPS what the group already had" from "this
+// write grants or widens it".
+func permissionCoveredBy(set []Permission, req Permission) bool {
+	for _, p := range set {
+		if p.Action != req.Action || p.Resource != req.Resource {
+			continue
+		}
+		if constraintsCover(p.Constraints, req.Constraints) {
+			return true
+		}
+	}
+	return false
+}
+
+// constraintsCover reports whether a permission constrained by held is broad
+// enough to cover a grant constrained by req.
+//
+// Mirrors the enforcement-time semantics in matchConstraints: an empty list
+// or a zero MaxPurchaseAmount means "no restriction on this dimension". So an
+// unconstrained holder covers anything, while a constrained one requires the
+// grant to name a subset of the same values and a cap no higher than its own.
+// A nil req against a constrained held is a widening and is refused.
+func constraintsCover(held, req *PermissionConstraints) bool {
+	if held == nil {
+		return true
+	}
+	if req == nil {
+		req = &PermissionConstraints{}
+	}
+	return listCovers(held.AccountIDs, req.AccountIDs) &&
+		listCovers(held.Providers, req.Providers) &&
+		listCovers(held.Services, req.Services) &&
+		listCovers(held.Regions, req.Regions) &&
+		amountCovers(held.MaxPurchaseAmount, req.MaxPurchaseAmount)
+}
+
+// listCovers reports whether every value in req is permitted by held. An
+// empty held list is "no restriction on this dimension" and covers anything;
+// a non-empty held list requires req to be a NON-EMPTY subset, so a grant can
+// never drop the restriction. Values are trimmed and lower-cased, matching
+// matchAllRegionsConstraint's comparison.
+func listCovers(held, req []string) bool {
+	if len(held) == 0 {
+		return true
+	}
+	if len(req) == 0 {
+		return false
+	}
+	permitted := make(map[string]bool, len(held))
+	for _, v := range held {
+		permitted[normalizeConstraintValue(v)] = true
+	}
+	for _, v := range req {
+		if !permitted[normalizeConstraintValue(v)] {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeConstraintValue(v string) string {
+	return strings.ToLower(strings.TrimSpace(v))
+}
+
+// amountCovers reports whether a grant capped at reqMax stays within a holder
+// capped at heldMax. Zero means "no cap" on both sides (mirroring
+// matchPurchaseAmountConstraint), so a capped holder cannot hand out an
+// uncapped grant.
+func amountCovers(heldMax, reqMax float64) bool {
+	if heldMax <= 0 {
+		return true
+	}
+	return reqMax > 0 && reqMax <= heldMax
+}

--- a/internal/auth/group_ceiling.go
+++ b/internal/auth/group_ceiling.go
@@ -155,6 +155,22 @@ func (s *Service) grantCeilingAccounts(ctx context.Context, actorUserID string) 
 	if err != nil {
 		return nil, fmt.Errorf("%w: could not resolve the acting user's account scope: %w", ErrPermissionCeiling, err)
 	}
+	// An unresolved scope is UNKNOWN, not unrestricted.
+	//
+	// collectGroupsAndAccounts skips a missing or deleted group silently
+	// (pgx.ErrNoRows, or a nil group), so an actor whose groups all fail to
+	// load yields an EMPTY account list -- which IsUnrestrictedAccess reads as
+	// "all accounts". That turns this ceiling into a no-op on exactly the
+	// path it guards, so require that at least one group actually resolved.
+	//
+	// Note the asymmetry this closes: the permission ceiling already fails
+	// closed on the same input, because an empty permission set grants
+	// nothing. Without this the account ceiling failed OPEN on it.
+	if len(authCtx.Groups) == 0 {
+		return nil, fmt.Errorf(
+			"%w: the acting user's account scope could not be established (no group resolved)",
+			ErrPermissionCeiling)
+	}
 	return authCtx.AllowedAccounts, nil
 }
 

--- a/internal/auth/group_ceiling.go
+++ b/internal/auth/group_ceiling.go
@@ -138,6 +138,104 @@ func validateRequestedPermissions(requested []Permission) error {
 	return nil
 }
 
+// grantCeilingAccounts returns the account scope a group write is measured
+// against: the union of the acting principal's groups' AllowedAccounts.
+// Fails closed on an unidentified actor or a resolution error.
+//
+// The stateless admin API key has no user row and is unrestricted everywhere
+// else (see getAllowedAccounts in internal/api), so it is unrestricted here.
+func (s *Service) grantCeilingAccounts(ctx context.Context, actorUserID string) ([]string, error) {
+	if actorUserID == "" {
+		return nil, fmt.Errorf("%w: the acting user could not be identified", ErrPermissionCeiling)
+	}
+	if actorUserID == AdminAPIKeyActorID {
+		return nil, nil
+	}
+	authCtx, err := s.BuildAuthContext(ctx, actorUserID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: could not resolve the acting user's account scope: %w", ErrPermissionCeiling, err)
+	}
+	return authCtx.AllowedAccounts, nil
+}
+
+// checkAccountCeiling bounds the OTHER account dimension of a group write.
+//
+// This is deliberately a separate call from checkGrantCeiling rather than a
+// branch inside it. checkGrantCeiling returns early when no permissions are
+// sent, and APIUpdateGroupRequest's "empty means not sent" contract makes an
+// allowed_accounts-only PUT the natural shape -- so folding this in would
+// leave exactly the request that widens account scope unchecked. That was the
+// live gap: widening AllowedAccounts to more accounts, to [] or to ["*"] was
+// accepted, while widening Permissions[].Constraints.AccountIDs on the SAME
+// call was correctly refused.
+//
+// requested == nil means "not sent" and is left alone. A write is in ceiling
+// if it does not widen the group's existing scope, or if it stays within the
+// acting principal's own scope.
+func (s *Service) checkAccountCeiling(ctx context.Context, actorUserID string, requested, existing []string) error {
+	if requested == nil {
+		return nil
+	}
+	// Not a widening of what the group already had -- safe whoever the actor
+	// is. Only reachable on update: a new group has no prior scope, and nil
+	// existing would read as UNRESTRICTED here and swallow every check, which
+	// is why CreateGroupAPI calls checkAccountGrant directly instead.
+	if accountScopeGap(existing, requested) == "" {
+		return nil
+	}
+	return s.checkAccountGrant(ctx, actorUserID, requested)
+}
+
+// checkAccountGrant requires requested to sit inside the acting principal's
+// own account scope. This is the create-path entry point, where there is no
+// prior scope to compare against, so every value is a grant.
+//
+// A nil requested is checked too, and deliberately: on create, omitting
+// allowed_accounts produces an UNRESTRICTED group (IsUnrestrictedAccess reads
+// empty as "all accounts"), so for a scoped actor that is the widest possible
+// grant rather than a no-op.
+func (s *Service) checkAccountGrant(ctx context.Context, actorUserID string, requested []string) error {
+	actorAccounts, err := s.grantCeilingAccounts(ctx, actorUserID)
+	if err != nil {
+		return err
+	}
+	if gap := accountScopeGap(actorAccounts, requested); gap != "" {
+		return fmt.Errorf(
+			"%w: cannot grant %s because your own account scope does not include it",
+			ErrPermissionCeiling, gap)
+	}
+	return nil
+}
+
+// accountScopeGap returns a description of the first way requested reaches
+// beyond outer, or "" when outer covers it entirely.
+//
+// Empty and "*" both mean UNRESTRICTED on either side (IsUnrestrictedAccess),
+// which is why this cannot be a plain subset test: the empty set is a subset
+// of everything but means the opposite of narrow. An unrestricted request
+// against a restricted holder is the widening this exists to catch.
+//
+// Comparison is exact, matching MatchesAccount. Case folding would only make
+// the check more permissive, which is the wrong direction for a ceiling.
+func accountScopeGap(outer, requested []string) string {
+	if IsUnrestrictedAccess(outer) {
+		return ""
+	}
+	if IsUnrestrictedAccess(requested) {
+		return "unrestricted access to all cloud accounts"
+	}
+	permitted := make(map[string]bool, len(outer))
+	for _, a := range outer {
+		permitted[strings.TrimSpace(a)] = true
+	}
+	for _, a := range requested {
+		if !permitted[strings.TrimSpace(a)] {
+			return fmt.Sprintf("access to cloud account %q", a)
+		}
+	}
+	return ""
+}
+
 // grantCeilingAllows reports whether actorPerms holds req in full. Action and
 // resource matching mirrors permissionsAllow exactly, including the admin:*
 // carve-out, so the ceiling can never be looser than enforcement. It adds one

--- a/internal/auth/group_ceiling.go
+++ b/internal/auth/group_ceiling.go
@@ -74,6 +74,9 @@ func (s *Service) checkGrantCeiling(ctx context.Context, actorUserID string, req
 	if len(requested) == 0 {
 		return nil
 	}
+	if err := validateRequestedPermissions(requested); err != nil {
+		return err
+	}
 	actorPerms, err := s.grantCeilingPermissions(ctx, actorUserID)
 	if err != nil {
 		return err
@@ -91,6 +94,45 @@ func (s *Service) checkGrantCeiling(ctx context.Context, actorUserID string, req
 			return fmt.Errorf(
 				"%w: cannot grant %s:%s because your own permissions do not include it (or not at the requested scope)",
 				ErrPermissionCeiling, req.Action, req.Resource)
+		}
+	}
+	return nil
+}
+
+// validateRequestedPermissions rejects malformed entries before the ceiling
+// runs (issue #1730).
+//
+// This is NOT redundant with the ceiling. The ceiling's admin:* branch grants
+// any (action, resource) pair that is not carved out, and ("view", "") is not
+// carved out, so before this check an admin could write a blank resource
+// straight through. It then round-trips as the "*" WILDCARD: the group-edit
+// form picks its `<option>` with `isDefault = !currentValue && resource ===
+// '*'`, so an empty stored resource renders as the selected "All (*)" entry
+// and saves back as view:*. Nothing validated the list on the way in, so the
+// same widening is reachable from any API client with no form involved.
+//
+// The two blank fields fail differently in the form -- a blank action is
+// silently DROPPED (its index 0 is an empty placeholder) while a blank
+// resource is silently WIDENED (its index 0 is the wildcard) -- which is why
+// the defect is in the defaulting rather than the parsing. Only the resource
+// side escalates; both are refused here, because a silently dropped
+// permission is a different bug rather than an acceptable one.
+//
+// Blank means empty or whitespace-only. Unknown-but-non-blank values are
+// deliberately NOT rejected: vocabulary validation is a separate concern
+// (#1629) and rejecting values this endpoint can legitimately already have
+// stored would break edits of existing groups.
+func validateRequestedPermissions(requested []Permission) error {
+	for i, p := range requested {
+		if strings.TrimSpace(p.Action) == "" {
+			return fmt.Errorf(
+				"%w: entry %d has a blank action (resource %q); a blank action is malformed input, not a permission to drop",
+				ErrInvalidPermission, i, p.Resource)
+		}
+		if strings.TrimSpace(p.Resource) == "" {
+			return fmt.Errorf(
+				"%w: entry %d has a blank resource (action %q); a blank resource is malformed input, not a request for the %q wildcard",
+				ErrInvalidPermission, i, p.Action, ResourceAll)
 		}
 	}
 	return nil

--- a/internal/auth/group_ceiling.go
+++ b/internal/auth/group_ceiling.go
@@ -250,8 +250,15 @@ func (s *Service) checkAccountGrant(ctx context.Context, actorUserID string, req
 // of everything but means the opposite of narrow. An unrestricted request
 // against a restricted holder is the widening this exists to catch.
 //
-// Comparison is exact, matching MatchesAccount. Case folding would only make
-// the check more permissive, which is the wrong direction for a ceiling.
+// Comparison is EXACT -- no trimming, no case folding -- because that is what
+// MatchesAccount does at enforcement (`a == accountID`). Normalising here
+// would make the ceiling MORE permissive than enforcement: an actor whose
+// stored scope is " acct-A" matches nothing when access is actually checked,
+// yet a trimming ceiling would treat them as holding "acct-A" and let them
+// grant it.
+//
+// The rule to preserve: a ceiling may be STRICTER than enforcement (a false
+// refusal fails closed and is visible), never looser.
 func accountScopeGap(outer, requested []string) string {
 	if IsUnrestrictedAccess(outer) {
 		return ""
@@ -261,10 +268,10 @@ func accountScopeGap(outer, requested []string) string {
 	}
 	permitted := make(map[string]bool, len(outer))
 	for _, a := range outer {
-		permitted[strings.TrimSpace(a)] = true
+		permitted[a] = true
 	}
 	for _, a := range requested {
-		if !permitted[strings.TrimSpace(a)] {
+		if !permitted[a] {
 			return fmt.Sprintf("access to cloud account %q", a)
 		}
 	}
@@ -340,8 +347,18 @@ func constraintsCover(held, req *PermissionConstraints) bool {
 // listCovers reports whether every value in req is permitted by held. An
 // empty held list is "no restriction on this dimension" and covers anything;
 // a non-empty held list requires req to be a NON-EMPTY subset, so a grant can
-// never drop the restriction. Values are trimmed and lower-cased, matching
-// matchAllRegionsConstraint's comparison.
+// never drop the restriction.
+//
+// Comparison is EXACT for every dimension. An earlier version normalised
+// (trim + lower-case) and justified it as "matching matchAllRegionsConstraint"
+// -- true for Regions only. AccountIDs, Providers and Services are enforced by
+// containsAny, an exact case-sensitive lookup, so normalising made the ceiling
+// LOOSER than enforcement there: a holder constrained to ["ACCT-1"] could
+// grant ["acct-1"], a value they cannot themselves use.
+//
+// Being exact on Regions too is stricter than its enforcement, not looser, so
+// it fails closed. A ceiling may exceed enforcement in strictness; it must
+// never fall short.
 func listCovers(held, req []string) bool {
 	if len(held) == 0 {
 		return true
@@ -351,18 +368,14 @@ func listCovers(held, req []string) bool {
 	}
 	permitted := make(map[string]bool, len(held))
 	for _, v := range held {
-		permitted[normalizeConstraintValue(v)] = true
+		permitted[v] = true
 	}
 	for _, v := range req {
-		if !permitted[normalizeConstraintValue(v)] {
+		if !permitted[v] {
 			return false
 		}
 	}
 	return true
-}
-
-func normalizeConstraintValue(v string) string {
-	return strings.ToLower(strings.TrimSpace(v))
 }
 
 // amountCovers reports whether a grant capped at reqMax stays within a holder

--- a/internal/auth/group_ceiling_fixtures_test.go
+++ b/internal/auth/group_ceiling_fixtures_test.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"context"
+	"testing"
+)
+
+// Shared fixtures for the group-ceiling test files (issues #1550, #1629,
+// #1730). Split out of group_ceiling_test.go, which exceeded the repo's
+// 500-line guideline.
+//
+// Every refusal case here deliberately stubs NO CreateGroup / UpdateGroup /
+// DeleteGroup expectation on the mock store. testify's mock panics on an
+// un-stubbed call, so if the guard under test were removed the write would
+// reach the store and the test would fail loudly rather than silently pass.
+// That is the mutation check: these assertions are not vacuous.
+
+const (
+	ceilingActorID      = "11111111-1111-4111-8111-111111111111"
+	ceilingActorGroupID = "22222222-2222-4222-8222-222222222222"
+	ceilingTargetID     = "33333333-3333-4333-8333-333333333333"
+)
+
+// stubActorPermissions wires the two store lookups GetUserPermissions makes
+// for the acting user: the user row, then each of its groups.
+func stubActorPermissions(ctx context.Context, mockStore *MockStore, perms []Permission) {
+	mockStore.On("GetUserByID", ctx, ceilingActorID).
+		Return(&User{ID: ceilingActorID, GroupIDs: []string{ceilingActorGroupID}}, nil)
+	mockStore.On("GetGroup", ctx, ceilingActorGroupID).
+		Return(&Group{ID: ceilingActorGroupID, Name: "Actor Group", Permissions: perms}, nil)
+}
+
+// stubActorPermissionsMaybe is the .Maybe() form, for tests where the guard
+// under test must return BEFORE the actor is resolved. Registering the reads
+// permissively means a removed guard is caught by the test's own assertions
+// rather than by an incidental panic on a missing stub -- a kill that a later
+// fixture tidy-up would silently delete.
+func stubActorPermissionsMaybe(ctx context.Context, mockStore *MockStore, perms []Permission) {
+	mockStore.On("GetUserByID", ctx, ceilingActorID).
+		Return(&User{ID: ceilingActorID, GroupIDs: []string{ceilingActorGroupID}}, nil).Maybe()
+	mockStore.On("GetGroup", ctx, ceilingActorGroupID).
+		Return(&Group{ID: ceilingActorGroupID, Name: "Actor Group", Permissions: perms}, nil).Maybe()
+}
+
+func stubTargetGroup(ctx context.Context, mockStore *MockStore, group *Group) {
+	mockStore.On("GetGroup", ctx, ceilingTargetID).Return(group, nil)
+}
+
+func newCeilingService(t *testing.T, mockStore *MockStore) *Service {
+	t.Helper()
+	return createTestService(mockStore, new(MockEmailSender))
+}
+
+func updateReqWith(perms ...APIPermission) APIUpdateGroupRequest {
+	return APIUpdateGroupRequest{Name: "Renamed", Permissions: perms}
+}
+
+var adminOnly = []Permission{{Action: ActionAdmin, Resource: ResourceAll}}

--- a/internal/auth/group_ceiling_permissions_test.go
+++ b/internal/auth/group_ceiling_permissions_test.go
@@ -1,5 +1,11 @@
 package auth
 
+// Grant-ceiling tests (issues #1550, #1629): what a caller may hand out.
+//
+// Shared fixtures live in group_ceiling_fixtures_test.go. Every refusal case
+// asserts that no write reached the store, with per-parameter matchers --
+// a name-only AssertNotCalled can never fail (issue #1595).
+
 import (
 	"context"
 	"errors"
@@ -9,44 +15,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-// Grant-ceiling regression tests for issues #1550 and #1629.
-//
-// Every refusal case here deliberately stubs NO CreateGroup / UpdateGroup /
-// DeleteGroup expectation on the mock store. testify's mock panics on an
-// un-stubbed call, so if the guard under test were removed the write would
-// reach the store and the test would fail loudly rather than silently pass.
-// That is the mutation check: these assertions are not vacuous.
-
-const (
-	ceilingActorID      = "11111111-1111-4111-8111-111111111111"
-	ceilingActorGroupID = "22222222-2222-4222-8222-222222222222"
-	ceilingTargetID     = "33333333-3333-4333-8333-333333333333"
-)
-
-// stubActorPermissions wires the two store lookups GetUserPermissions makes
-// for the acting user: the user row, then each of its groups.
-func stubActorPermissions(ctx context.Context, mockStore *MockStore, perms []Permission) {
-	mockStore.On("GetUserByID", ctx, ceilingActorID).
-		Return(&User{ID: ceilingActorID, GroupIDs: []string{ceilingActorGroupID}}, nil)
-	mockStore.On("GetGroup", ctx, ceilingActorGroupID).
-		Return(&Group{ID: ceilingActorGroupID, Name: "Actor Group", Permissions: perms}, nil)
-}
-
-func stubTargetGroup(ctx context.Context, mockStore *MockStore, group *Group) {
-	mockStore.On("GetGroup", ctx, ceilingTargetID).Return(group, nil)
-}
-
-func newCeilingService(t *testing.T, mockStore *MockStore) *Service {
-	t.Helper()
-	return createTestService(mockStore, new(MockEmailSender))
-}
-
-func updateReqWith(perms ...APIPermission) APIUpdateGroupRequest {
-	return APIUpdateGroupRequest{Name: "Renamed", Permissions: perms}
-}
-
-var adminOnly = []Permission{{Action: ActionAdmin, Resource: ResourceAll}}
 
 // TestGrantCeiling_CarvedOutNotGrantable is the #1550 attack itself: an admin
 // writing the money verbs onto a group in a single request.
@@ -158,131 +126,6 @@ func TestGrantCeiling_CarvedOutMayBeKeptNotWidened(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrPermissionNotGrantable)
 		mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
-	})
-}
-
-// TestGrantCeiling_RejectsBlankActionOrResource covers the #1730 widening
-// path. A blank resource is NOT caught by the ceiling: the admin:* branch
-// grants any pair that is not carved out, and ("view", "") is not carved out,
-// so before validateRequestedPermissions an admin wrote it straight through
-// and it round-tripped through the group-edit form as the "*" wildcard.
-func TestGrantCeiling_RejectsBlankActionOrResource(t *testing.T) {
-	ctx := context.Background()
-
-	blank := []struct {
-		name string
-		perm APIPermission
-	}{
-		// The escalating case: blank resource widens to "*".
-		{"empty resource", APIPermission{Action: ActionView, Resource: ""}},
-		{"whitespace resource", APIPermission{Action: ActionView, Resource: "   "}},
-		// The non-escalating but still malformed case: blank action is
-		// silently dropped by the form.
-		{"empty action", APIPermission{Action: "", Resource: ResourcePurchases}},
-		{"whitespace action", APIPermission{Action: "  ", Resource: ResourcePurchases}},
-		{"both blank", APIPermission{Action: "", Resource: ""}},
-	}
-
-	for _, tc := range blank {
-		t.Run("update/"+tc.name, func(t *testing.T) {
-			mockStore := new(MockStore)
-			t.Cleanup(func() { mockStore.AssertExpectations(t) })
-			svc := newCeilingService(t, mockStore)
-
-			stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
-
-			result, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID, updateReqWith(tc.perm))
-
-			require.Error(t, err)
-			assert.Nil(t, result)
-			assert.ErrorIs(t, err, ErrInvalidPermission)
-			// The refusal names the offending entry.
-			assert.Contains(t, err.Error(), "entry 0")
-			mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
-			// Validation runs BEFORE the actor lookup, so a malformed entry is
-			// refused whoever the caller is -- including a full admin, whose
-			// admin:* branch would otherwise grant ("view", "") outright.
-			mockStore.AssertNotCalled(t, "GetUserByID", mock.Anything, mock.Anything)
-		})
-
-		t.Run("create/"+tc.name, func(t *testing.T) {
-			mockStore := new(MockStore)
-			t.Cleanup(func() { mockStore.AssertExpectations(t) })
-			svc := newCeilingService(t, mockStore)
-
-			_, err := svc.CreateGroupAPI(ctx, ceilingActorID, APICreateGroupRequest{
-				Name:        "Team",
-				Permissions: []APIPermission{tc.perm},
-			})
-
-			require.Error(t, err)
-			assert.ErrorIs(t, err, ErrInvalidPermission)
-			mockStore.AssertNotCalled(t, "CreateGroup", mock.Anything, mock.Anything)
-			mockStore.AssertNotCalled(t, "GetUserByID", mock.Anything, mock.Anything)
-		})
-	}
-
-	// A blank entry anywhere in the list refuses the WHOLE write; the valid
-	// entries are not saved without it (never silently narrow).
-	t.Run("a blank entry beside valid ones refuses the whole list", func(t *testing.T) {
-		mockStore := new(MockStore)
-		t.Cleanup(func() { mockStore.AssertExpectations(t) })
-		svc := newCeilingService(t, mockStore)
-
-		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
-
-		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID, updateReqWith(
-			APIPermission{Action: ActionView, Resource: ResourcePlans},
-			APIPermission{Action: ActionView, Resource: ""},
-		))
-
-		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrInvalidPermission)
-		assert.Contains(t, err.Error(), "entry 1")
-		mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
-	})
-
-	// Negative control: a well-formed permission is still accepted, so the
-	// validator is not simply refusing everything.
-	t.Run("a well-formed permission is still accepted", func(t *testing.T) {
-		mockStore := new(MockStore)
-		t.Cleanup(func() { mockStore.AssertExpectations(t) })
-		svc := newCeilingService(t, mockStore)
-
-		stubActorPermissions(ctx, mockStore, adminOnly)
-		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
-
-		var saved *Group
-		mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).
-			Run(func(args mock.Arguments) {
-				g, ok := args.Get(1).(*Group)
-				require.True(t, ok)
-				saved = g
-			}).Return(nil).Once()
-
-		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
-			updateReqWith(APIPermission{Action: ActionView, Resource: ResourcePlans}))
-
-		require.NoError(t, err)
-		require.NotNil(t, saved)
-		assert.Equal(t, []Permission{{Action: ActionView, Resource: ResourcePlans}}, saved.Permissions)
-	})
-
-	// An explicit "*" is a legitimate value and must NOT be confused with a
-	// blank one; it is gated by the ceiling instead.
-	t.Run("an explicit wildcard is not treated as blank", func(t *testing.T) {
-		mockStore := new(MockStore)
-		t.Cleanup(func() { mockStore.AssertExpectations(t) })
-		svc := newCeilingService(t, mockStore)
-
-		stubActorPermissions(ctx, mockStore, adminOnly)
-		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
-		mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Once()
-
-		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
-			updateReqWith(APIPermission{Action: ActionView, Resource: ResourceAll}))
-
-		require.NoError(t, err, "an admin holding admin:* may grant view:*; only a BLANK resource is malformed")
 	})
 }
 
@@ -568,75 +411,5 @@ func TestGrantCeiling_CreateGroupAPI(t *testing.T) {
 			Permissions: []APIPermission{{Action: ActionView, Resource: ResourcePlans}},
 		})
 		require.NoError(t, err)
-	})
-}
-
-// TestSystemManagedGroup_Immutable covers the second half of #1629: the
-// seeded groups are owned by migrations and no API verb may reshape them.
-func TestSystemManagedGroup_Immutable(t *testing.T) {
-	ctx := context.Background()
-
-	seeded := func() *Group {
-		return &Group{
-			ID:            DefaultPurchaserGroupID,
-			Name:          GroupPurchaser,
-			SystemManaged: true,
-			Permissions: []Permission{
-				{Action: ActionExecute, Resource: ResourcePurchases},
-				{Action: ActionApproveAny, Resource: ResourcePurchases},
-				{Action: ActionRetryAny, Resource: ResourcePurchases},
-				{Action: ActionView, Resource: ResourceHistory},
-			},
-		}
-	}
-
-	t.Run("update is refused", func(t *testing.T) {
-		mockStore := new(MockStore)
-		t.Cleanup(func() { mockStore.AssertExpectations(t) })
-		svc := newCeilingService(t, mockStore)
-
-		mockStore.On("GetGroup", ctx, DefaultPurchaserGroupID).Return(seeded(), nil)
-
-		// The exact #1629 payload: approve-any/retry-any dropped, view
-		// widened to the wildcard.
-		result, err := svc.UpdateGroupAPI(ctx, ceilingActorID, DefaultPurchaserGroupID,
-			APIUpdateGroupRequest{
-				Description: "cosmetic edit",
-				Permissions: []APIPermission{
-					{Action: ActionExecute, Resource: ResourcePurchases},
-					{Action: ActionView, Resource: ResourceAll},
-				},
-			})
-
-		require.Error(t, err)
-		assert.Nil(t, result)
-		assert.ErrorIs(t, err, ErrSystemManagedGroup)
-		assert.Contains(t, err.Error(), GroupPurchaser)
-		mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
-	})
-
-	t.Run("delete is refused", func(t *testing.T) {
-		mockStore := new(MockStore)
-		t.Cleanup(func() { mockStore.AssertExpectations(t) })
-		svc := newCeilingService(t, mockStore)
-
-		mockStore.On("GetGroup", ctx, DefaultPurchaserGroupID).Return(seeded(), nil)
-
-		err := svc.DeleteGroup(ctx, DefaultPurchaserGroupID)
-
-		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrSystemManagedGroup)
-		mockStore.AssertNotCalled(t, "DeleteGroup", mock.Anything, mock.Anything)
-	})
-
-	t.Run("an ordinary group is still deletable", func(t *testing.T) {
-		mockStore := new(MockStore)
-		t.Cleanup(func() { mockStore.AssertExpectations(t) })
-		svc := newCeilingService(t, mockStore)
-
-		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
-		mockStore.On("DeleteGroup", ctx, ceilingTargetID).Return(nil).Once()
-
-		require.NoError(t, svc.DeleteGroup(ctx, ceilingTargetID))
 	})
 }

--- a/internal/auth/group_ceiling_test.go
+++ b/internal/auth/group_ceiling_test.go
@@ -1,0 +1,517 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Grant-ceiling regression tests for issues #1550 and #1629.
+//
+// Every refusal case here deliberately stubs NO CreateGroup / UpdateGroup /
+// DeleteGroup expectation on the mock store. testify's mock panics on an
+// un-stubbed call, so if the guard under test were removed the write would
+// reach the store and the test would fail loudly rather than silently pass.
+// That is the mutation check: these assertions are not vacuous.
+
+const (
+	ceilingActorID      = "11111111-1111-4111-8111-111111111111"
+	ceilingActorGroupID = "22222222-2222-4222-8222-222222222222"
+	ceilingTargetID     = "33333333-3333-4333-8333-333333333333"
+)
+
+// stubActorPermissions wires the two store lookups GetUserPermissions makes
+// for the acting user: the user row, then each of its groups.
+func stubActorPermissions(ctx context.Context, mockStore *MockStore, perms []Permission) {
+	mockStore.On("GetUserByID", ctx, ceilingActorID).
+		Return(&User{ID: ceilingActorID, GroupIDs: []string{ceilingActorGroupID}}, nil)
+	mockStore.On("GetGroup", ctx, ceilingActorGroupID).
+		Return(&Group{ID: ceilingActorGroupID, Name: "Actor Group", Permissions: perms}, nil)
+}
+
+func stubTargetGroup(ctx context.Context, mockStore *MockStore, group *Group) {
+	mockStore.On("GetGroup", ctx, ceilingTargetID).Return(group, nil)
+}
+
+func newCeilingService(t *testing.T, mockStore *MockStore) *Service {
+	t.Helper()
+	return createTestService(mockStore, new(MockEmailSender))
+}
+
+func updateReqWith(perms ...APIPermission) APIUpdateGroupRequest {
+	return APIUpdateGroupRequest{Name: "Renamed", Permissions: perms}
+}
+
+var adminOnly = []Permission{{Action: ActionAdmin, Resource: ResourceAll}}
+
+// TestGrantCeiling_CarvedOutNotGrantable is the #1550 attack itself: an admin
+// writing the money verbs onto a group in a single request.
+func TestGrantCeiling_CarvedOutNotGrantable(t *testing.T) {
+	ctx := context.Background()
+
+	carvedOut := []APIPermission{
+		{Action: ActionExecute, Resource: ResourcePurchases},
+		{Action: ActionApproveAny, Resource: ResourcePurchases},
+		{Action: ActionRetryAny, Resource: ResourcePurchases},
+	}
+
+	for _, perm := range carvedOut {
+		t.Run(perm.Action+":"+perm.Resource, func(t *testing.T) {
+			mockStore := new(MockStore)
+			t.Cleanup(func() { mockStore.AssertExpectations(t) })
+			svc := newCeilingService(t, mockStore)
+
+			stubActorPermissions(ctx, mockStore, adminOnly)
+			stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Administrators"})
+
+			result, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID, updateReqWith(perm))
+
+			require.Error(t, err)
+			assert.Nil(t, result)
+			assert.ErrorIs(t, err, ErrPermissionNotGrantable)
+			// The refusal must name the exact permission (#1629: never
+			// silently narrow the list).
+			assert.Contains(t, err.Error(), perm.Action+":"+perm.Resource)
+			mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+		})
+	}
+}
+
+// TestGrantCeiling_CarvedOutNotGrantableByPurchaserAdmin is the load-bearing
+// case. Migrations 000059/000064 backfill every Administrators member into
+// the Purchaser group, so a default-deployment admin explicitly HOLDS the
+// money verbs. A ceiling that only asked "do you hold it?" would let that
+// admin relay the verbs onto the Administrators group and #1550 would stay
+// open in the default configuration.
+func TestGrantCeiling_CarvedOutNotGrantableByPurchaserAdmin(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := newCeilingService(t, mockStore)
+
+	stubActorPermissions(ctx, mockStore, []Permission{
+		{Action: ActionAdmin, Resource: ResourceAll},
+		{Action: ActionExecute, Resource: ResourcePurchases},
+		{Action: ActionApproveAny, Resource: ResourcePurchases},
+		{Action: ActionRetryAny, Resource: ResourcePurchases},
+	})
+	stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Administrators"})
+
+	_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+		updateReqWith(APIPermission{Action: ActionExecute, Resource: ResourcePurchases}))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPermissionNotGrantable)
+	mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+}
+
+// TestGrantCeiling_CarvedOutMayBeKeptNotWidened: an unrelated edit to a group
+// that already holds a money verb must not be forced to strip it, but must
+// not be able to raise its cap either.
+func TestGrantCeiling_CarvedOutMayBeKeptNotWidened(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("kept unchanged is allowed", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubActorPermissions(ctx, mockStore, adminOnly)
+		stubTargetGroup(ctx, mockStore, &Group{
+			ID:          ceilingTargetID,
+			Name:        "Custom Purchasers",
+			Permissions: []Permission{{Action: ActionExecute, Resource: ResourcePurchases}},
+		})
+		mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Once()
+
+		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID, updateReqWith(
+			APIPermission{Action: ActionExecute, Resource: ResourcePurchases},
+			APIPermission{Action: ActionView, Resource: ResourcePlans},
+		))
+		require.NoError(t, err)
+	})
+
+	t.Run("widening an existing cap is refused", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubActorPermissions(ctx, mockStore, adminOnly)
+		stubTargetGroup(ctx, mockStore, &Group{
+			ID:   ceilingTargetID,
+			Name: "Custom Purchasers",
+			Permissions: []Permission{{
+				Action:      ActionExecute,
+				Resource:    ResourcePurchases,
+				Constraints: &PermissionConstraints{MaxPurchaseAmount: 100},
+			}},
+		})
+
+		// Same action/resource, cap removed entirely.
+		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+			updateReqWith(APIPermission{Action: ActionExecute, Resource: ResourcePurchases}))
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrPermissionNotGrantable)
+		mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+	})
+}
+
+// TestGrantCeiling_CannotGrantUnheldPermission covers rule 1: you cannot hand
+// out what you do not hold.
+func TestGrantCeiling_CannotGrantUnheldPermission(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := newCeilingService(t, mockStore)
+
+	// A group manager: can administer groups, but holds nothing on accounts.
+	stubActorPermissions(ctx, mockStore, []Permission{
+		{Action: ActionUpdate, Resource: ResourceGroups},
+		{Action: ActionView, Resource: ResourcePlans},
+	})
+	stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+
+	_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+		updateReqWith(APIPermission{Action: ActionDelete, Resource: ResourceAccounts}))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPermissionCeiling)
+	assert.Contains(t, err.Error(), ActionDelete+":"+ResourceAccounts)
+	mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+}
+
+// TestGrantCeiling_CannotWidenResourceWildcard: holding view on one resource
+// does not authorize granting view on every resource.
+func TestGrantCeiling_CannotWidenResourceWildcard(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := newCeilingService(t, mockStore)
+
+	stubActorPermissions(ctx, mockStore, []Permission{
+		{Action: ActionUpdate, Resource: ResourceGroups},
+		{Action: ActionView, Resource: ResourcePlans},
+	})
+	stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+
+	_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+		updateReqWith(APIPermission{Action: ActionView, Resource: ResourceAll}))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPermissionCeiling)
+	assert.Contains(t, err.Error(), ActionView+":"+ResourceAll)
+	mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+}
+
+// TestGrantCeiling_InCeilingUpdateSucceeds is the negative control. Without
+// it, a guard that refused every write would pass every test above.
+func TestGrantCeiling_InCeilingUpdateSucceeds(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := newCeilingService(t, mockStore)
+
+	stubActorPermissions(ctx, mockStore, []Permission{
+		{Action: ActionUpdate, Resource: ResourceGroups},
+		{Action: ActionView, Resource: ResourcePlans},
+		{Action: ActionView, Resource: ResourceRecommendations},
+	})
+	stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+
+	var saved *Group
+	mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).
+		Run(func(args mock.Arguments) {
+			g, ok := args.Get(1).(*Group)
+			require.True(t, ok)
+			saved = g
+		}).Return(nil).Once()
+
+	result, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID, updateReqWith(
+		APIPermission{Action: ActionView, Resource: ResourcePlans},
+		APIPermission{Action: ActionView, Resource: ResourceRecommendations},
+	))
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, saved)
+	// The full requested list is persisted; nothing was quietly dropped.
+	assert.Equal(t, []Permission{
+		{Action: ActionView, Resource: ResourcePlans},
+		{Action: ActionView, Resource: ResourceRecommendations},
+	}, saved.Permissions)
+}
+
+// TestGrantCeiling_ConstraintContainment: a constrained holder may hand out a
+// narrower grant but not a broader one.
+func TestGrantCeiling_ConstraintContainment(t *testing.T) {
+	ctx := context.Background()
+
+	held := []Permission{
+		{Action: ActionUpdate, Resource: ResourceGroups},
+		{
+			Action:   ActionExecute,
+			Resource: ResourceRIExchange,
+			Constraints: &PermissionConstraints{
+				Providers:         []string{"aws"},
+				MaxPurchaseAmount: 100,
+			},
+		},
+	}
+
+	t.Run("narrower grant is allowed", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubActorPermissions(ctx, mockStore, held)
+		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+		mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Once()
+
+		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+			updateReqWith(APIPermission{
+				Action:   ActionExecute,
+				Resource: ResourceRIExchange,
+				Constraints: &APIPermissionConstraint{
+					Providers: []string{"aws"},
+					MaxAmount: 50,
+				},
+			}))
+		require.NoError(t, err)
+	})
+
+	t.Run("dropping the cap is refused", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubActorPermissions(ctx, mockStore, held)
+		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+
+		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+			updateReqWith(APIPermission{Action: ActionExecute, Resource: ResourceRIExchange}))
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrPermissionCeiling)
+		mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+	})
+
+	t.Run("adding an unheld provider is refused", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubActorPermissions(ctx, mockStore, held)
+		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+
+		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+			updateReqWith(APIPermission{
+				Action:   ActionExecute,
+				Resource: ResourceRIExchange,
+				Constraints: &APIPermissionConstraint{
+					Providers: []string{"aws", "azure"},
+					MaxAmount: 50,
+				},
+			}))
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrPermissionCeiling)
+		mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+	})
+}
+
+// TestGrantCeiling_FailsClosed: if the acting principal cannot be identified
+// or their permissions cannot be resolved, the write is refused rather than
+// falling through to "allow".
+func TestGrantCeiling_FailsClosed(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("unidentified actor", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+
+		_, err := svc.UpdateGroupAPI(ctx, "", ceilingTargetID,
+			updateReqWith(APIPermission{Action: ActionView, Resource: ResourcePlans}))
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrPermissionCeiling)
+		mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+	})
+
+	t.Run("actor permission lookup fails", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		lookupErr := errors.New("database unavailable")
+		mockStore.On("GetUserByID", ctx, ceilingActorID).Return(nil, lookupErr)
+		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+
+		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+			updateReqWith(APIPermission{Action: ActionView, Resource: ResourcePlans}))
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrPermissionCeiling)
+		mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+	})
+}
+
+// TestGrantCeiling_AdminAPIKeyActor: the stateless admin API key has no user
+// row. It is measured as a bare {admin, *} holder, so it can seed ordinary
+// groups but is subject to the same money carve-out as a human admin
+// (#1550's third vector).
+func TestGrantCeiling_AdminAPIKeyActor(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("may create an ordinary group", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		mockStore.On("CreateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Once()
+
+		_, err := svc.CreateGroupAPI(ctx, AdminAPIKeyActorID, APICreateGroupRequest{
+			Name:        "Viewers",
+			Permissions: []APIPermission{{Action: ActionView, Resource: ResourcePlans}},
+		})
+		require.NoError(t, err)
+		// No user lookup is attempted for the key.
+		mockStore.AssertNotCalled(t, "GetUserByID", mock.Anything, mock.Anything)
+	})
+
+	t.Run("may not grant a carved-out permission", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		_, err := svc.CreateGroupAPI(ctx, AdminAPIKeyActorID, APICreateGroupRequest{
+			Name:        "Shadow Purchasers",
+			Permissions: []APIPermission{{Action: ActionExecute, Resource: ResourcePurchases}},
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrPermissionNotGrantable)
+		mockStore.AssertNotCalled(t, "CreateGroup", mock.Anything, mock.Anything)
+	})
+}
+
+// TestGrantCeiling_CreateGroupAPI covers the create path's ceiling directly.
+func TestGrantCeiling_CreateGroupAPI(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("refuses an unheld permission", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubActorPermissions(ctx, mockStore, []Permission{
+			{Action: ActionCreate, Resource: ResourceGroups},
+			{Action: ActionView, Resource: ResourcePlans},
+		})
+
+		_, err := svc.CreateGroupAPI(ctx, ceilingActorID, APICreateGroupRequest{
+			Name:        "Escalated",
+			Permissions: []APIPermission{{Action: ActionAdmin, Resource: ResourceAll}},
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrPermissionCeiling)
+		assert.Contains(t, err.Error(), ActionAdmin+":"+ResourceAll)
+		mockStore.AssertNotCalled(t, "CreateGroup", mock.Anything, mock.Anything)
+	})
+
+	t.Run("allows an in-ceiling permission", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubActorPermissions(ctx, mockStore, []Permission{
+			{Action: ActionCreate, Resource: ResourceGroups},
+			{Action: ActionView, Resource: ResourcePlans},
+		})
+		mockStore.On("CreateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Once()
+
+		_, err := svc.CreateGroupAPI(ctx, ceilingActorID, APICreateGroupRequest{
+			Name:        "Plan Viewers",
+			Permissions: []APIPermission{{Action: ActionView, Resource: ResourcePlans}},
+		})
+		require.NoError(t, err)
+	})
+}
+
+// TestSystemManagedGroup_Immutable covers the second half of #1629: the
+// seeded groups are owned by migrations and no API verb may reshape them.
+func TestSystemManagedGroup_Immutable(t *testing.T) {
+	ctx := context.Background()
+
+	seeded := func() *Group {
+		return &Group{
+			ID:            DefaultPurchaserGroupID,
+			Name:          GroupPurchaser,
+			SystemManaged: true,
+			Permissions: []Permission{
+				{Action: ActionExecute, Resource: ResourcePurchases},
+				{Action: ActionApproveAny, Resource: ResourcePurchases},
+				{Action: ActionRetryAny, Resource: ResourcePurchases},
+				{Action: ActionView, Resource: ResourceHistory},
+			},
+		}
+	}
+
+	t.Run("update is refused", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		mockStore.On("GetGroup", ctx, DefaultPurchaserGroupID).Return(seeded(), nil)
+
+		// The exact #1629 payload: approve-any/retry-any dropped, view
+		// widened to the wildcard.
+		result, err := svc.UpdateGroupAPI(ctx, ceilingActorID, DefaultPurchaserGroupID,
+			APIUpdateGroupRequest{
+				Description: "cosmetic edit",
+				Permissions: []APIPermission{
+					{Action: ActionExecute, Resource: ResourcePurchases},
+					{Action: ActionView, Resource: ResourceAll},
+				},
+			})
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, ErrSystemManagedGroup)
+		assert.Contains(t, err.Error(), GroupPurchaser)
+		mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+	})
+
+	t.Run("delete is refused", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		mockStore.On("GetGroup", ctx, DefaultPurchaserGroupID).Return(seeded(), nil)
+
+		err := svc.DeleteGroup(ctx, DefaultPurchaserGroupID)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrSystemManagedGroup)
+		mockStore.AssertNotCalled(t, "DeleteGroup", mock.Anything, mock.Anything)
+	})
+
+	t.Run("an ordinary group is still deletable", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+		mockStore.On("DeleteGroup", ctx, ceilingTargetID).Return(nil).Once()
+
+		require.NoError(t, svc.DeleteGroup(ctx, ceilingTargetID))
+	})
+}

--- a/internal/auth/group_ceiling_test.go
+++ b/internal/auth/group_ceiling_test.go
@@ -161,6 +161,131 @@ func TestGrantCeiling_CarvedOutMayBeKeptNotWidened(t *testing.T) {
 	})
 }
 
+// TestGrantCeiling_RejectsBlankActionOrResource covers the #1730 widening
+// path. A blank resource is NOT caught by the ceiling: the admin:* branch
+// grants any pair that is not carved out, and ("view", "") is not carved out,
+// so before validateRequestedPermissions an admin wrote it straight through
+// and it round-tripped through the group-edit form as the "*" wildcard.
+func TestGrantCeiling_RejectsBlankActionOrResource(t *testing.T) {
+	ctx := context.Background()
+
+	blank := []struct {
+		name string
+		perm APIPermission
+	}{
+		// The escalating case: blank resource widens to "*".
+		{"empty resource", APIPermission{Action: ActionView, Resource: ""}},
+		{"whitespace resource", APIPermission{Action: ActionView, Resource: "   "}},
+		// The non-escalating but still malformed case: blank action is
+		// silently dropped by the form.
+		{"empty action", APIPermission{Action: "", Resource: ResourcePurchases}},
+		{"whitespace action", APIPermission{Action: "  ", Resource: ResourcePurchases}},
+		{"both blank", APIPermission{Action: "", Resource: ""}},
+	}
+
+	for _, tc := range blank {
+		t.Run("update/"+tc.name, func(t *testing.T) {
+			mockStore := new(MockStore)
+			t.Cleanup(func() { mockStore.AssertExpectations(t) })
+			svc := newCeilingService(t, mockStore)
+
+			stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+
+			result, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID, updateReqWith(tc.perm))
+
+			require.Error(t, err)
+			assert.Nil(t, result)
+			assert.ErrorIs(t, err, ErrInvalidPermission)
+			// The refusal names the offending entry.
+			assert.Contains(t, err.Error(), "entry 0")
+			mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+			// Validation runs BEFORE the actor lookup, so a malformed entry is
+			// refused whoever the caller is -- including a full admin, whose
+			// admin:* branch would otherwise grant ("view", "") outright.
+			mockStore.AssertNotCalled(t, "GetUserByID", mock.Anything, mock.Anything)
+		})
+
+		t.Run("create/"+tc.name, func(t *testing.T) {
+			mockStore := new(MockStore)
+			t.Cleanup(func() { mockStore.AssertExpectations(t) })
+			svc := newCeilingService(t, mockStore)
+
+			_, err := svc.CreateGroupAPI(ctx, ceilingActorID, APICreateGroupRequest{
+				Name:        "Team",
+				Permissions: []APIPermission{tc.perm},
+			})
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrInvalidPermission)
+			mockStore.AssertNotCalled(t, "CreateGroup", mock.Anything, mock.Anything)
+			mockStore.AssertNotCalled(t, "GetUserByID", mock.Anything, mock.Anything)
+		})
+	}
+
+	// A blank entry anywhere in the list refuses the WHOLE write; the valid
+	// entries are not saved without it (never silently narrow).
+	t.Run("a blank entry beside valid ones refuses the whole list", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+
+		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID, updateReqWith(
+			APIPermission{Action: ActionView, Resource: ResourcePlans},
+			APIPermission{Action: ActionView, Resource: ""},
+		))
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidPermission)
+		assert.Contains(t, err.Error(), "entry 1")
+		mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+	})
+
+	// Negative control: a well-formed permission is still accepted, so the
+	// validator is not simply refusing everything.
+	t.Run("a well-formed permission is still accepted", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubActorPermissions(ctx, mockStore, adminOnly)
+		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+
+		var saved *Group
+		mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).
+			Run(func(args mock.Arguments) {
+				g, ok := args.Get(1).(*Group)
+				require.True(t, ok)
+				saved = g
+			}).Return(nil).Once()
+
+		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+			updateReqWith(APIPermission{Action: ActionView, Resource: ResourcePlans}))
+
+		require.NoError(t, err)
+		require.NotNil(t, saved)
+		assert.Equal(t, []Permission{{Action: ActionView, Resource: ResourcePlans}}, saved.Permissions)
+	})
+
+	// An explicit "*" is a legitimate value and must NOT be confused with a
+	// blank one; it is gated by the ceiling instead.
+	t.Run("an explicit wildcard is not treated as blank", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubActorPermissions(ctx, mockStore, adminOnly)
+		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+		mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Once()
+
+		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+			updateReqWith(APIPermission{Action: ActionView, Resource: ResourceAll}))
+
+		require.NoError(t, err, "an admin holding admin:* may grant view:*; only a BLANK resource is malformed")
+	})
+}
+
 // TestGrantCeiling_CannotGrantUnheldPermission covers rule 1: you cannot hand
 // out what you do not hold.
 func TestGrantCeiling_CannotGrantUnheldPermission(t *testing.T) {

--- a/internal/auth/group_ceiling_validation_test.go
+++ b/internal/auth/group_ceiling_validation_test.go
@@ -1,0 +1,150 @@
+package auth
+
+// Malformed-permission rejection (issue #1730).
+//
+// Separate from the ceiling tests because this guard runs BEFORE the ceiling
+// and is actor-independent: a blank resource is refused whoever asks, which
+// the tests assert positively rather than by implication.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGrantCeiling_RejectsBlankActionOrResource covers the #1730 widening
+// path. A blank resource is NOT caught by the ceiling: the admin:* branch
+// grants any pair that is not carved out, and ("view", "") is not carved out,
+// so before validateRequestedPermissions an admin wrote it straight through
+// and it round-tripped through the group-edit form as the "*" wildcard.
+func TestGrantCeiling_RejectsBlankActionOrResource(t *testing.T) {
+	ctx := context.Background()
+
+	blank := []struct {
+		name string
+		perm APIPermission
+	}{
+		// The escalating case: blank resource widens to "*".
+		{"empty resource", APIPermission{Action: ActionView, Resource: ""}},
+		{"whitespace resource", APIPermission{Action: ActionView, Resource: "   "}},
+		// The non-escalating but still malformed case: blank action is
+		// silently dropped by the form.
+		{"empty action", APIPermission{Action: "", Resource: ResourcePurchases}},
+		{"whitespace action", APIPermission{Action: "  ", Resource: ResourcePurchases}},
+		{"both blank", APIPermission{Action: "", Resource: ""}},
+	}
+
+	for _, tc := range blank {
+		t.Run("update/"+tc.name, func(t *testing.T) {
+			mockStore := new(MockStore)
+			t.Cleanup(func() { mockStore.AssertExpectations(t) })
+			svc := newCeilingService(t, mockStore)
+
+			stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+			// Permissive downstream stubs so removing validateRequestedPermissions
+			// cannot kill this test by panicking on a missing stub. With them,
+			// the blank permission would be accepted (admin:* grants view on
+			// any resource, including "") and the assertions below catch it.
+			stubActorPermissionsMaybe(ctx, mockStore, adminOnly)
+			mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Maybe()
+
+			result, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID, updateReqWith(tc.perm))
+
+			require.Error(t, err)
+			assert.Nil(t, result)
+			assert.ErrorIs(t, err, ErrInvalidPermission)
+			// The refusal names the offending entry.
+			assert.Contains(t, err.Error(), "entry 0")
+			mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+			// Validation runs BEFORE the actor lookup, so a malformed entry is
+			// refused whoever the caller is -- including a full admin, whose
+			// admin:* branch would otherwise grant ("view", "") outright.
+			mockStore.AssertNotCalled(t, "GetUserByID", mock.Anything, mock.Anything)
+		})
+
+		t.Run("create/"+tc.name, func(t *testing.T) {
+			mockStore := new(MockStore)
+			t.Cleanup(func() { mockStore.AssertExpectations(t) })
+			svc := newCeilingService(t, mockStore)
+
+			stubActorPermissionsMaybe(ctx, mockStore, adminOnly)
+			mockStore.On("CreateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Maybe()
+
+			_, err := svc.CreateGroupAPI(ctx, ceilingActorID, APICreateGroupRequest{
+				Name:        "Team",
+				Permissions: []APIPermission{tc.perm},
+			})
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrInvalidPermission)
+			mockStore.AssertNotCalled(t, "CreateGroup", mock.Anything, mock.Anything)
+			mockStore.AssertNotCalled(t, "GetUserByID", mock.Anything, mock.Anything)
+		})
+	}
+
+	// A blank entry anywhere in the list refuses the WHOLE write; the valid
+	// entries are not saved without it (never silently narrow).
+	t.Run("a blank entry beside valid ones refuses the whole list", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+
+		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID, updateReqWith(
+			APIPermission{Action: ActionView, Resource: ResourcePlans},
+			APIPermission{Action: ActionView, Resource: ""},
+		))
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidPermission)
+		assert.Contains(t, err.Error(), "entry 1")
+		mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+	})
+
+	// Negative control: a well-formed permission is still accepted, so the
+	// validator is not simply refusing everything.
+	t.Run("a well-formed permission is still accepted", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubActorPermissions(ctx, mockStore, adminOnly)
+		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+
+		var saved *Group
+		mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).
+			Run(func(args mock.Arguments) {
+				g, ok := args.Get(1).(*Group)
+				require.True(t, ok)
+				saved = g
+			}).Return(nil).Once()
+
+		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+			updateReqWith(APIPermission{Action: ActionView, Resource: ResourcePlans}))
+
+		require.NoError(t, err)
+		require.NotNil(t, saved)
+		assert.Equal(t, []Permission{{Action: ActionView, Resource: ResourcePlans}}, saved.Permissions)
+	})
+
+	// An explicit "*" is a legitimate value and must NOT be confused with a
+	// blank one; it is gated by the ceiling instead.
+	t.Run("an explicit wildcard is not treated as blank", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubActorPermissions(ctx, mockStore, adminOnly)
+		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+		mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Once()
+
+		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
+			updateReqWith(APIPermission{Action: ActionView, Resource: ResourceAll}))
+
+		require.NoError(t, err, "an admin holding admin:* may grant view:*; only a BLANK resource is malformed")
+	})
+}

--- a/internal/auth/group_system_managed_test.go
+++ b/internal/auth/group_system_managed_test.go
@@ -1,0 +1,97 @@
+package auth
+
+// system_managed immutability (issue #1629).
+//
+// The seeded groups are owned by migrations; no API verb may reshape or drop
+// them. Covers both the update and the delete path -- the delete path is a
+// third write path to a group's permissions that neither #1550 nor #1629
+// named.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSystemManagedGroup_Immutable covers the second half of #1629: the
+// seeded groups are owned by migrations and no API verb may reshape them.
+func TestSystemManagedGroup_Immutable(t *testing.T) {
+	ctx := context.Background()
+
+	seeded := func() *Group {
+		return &Group{
+			ID:            DefaultPurchaserGroupID,
+			Name:          GroupPurchaser,
+			SystemManaged: true,
+			Permissions: []Permission{
+				{Action: ActionExecute, Resource: ResourcePurchases},
+				{Action: ActionApproveAny, Resource: ResourcePurchases},
+				{Action: ActionRetryAny, Resource: ResourcePurchases},
+				{Action: ActionView, Resource: ResourceHistory},
+			},
+		}
+	}
+
+	t.Run("update is refused", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		mockStore.On("GetGroup", ctx, DefaultPurchaserGroupID).Return(seeded(), nil)
+		// Permissive actor stubs, deliberately. Without them, removing the
+		// system_managed guard kills this test by panicking on an unstubbed
+		// GetUserByID -- a kill that evaporates the moment someone adds a
+		// stub while tidying fixtures. With them, the guard's removal is
+		// caught by the assertions below instead, which is the property.
+		mockStore.On("GetUserByID", ctx, ceilingActorID).
+			Return(&User{ID: ceilingActorID, GroupIDs: []string{ceilingActorGroupID}}, nil).Maybe()
+		mockStore.On("GetGroup", ctx, ceilingActorGroupID).
+			Return(&Group{ID: ceilingActorGroupID, Permissions: adminOnly}, nil).Maybe()
+		mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Maybe()
+
+		// The exact #1629 payload: approve-any/retry-any dropped, view
+		// widened to the wildcard.
+		result, err := svc.UpdateGroupAPI(ctx, ceilingActorID, DefaultPurchaserGroupID,
+			APIUpdateGroupRequest{
+				Description: "cosmetic edit",
+				Permissions: []APIPermission{
+					{Action: ActionExecute, Resource: ResourcePurchases},
+					{Action: ActionView, Resource: ResourceAll},
+				},
+			})
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, ErrSystemManagedGroup)
+		assert.Contains(t, err.Error(), GroupPurchaser)
+		mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+	})
+
+	t.Run("delete is refused", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		mockStore.On("GetGroup", ctx, DefaultPurchaserGroupID).Return(seeded(), nil)
+
+		err := svc.DeleteGroup(ctx, DefaultPurchaserGroupID)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrSystemManagedGroup)
+		mockStore.AssertNotCalled(t, "DeleteGroup", mock.Anything, mock.Anything)
+	})
+
+	t.Run("an ordinary group is still deletable", func(t *testing.T) {
+		mockStore := new(MockStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+		svc := newCeilingService(t, mockStore)
+
+		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+		mockStore.On("DeleteGroup", ctx, ceilingTargetID).Return(nil).Once()
+
+		require.NoError(t, svc.DeleteGroup(ctx, ceilingTargetID))
+	})
+}

--- a/internal/auth/self_escalation_carveout_test.go
+++ b/internal/auth/self_escalation_carveout_test.go
@@ -1,0 +1,229 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// The membership route to the #923 bypass (issue #1550's "one-request
+// alternative"): an admin adding themselves to the Purchaser group.
+//
+// The pre-existing #907 guard gates self-added groups on update:users, which
+// admin:* grants, so it passed. Closing only the group-permission write path
+// would have left this open and #1550 would have auto-closed over it.
+//
+// As elsewhere in this package, refusal cases stub NO UpdateUser expectation:
+// testify panics if the write lands, so the assertions cannot be vacuous.
+
+const (
+	selfActorID    = "44444444-4444-4444-8444-444444444444"
+	otherUserID    = "55555555-5555-4555-8555-555555555555"
+	adminGroupID   = DefaultAdminGroupID
+	purchaserGroup = DefaultPurchaserGroupID
+)
+
+func purchaserGroupRow() *Group {
+	return &Group{
+		ID:            purchaserGroup,
+		Name:          GroupPurchaser,
+		SystemManaged: true,
+		Permissions: []Permission{
+			{Action: ActionExecute, Resource: ResourcePurchases},
+			{Action: ActionApproveAny, Resource: ResourcePurchases},
+			{Action: ActionRetryAny, Resource: ResourcePurchases},
+			{Action: ActionView, Resource: ResourceHistory},
+		},
+	}
+}
+
+func adminGroupRow() *Group {
+	return &Group{
+		ID:          adminGroupID,
+		Name:        "Administrators",
+		Permissions: []Permission{{Action: ActionAdmin, Resource: ResourceAll}},
+	}
+}
+
+// stubSelfActor wires the user row plus the groups it belongs to, so both
+// HasPermission(update:users) and GetUserPermissions resolve.
+func stubSelfActor(ctx context.Context, mockStore *MockStore, groupIDs []string, groups ...*Group) {
+	mockStore.On("GetUserByID", ctx, selfActorID).
+		Return(&User{ID: selfActorID, Active: true, GroupIDs: groupIDs}, nil)
+	for _, g := range groups {
+		mockStore.On("GetGroup", ctx, g.ID).Return(g, nil)
+	}
+}
+
+func TestSelfCarvedOutGrant_AdminCannotJoinPurchaser(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	// A full admin, currently NOT a purchaser (the strict-SoD posture #923
+	// tells admins to adopt).
+	stubSelfActor(ctx, mockStore, []string{adminGroupID}, adminGroupRow(), purchaserGroupRow())
+
+	_, err := svc.UpdateUser(ctx, selfActorID, selfActorID, UpdateUserRequest{
+		GroupIDs: []string{adminGroupID, purchaserGroup},
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSelfEscalation)
+	// Names the group and the specific verb.
+	assert.Contains(t, err.Error(), GroupPurchaser)
+	assert.Contains(t, err.Error(), ActionExecute+":"+ResourcePurchases)
+	mockStore.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+}
+
+// A custom (non-seeded) group carrying a carved-out verb is blocked too: the
+// guard keys off the permission, not off DefaultPurchaserGroupID.
+func TestSelfCarvedOutGrant_CustomGroupWithMoneyVerbAlsoBlocked(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	custom := &Group{
+		ID:          "66666666-6666-4666-8666-666666666666",
+		Name:        "Ops Spenders",
+		Permissions: []Permission{{Action: ActionRetryAny, Resource: ResourcePurchases}},
+	}
+	stubSelfActor(ctx, mockStore, []string{adminGroupID}, adminGroupRow(), custom)
+
+	_, err := svc.UpdateUser(ctx, selfActorID, selfActorID, UpdateUserRequest{
+		GroupIDs: []string{adminGroupID, custom.ID},
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSelfEscalation)
+	assert.Contains(t, err.Error(), ActionRetryAny+":"+ResourcePurchases)
+	mockStore.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+}
+
+// Negative control 1: an admin may still add themselves to a group that
+// carries NO carved-out verb. Without this a guard that refused every
+// self-addition would pass the tests above.
+func TestSelfCarvedOutGrant_OrdinaryGroupStillAllowed(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	readOnly := &Group{
+		ID:          "77777777-7777-4777-8777-777777777777",
+		Name:        "Read-Only Users",
+		Permissions: []Permission{{Action: ActionView, Resource: ResourcePlans}},
+	}
+	stubSelfActor(ctx, mockStore, []string{adminGroupID}, adminGroupRow(), readOnly)
+
+	var saved *User
+	mockStore.On("UpdateUser", ctx, mock.AnythingOfType("*auth.User")).
+		Run(func(args mock.Arguments) {
+			u, ok := args.Get(1).(*User)
+			require.True(t, ok)
+			saved = u
+		}).Return(nil).Once()
+
+	_, err := svc.UpdateUser(ctx, selfActorID, selfActorID, UpdateUserRequest{
+		GroupIDs: []string{adminGroupID, readOnly.ID},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, saved)
+	assert.Equal(t, []string{adminGroupID, readOnly.ID}, saved.GroupIDs)
+}
+
+// Negative control 2: a user who ALREADY holds the money verbs is not blocked
+// from ordinary membership changes -- adding a second group carrying a verb
+// they already have is not an escalation.
+func TestSelfCarvedOutGrant_ExistingPurchaserNotBlocked(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	second := &Group{
+		ID:          "88888888-8888-4888-8888-888888888888",
+		Name:        "Second Purchasers",
+		Permissions: []Permission{{Action: ActionExecute, Resource: ResourcePurchases}},
+	}
+	// Actor is already in Purchaser, so execute:purchases is already held.
+	stubSelfActor(ctx, mockStore,
+		[]string{adminGroupID, purchaserGroup},
+		adminGroupRow(), purchaserGroupRow(), second)
+
+	mockStore.On("UpdateUser", ctx, mock.AnythingOfType("*auth.User")).Return(nil).Once()
+
+	_, err := svc.UpdateUser(ctx, selfActorID, selfActorID, UpdateUserRequest{
+		GroupIDs: []string{adminGroupID, purchaserGroup, second.ID},
+	})
+	require.NoError(t, err)
+}
+
+// Negative control 3: the two-person control is preserved. An admin may add
+// ANOTHER user to the Purchaser group; only self-edits are gated.
+func TestSelfCarvedOutGrant_AdminMayAddAnotherUserToPurchaser(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	mockStore.On("GetUserByID", ctx, otherUserID).
+		Return(&User{ID: otherUserID, Active: true, GroupIDs: []string{adminGroupID}}, nil)
+	mockStore.On("UpdateUser", ctx, mock.AnythingOfType("*auth.User")).Return(nil).Once()
+
+	_, err := svc.UpdateUser(ctx, selfActorID, otherUserID, UpdateUserRequest{
+		GroupIDs: []string{adminGroupID, purchaserGroup},
+	})
+	require.NoError(t, err)
+	// The self-guard never runs for a cross-user edit, so the actor's own
+	// permissions are never even fetched.
+	mockStore.AssertNotCalled(t, "GetUserByID", ctx, selfActorID)
+}
+
+// Trusted internal callers (actorUserID == "") are unaffected, so bootstrap
+// and seeding paths keep working.
+func TestSelfCarvedOutGrant_InternalCallerUnaffected(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	mockStore.On("GetUserByID", ctx, selfActorID).
+		Return(&User{ID: selfActorID, Active: true, GroupIDs: []string{adminGroupID}}, nil)
+	mockStore.On("UpdateUser", ctx, mock.AnythingOfType("*auth.User")).Return(nil).Once()
+
+	_, err := svc.UpdateUser(ctx, "", selfActorID, UpdateUserRequest{
+		GroupIDs: []string{adminGroupID, purchaserGroup},
+	})
+	require.NoError(t, err)
+}
+
+// Fail closed: an error loading a group being joined refuses the change
+// rather than falling through to "allow".
+func TestSelfCarvedOutGrant_FailsClosedOnGroupLoadError(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockStore)
+	t.Cleanup(func() { mockStore.AssertExpectations(t) })
+	svc := createTestService(mockStore, new(MockEmailSender))
+
+	loadErr := errors.New("database unavailable")
+	mockStore.On("GetUserByID", ctx, selfActorID).
+		Return(&User{ID: selfActorID, Active: true, GroupIDs: []string{adminGroupID}}, nil)
+	mockStore.On("GetGroup", ctx, adminGroupID).Return(adminGroupRow(), nil)
+	mockStore.On("GetGroup", ctx, purchaserGroup).Return(nil, loadErr)
+
+	_, err := svc.UpdateUser(ctx, selfActorID, selfActorID, UpdateUserRequest{
+		GroupIDs: []string{adminGroupID, purchaserGroup},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load group")
+	mockStore.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+}

--- a/internal/auth/self_escalation_carveout_test.go
+++ b/internal/auth/self_escalation_carveout_test.go
@@ -224,6 +224,10 @@ func TestSelfCarvedOutGrant_FailsClosedOnGroupLoadError(t *testing.T) {
 	})
 
 	require.Error(t, err)
+	// Assert the underlying error is PROPAGATED, not just that some message
+	// mentions the group. A guard that swallowed loadErr and returned its own
+	// generic error would pass a message-text check while losing the reason.
+	assert.ErrorIs(t, err, loadErr)
 	assert.Contains(t, err.Error(), "failed to load group")
 	mockStore.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
 }

--- a/internal/auth/service_api.go
+++ b/internal/auth/service_api.go
@@ -268,15 +268,34 @@ func (s *Service) ChangePasswordAPI(ctx context.Context, userID, currentPassword
 	return s.ChangePassword(ctx, userID, req)
 }
 
-// CreateGroupAPI creates a new group via the API.
-func (s *Service) CreateGroupAPI(ctx context.Context, reqInterface any) (any, error) {
+// apiPermissionsToPermissions converts a request-side permission list. A nil
+// result for an empty input preserves the "not sent" signal APIUpdateGroupRequest
+// relies on.
+func apiPermissionsToPermissions(in []APIPermission) []Permission {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]Permission, len(in))
+	for i, p := range in {
+		out[i] = apiPermissionToPermission(p)
+	}
+	return out
+}
+
+// CreateGroupAPI creates a new group via the API. actorUserID is the acting
+// principal (a user ID, or AdminAPIKeyActorID for the stateless admin API
+// key); the requested permissions are checked against that principal's own
+// effective set before anything is written (issue #1550).
+func (s *Service) CreateGroupAPI(ctx context.Context, actorUserID string, reqInterface any) (any, error) {
 	req, ok := reqInterface.(APICreateGroupRequest)
 	if !ok {
 		return nil, fmt.Errorf("invalid request type")
 	}
-	perms := make([]Permission, len(req.Permissions))
-	for i, p := range req.Permissions {
-		perms[i] = apiPermissionToPermission(p)
+	perms := apiPermissionsToPermissions(req.Permissions)
+	// A new group has no permissions yet, so nothing can be "carried over":
+	// pass a nil existing set, which makes every carved-out verb a grant.
+	if err := s.checkGrantCeiling(ctx, actorUserID, perms, nil); err != nil {
+		return nil, err
 	}
 	group := &Group{
 		Name:            req.Name,
@@ -284,15 +303,39 @@ func (s *Service) CreateGroupAPI(ctx context.Context, reqInterface any) (any, er
 		Permissions:     perms,
 		AllowedAccounts: req.AllowedAccounts,
 	}
-	// Use empty string for createdBy since we don't have user context here
+	// Use empty string for createdBy: the column is a UUID FK and
+	// actorUserID may be the non-UUID admin-API-key sentinel.
 	if err := s.CreateGroup(ctx, group, ""); err != nil {
 		return nil, err
 	}
 	return groupToAPIGroup(group), nil
 }
 
-// UpdateGroupAPI updates a group via the API.
-func (s *Service) UpdateGroupAPI(ctx context.Context, groupID string, reqInterface any) (any, error) {
+// applyUpdateGroupRequest applies the set fields of req to group. perms is the
+// already-converted permission list; empty means "not sent" and leaves the
+// group's permissions unchanged, which is APIUpdateGroupRequest's pre-existing
+// contract.
+func applyUpdateGroupRequest(group *Group, req APIUpdateGroupRequest, perms []Permission) {
+	if req.Name != "" {
+		group.Name = req.Name
+	}
+	if req.Description != "" {
+		group.Description = req.Description
+	}
+	if len(perms) > 0 {
+		group.Permissions = perms
+	}
+	if req.AllowedAccounts != nil {
+		group.AllowedAccounts = req.AllowedAccounts
+	}
+}
+
+// UpdateGroupAPI updates a group via the API. It refuses to touch a
+// system-managed group at all, and checks any requested permission list
+// against the acting principal's own effective permissions before writing
+// (issues #1550, #1629). actorUserID is a user ID, or AdminAPIKeyActorID for
+// the stateless admin API key.
+func (s *Service) UpdateGroupAPI(ctx context.Context, actorUserID, groupID string, reqInterface any) (any, error) {
 	req, ok := reqInterface.(APIUpdateGroupRequest)
 	if !ok {
 		return nil, fmt.Errorf("invalid request type")
@@ -304,23 +347,16 @@ func (s *Service) UpdateGroupAPI(ctx context.Context, groupID string, reqInterfa
 	if group == nil {
 		return nil, fmt.Errorf("group not found")
 	}
+	if group.SystemManaged {
+		return nil, fmt.Errorf("%w: %q is seeded and maintained by migrations", ErrSystemManagedGroup, group.Name)
+	}
 
-	if req.Name != "" {
-		group.Name = req.Name
+	perms := apiPermissionsToPermissions(req.Permissions)
+	if err := s.checkGrantCeiling(ctx, actorUserID, perms, group.Permissions); err != nil {
+		return nil, err
 	}
-	if req.Description != "" {
-		group.Description = req.Description
-	}
-	if len(req.Permissions) > 0 {
-		perms := make([]Permission, len(req.Permissions))
-		for i, p := range req.Permissions {
-			perms[i] = apiPermissionToPermission(p)
-		}
-		group.Permissions = perms
-	}
-	if req.AllowedAccounts != nil {
-		group.AllowedAccounts = req.AllowedAccounts
-	}
+
+	applyUpdateGroupRequest(group, req, perms)
 
 	group.UpdatedAt = time.Now()
 	if err := s.UpdateGroup(ctx, group); err != nil {

--- a/internal/auth/service_api.go
+++ b/internal/auth/service_api.go
@@ -297,6 +297,11 @@ func (s *Service) CreateGroupAPI(ctx context.Context, actorUserID string, reqInt
 	if err := s.checkGrantCeiling(ctx, actorUserID, perms, nil); err != nil {
 		return nil, err
 	}
+	// A new group has no prior scope, so every allowed_accounts value is a
+	// grant -- including an omitted one, which creates an UNRESTRICTED group.
+	if err := s.checkAccountGrant(ctx, actorUserID, req.AllowedAccounts); err != nil {
+		return nil, err
+	}
 	group := &Group{
 		Name:            req.Name,
 		Description:     req.Description,
@@ -353,6 +358,9 @@ func (s *Service) UpdateGroupAPI(ctx context.Context, actorUserID, groupID strin
 
 	perms := apiPermissionsToPermissions(req.Permissions)
 	if err := s.checkGrantCeiling(ctx, actorUserID, perms, group.Permissions); err != nil {
+		return nil, err
+	}
+	if err := s.checkAccountCeiling(ctx, actorUserID, req.AllowedAccounts, group.AllowedAccounts); err != nil {
 		return nil, err
 	}
 

--- a/internal/auth/service_api_test.go
+++ b/internal/auth/service_api_test.go
@@ -377,7 +377,8 @@ func TestService_CreateGroupAPI(t *testing.T) {
 			},
 		}
 
-		result, err := service.CreateGroupAPI(ctx, req)
+		// The admin API key holds {admin, *}, which covers view:recommendations.
+		result, err := service.CreateGroupAPI(ctx, AdminAPIKeyActorID, req)
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 
@@ -395,7 +396,7 @@ func TestService_CreateGroupAPI(t *testing.T) {
 		mockEmail := new(MockEmailSender)
 		service := createTestService(mockStore, mockEmail)
 
-		result, err := service.CreateGroupAPI(ctx, "invalid")
+		result, err := service.CreateGroupAPI(ctx, AdminAPIKeyActorID, "invalid")
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "invalid request type")
@@ -431,7 +432,7 @@ func TestService_UpdateGroupAPI(t *testing.T) {
 			},
 		}
 
-		result, err := service.UpdateGroupAPI(ctx, "group-123", req)
+		result, err := service.UpdateGroupAPI(ctx, AdminAPIKeyActorID, "group-123", req)
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 
@@ -449,7 +450,7 @@ func TestService_UpdateGroupAPI(t *testing.T) {
 		mockEmail := new(MockEmailSender)
 		service := createTestService(mockStore, mockEmail)
 
-		result, err := service.UpdateGroupAPI(ctx, "group-123", "invalid")
+		result, err := service.UpdateGroupAPI(ctx, AdminAPIKeyActorID, "group-123", "invalid")
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "invalid request type")
@@ -466,7 +467,7 @@ func TestService_UpdateGroupAPI(t *testing.T) {
 			Name: "New Name",
 		}
 
-		result, err := service.UpdateGroupAPI(ctx, "group-123", req)
+		result, err := service.UpdateGroupAPI(ctx, AdminAPIKeyActorID, "group-123", req)
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "group not found")

--- a/internal/auth/service_group.go
+++ b/internal/auth/service_group.go
@@ -32,7 +32,24 @@ func (s *Service) UpdateGroup(ctx context.Context, group *Group) error {
 }
 
 // DeleteGroup removes a permission group.
+//
+// Deleting a system-managed group is refused: it is the same defect class as
+// the #1629 permission wipe, reached through a different verb. Dropping the
+// seeded Purchaser group destroys the only holder of the money verbs carved
+// out of admin:*, which no admin can then re-grant (see checkGrantCeiling),
+// so the purchase path would be dead tenant-wide until someone re-ran the
+// migration by hand.
 func (s *Service) DeleteGroup(ctx context.Context, groupID string) error {
+	group, err := s.store.GetGroup(ctx, groupID)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("failed to load group %s: %w", groupID, err)
+	}
+	if group == nil {
+		return fmt.Errorf("group not found: %s", groupID)
+	}
+	if group.SystemManaged {
+		return fmt.Errorf("%w: %q is seeded and maintained by migrations", ErrSystemManagedGroup, group.Name)
+	}
 	return s.store.DeleteGroup(ctx, groupID)
 }
 

--- a/internal/auth/service_group.go
+++ b/internal/auth/service_group.go
@@ -84,10 +84,24 @@ func (s *Service) GetUserPermissions(ctx context.Context, userID string) ([]Perm
 		return nil, fmt.Errorf("user not found")
 	}
 
+	// Permissions come exclusively from group memberships.
+	return s.permissionsForGroups(ctx, user.GroupIDs)
+}
+
+// permissionsForGroups returns the union of the permissions granted by the
+// given groups. Unlike GetUserPermissions it takes the membership list
+// directly, so a caller reasoning about a membership CHANGE can evaluate the
+// PRIOR membership without depending on the stored row not yet reflecting the
+// change (see guardSelfEscalation).
+//
+// Any transient store error is propagated immediately so callers fail closed
+// with an error rather than silently receiving a partial permission set. A
+// nil group (the store returns nil, nil for a deleted/missing group) is
+// skipped without error.
+func (s *Service) permissionsForGroups(ctx context.Context, groupIDs []string) ([]Permission, error) {
 	var permissions []Permission
 
-	// Permissions come exclusively from group memberships.
-	for _, groupID := range user.GroupIDs {
+	for _, groupID := range groupIDs {
 		group, err := s.store.GetGroup(ctx, groupID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/auth/service_group_only_authz_test.go
+++ b/internal/auth/service_group_only_authz_test.go
@@ -82,12 +82,6 @@ func TestGroupOnlyAuthz_NonAdminDenied(t *testing.T) {
 	viewer := &User{ID: "viewer-1", GroupIDs: []string{viewerGroup().ID}, Active: true}
 	mockStore.On("GetUserByID", ctx, "viewer-1").Return(viewer, nil)
 	mockStore.On("GetGroup", ctx, viewerGroup().ID).Return(viewerGroup(), nil)
-	// Permissive write stub, deliberately: without it, removing the
-	// self-escalation guard kills this test by panicking on an unstubbed
-	// UpdateUser. With it, the removal is caught by AssertNotCalled below,
-	// which is the actual security property (no write happened).
-	mockStore.On("UpdateUser", ctx, mock.AnythingOfType("*auth.User")).Return(nil).Maybe()
-	mockStore.On("GetGroup", ctx, DefaultAdminGroupID).Return(adminGroup(), nil).Maybe()
 
 	has, err := svc.HasPermission(ctx, "viewer-1", ActionApproveAny, ResourcePurchases, nil)
 	require.NoError(t, err)
@@ -252,6 +246,13 @@ func TestUpdateUser_SelfEscalationDenied(t *testing.T) {
 	target := &User{ID: "self-1", GroupIDs: []string{viewerGroup().ID}, Active: true}
 	mockStore.On("GetUserByID", ctx, "self-1").Return(target, nil).Once()
 	mockStore.On("GetGroup", ctx, viewerGroup().ID).Return(viewerGroup(), nil)
+	// Permissive write stub, deliberately: without it, removing the
+	// self-escalation guard kills this test by panicking on an unstubbed
+	// UpdateUser -- a kill that disappears the moment someone adds a stub
+	// while tidying fixtures. With it, the removal is caught by the
+	// AssertNotCalled below, which is the actual security property.
+	mockStore.On("UpdateUser", ctx, mock.AnythingOfType("*auth.User")).Return(nil).Maybe()
+	mockStore.On("GetGroup", ctx, DefaultAdminGroupID).Return(adminGroup(), nil).Maybe()
 	// The change ADDS Administrators (does not remove it), so the last-admin
 	// branch is skipped; the self-escalation branch then evaluates
 	// HasPermission(update, users), which a viewer lacks.

--- a/internal/auth/service_group_only_authz_test.go
+++ b/internal/auth/service_group_only_authz_test.go
@@ -82,6 +82,12 @@ func TestGroupOnlyAuthz_NonAdminDenied(t *testing.T) {
 	viewer := &User{ID: "viewer-1", GroupIDs: []string{viewerGroup().ID}, Active: true}
 	mockStore.On("GetUserByID", ctx, "viewer-1").Return(viewer, nil)
 	mockStore.On("GetGroup", ctx, viewerGroup().ID).Return(viewerGroup(), nil)
+	// Permissive write stub, deliberately: without it, removing the
+	// self-escalation guard kills this test by panicking on an unstubbed
+	// UpdateUser. With it, the removal is caught by AssertNotCalled below,
+	// which is the actual security property (no write happened).
+	mockStore.On("UpdateUser", ctx, mock.AnythingOfType("*auth.User")).Return(nil).Maybe()
+	mockStore.On("GetGroup", ctx, DefaultAdminGroupID).Return(adminGroup(), nil).Maybe()
 
 	has, err := svc.HasPermission(ctx, "viewer-1", ActionApproveAny, ResourcePurchases, nil)
 	require.NoError(t, err)

--- a/internal/auth/service_group_only_authz_test.go
+++ b/internal/auth/service_group_only_authz_test.go
@@ -234,16 +234,17 @@ func TestUpdateUser_SelfEscalationDenied(t *testing.T) {
 	t.Cleanup(func() { mockStore.AssertExpectations(t) })
 
 	// Actor == target, currently only a viewer, attempts to add the
-	// Administrators group to themselves. UpdateUser fetches the target first
-	// (this object is mutated in place by applyUpdateUserRequest), then the
-	// self-escalation guard re-resolves the actor's *persisted* permissions
-	// via a fresh GetUserByID; return a distinct, unmutated viewer copy for
-	// that second read so it mirrors a real DB round-trip rather than aliasing
-	// the just-mutated object.
+	// Administrators group to themselves.
+	//
+	// The guard used to re-read the actor's row to resolve their permissions,
+	// which forced this test to hand back a distinct unmutated copy on the
+	// second GetUserByID so the read did not alias the object
+	// applyUpdateUserRequest had already mutated. It now resolves the PRIOR
+	// membership from the snapshot instead (guardSelfEscalation), so there is
+	// no second read and no aliasing hazard to work around: one target fetch,
+	// then the prior groups.
 	target := &User{ID: "self-1", GroupIDs: []string{viewerGroup().ID}, Active: true}
-	actor := &User{ID: "self-1", GroupIDs: []string{viewerGroup().ID}, Active: true}
 	mockStore.On("GetUserByID", ctx, "self-1").Return(target, nil).Once()
-	mockStore.On("GetUserByID", ctx, "self-1").Return(actor, nil).Once()
 	mockStore.On("GetGroup", ctx, viewerGroup().ID).Return(viewerGroup(), nil)
 	// The change ADDS Administrators (does not remove it), so the last-admin
 	// branch is skipped; the self-escalation branch then evaluates

--- a/internal/auth/service_group_test.go
+++ b/internal/auth/service_group_test.go
@@ -246,6 +246,10 @@ func TestService_DeleteGroup(t *testing.T) {
 		mockEmail := new(MockEmailSender)
 		service := createTestService(mockStore, mockEmail)
 
+		// DeleteGroup loads the group first so it can refuse to drop a
+		// system-managed one (issue #1629).
+		mockStore.On("GetGroup", ctx, "group-123").
+			Return(&Group{ID: "group-123", Name: "Test Team"}, nil).Once()
 		mockStore.On("DeleteGroup", ctx, "group-123").Return(nil).Once()
 
 		err := service.DeleteGroup(ctx, "group-123")

--- a/internal/auth/service_user.go
+++ b/internal/auth/service_user.go
@@ -396,15 +396,28 @@ func (s *Service) guardGroupChange(ctx context.Context, actorUserID, targetUserI
 // not sufficient to pass. Split out of guardGroupChange to keep that function
 // under gocyclo's threshold.
 //
+// DO NOT "simplify" this back to re-reading the actor's row
+// (GetUserPermissions, or any fresh GetUserByID). That is the shorter
+// spelling and it is a silent regression.
+//
 // Both checks are evaluated against the actor's PRIOR membership, resolved
-// from `prior` directly rather than by re-reading the actor's row. That is the
-// question a self-escalation guard has to ask -- "did you hold this BEFORE the
-// change?" -- and reading it from `prior` makes the answer independent of when
-// the change reaches storage. Re-reading the row happens to give the same
-// answer today only because the write has not been committed yet; a guard
-// whose correctness rests on that ordering silently defeats itself the moment
-// a caller passes the already-mutated user, which is exactly what an
-// in-memory caller does.
+// from `prior` directly. "Did you hold this BEFORE the change?" is the
+// question a self-escalation guard has to ask, so resolving it from the
+// snapshot is the correct implementation as well as the simpler one -- not a
+// workaround for anything.
+//
+// The previous version re-read the row and was correct only by accident of
+// transaction timing: UpdateUser calls applyUpdateUserRequest BEFORE these
+// guards run, so the in-memory user already carries the NEW membership, and
+// the re-read returned the old values purely because the write had not been
+// committed yet. The tell was in the test suite, where this case had to hand
+// back "a distinct, unmutated viewer copy for that second read" to avoid
+// aliasing the just-mutated object. Any caller that passes the mutated user,
+// or any future change that resolves permissions through it, makes the guard
+// authorize the very escalation it exists to block.
+//
+// Enforced by mutation, not just by this comment: swapping `prior` for `next`
+// below fails the suite (see the M13 row in the PR #1737 mutation matrix).
 func (s *Service) guardSelfEscalation(ctx context.Context, prior, next []string) error {
 	heldBefore, err := s.permissionsForGroups(ctx, prior)
 	if err != nil {

--- a/internal/auth/service_user.go
+++ b/internal/auth/service_user.go
@@ -385,14 +385,98 @@ func (s *Service) guardGroupChange(ctx context.Context, actorUserID, targetUserI
 	// to hold the manage-users permission. A non-privileged user therefore
 	// cannot grant themselves a more powerful group. Internal callers
 	// (actorUserID == "") are already trusted and skip this check.
-	if actorUserID != "" && actorUserID == targetUserID && addsNewGroup(prior, next) {
-		canManage, err := s.HasPermission(ctx, actorUserID, ActionUpdate, ResourceUsers, nil)
+	if actorUserID == "" || actorUserID != targetUserID || !addsNewGroup(prior, next) {
+		return nil
+	}
+	return s.guardSelfEscalation(ctx, prior, next)
+}
+
+// guardSelfEscalation runs the two self-edit checks in order: the #907
+// manage-users gate, then the #1550 carved-out-verb gate that manage-users is
+// not sufficient to pass. Split out of guardGroupChange to keep that function
+// under gocyclo's threshold.
+//
+// Both checks are evaluated against the actor's PRIOR membership, resolved
+// from `prior` directly rather than by re-reading the actor's row. That is the
+// question a self-escalation guard has to ask -- "did you hold this BEFORE the
+// change?" -- and reading it from `prior` makes the answer independent of when
+// the change reaches storage. Re-reading the row happens to give the same
+// answer today only because the write has not been committed yet; a guard
+// whose correctness rests on that ordering silently defeats itself the moment
+// a caller passes the already-mutated user, which is exactly what an
+// in-memory caller does.
+func (s *Service) guardSelfEscalation(ctx context.Context, prior, next []string) error {
+	heldBefore, err := s.permissionsForGroups(ctx, prior)
+	if err != nil {
+		return fmt.Errorf("failed to verify manage-users permission: %w", err)
+	}
+	if !s.permissionsAllow(heldBefore, ActionUpdate, ResourceUsers, nil) {
+		return ErrSelfEscalation
+	}
+	// Holding update:users is NOT enough to hand yourself the money verbs.
+	return s.guardSelfCarvedOutGrant(ctx, heldBefore, next, prior)
+}
+
+// guardSelfCarvedOutGrant blocks the membership route to the same escalation
+// the group-permission grant ceiling blocks (issue #1550).
+//
+// The check above gates self-added groups on update:users, which admin:*
+// grants -- so an admin could add themselves to the Purchaser group and pick
+// up execute / approve-any / retry-any on purchases in one request, voiding
+// the #923 separation of duties exactly as writing those verbs onto their own
+// group would. It is the "one-request alternative" named in #1550's report,
+// and it is why closing only the group-permission path would leave the issue
+// open.
+//
+// The rule matches the grant ceiling's: you cannot grant yourself a carved-out
+// verb you do not already hold. Adding a SECOND group that carries a verb the
+// actor already holds is not an escalation and is allowed, so a user who is
+// legitimately a purchaser is not blocked from ordinary membership changes.
+//
+// Only SELF-edits reach here. An admin may still add another user to the
+// Purchaser group: that is the two-person control separation of duties is
+// meant to create, not a hole. Trusted internal callers (actorUserID == "")
+// never reach here either, so seeding and bootstrap paths are unaffected.
+//
+// held is the actor's PRIOR permission set (see guardSelfEscalation). Fails
+// closed: any error loading a group being joined refuses the change.
+func (s *Service) guardSelfCarvedOutGrant(ctx context.Context, held []Permission, next, prior []string) error {
+	added := addedGroups(prior, next)
+	if len(added) == 0 {
+		return nil
+	}
+	for _, groupID := range added {
+		group, err := s.store.GetGroup(ctx, groupID)
 		if err != nil {
-			return fmt.Errorf("failed to verify manage-users permission: %w", err)
+			return fmt.Errorf("failed to load group %s: %w", groupID, err)
 		}
-		if !canManage {
-			return ErrSelfEscalation
+		if group == nil {
+			// A membership entry for a group that does not exist grants
+			// nothing; the change is validated elsewhere.
+			continue
 		}
+		if perm := s.firstUnheldCarvedOut(group, held); perm != nil {
+			return fmt.Errorf(
+				"%w: joining %q would grant you %s:%s, which is reserved for separation of duties (issue #923); ask another administrator to add you",
+				ErrSelfEscalation, group.Name, perm.Action, perm.Resource)
+		}
+	}
+	return nil
+}
+
+// firstUnheldCarvedOut returns the first permission on group that is carved
+// out of the admin:* wildcard and is NOT already covered by held, or nil if
+// there is none. Coverage is evaluated with permissionsAllow so the carve-out
+// applies: an actor holding only admin:* does not "already hold" these.
+func (s *Service) firstUnheldCarvedOut(group *Group, held []Permission) *Permission {
+	for i, perm := range group.Permissions {
+		if !adminCarvedOuts[[2]string{perm.Action, perm.Resource}] {
+			continue
+		}
+		if s.permissionsAllow(held, perm.Action, perm.Resource, nil) {
+			continue
+		}
+		return &group.Permissions[i]
 	}
 	return nil
 }
@@ -423,14 +507,20 @@ func containsGroup(groups []string, target string) bool {
 	return false
 }
 
-// addsNewGroup reports whether next contains any group not present in prior.
-func addsNewGroup(prior, next []string) bool {
+// addedGroups returns the groups present in next but not in prior.
+func addedGroups(prior, next []string) []string {
+	var added []string
 	for _, g := range next {
 		if !containsGroup(prior, g) {
-			return true
+			added = append(added, g)
 		}
 	}
-	return false
+	return added
+}
+
+// addsNewGroup reports whether next contains any group not present in prior.
+func addsNewGroup(prior, next []string) bool {
+	return len(addedGroups(prior, next)) > 0
 }
 
 // applyUpdateUserRequest applies the non-nil fields of req to user. GroupID

--- a/internal/server/adapter_test.go
+++ b/internal/server/adapter_test.go
@@ -210,6 +210,8 @@ func TestAuthServiceAdapter_DeleteGroup(t *testing.T) {
 	adapter, mockStore := createMockAuthService(t)
 	ctx := context.Background()
 
+	// DeleteGroup loads the group first to refuse system-managed ones (#1629).
+	mockStore.On("GetGroup", ctx, "group-1").Return(&auth.Group{ID: "group-1", Name: "team"}, nil)
 	mockStore.On("DeleteGroup", ctx, "group-1").Return(nil)
 
 	err := adapter.DeleteGroup(ctx, "group-1")
@@ -347,7 +349,7 @@ func TestAuthServiceAdapter_CreateGroupAPI(t *testing.T) {
 
 	mockStore.On("CreateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil)
 
-	_, err := adapter.CreateGroupAPI(ctx, map[string]interface{}{
+	_, err := adapter.CreateGroupAPI(ctx, auth.AdminAPIKeyActorID, map[string]interface{}{
 		"name":        "test-group",
 		"permissions": []string{"read:config"},
 	})
@@ -364,7 +366,7 @@ func TestAuthServiceAdapter_UpdateGroupAPI(t *testing.T) {
 	}, nil)
 	mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil)
 
-	_, err := adapter.UpdateGroupAPI(ctx, "group-1", map[string]interface{}{
+	_, err := adapter.UpdateGroupAPI(ctx, auth.AdminAPIKeyActorID, "group-1", map[string]interface{}{
 		"name": "new-name",
 	})
 	_ = err

--- a/internal/server/app.go
+++ b/internal/server/app.go
@@ -1122,12 +1122,12 @@ func (a *authServiceAdapter) MFARegenerateRecoveryCodesAPI(ctx context.Context, 
 }
 
 // Group management methods - delegate to auth service API methods.
-func (a *authServiceAdapter) CreateGroupAPI(ctx context.Context, req any) (any, error) {
-	return a.service.CreateGroupAPI(ctx, req)
+func (a *authServiceAdapter) CreateGroupAPI(ctx context.Context, actorUserID string, req any) (any, error) {
+	return a.service.CreateGroupAPI(ctx, actorUserID, req)
 }
 
-func (a *authServiceAdapter) UpdateGroupAPI(ctx context.Context, groupID string, req any) (any, error) {
-	return a.service.UpdateGroupAPI(ctx, groupID, req)
+func (a *authServiceAdapter) UpdateGroupAPI(ctx context.Context, actorUserID, groupID string, req any) (any, error) {
+	return a.service.UpdateGroupAPI(ctx, actorUserID, groupID, req)
 }
 
 func (a *authServiceAdapter) DeleteGroup(ctx context.Context, groupID string) error {


### PR DESCRIPTION
Closes #1550.
Closes #1738.

> **Scope of the claim.** This PR bounds **writes to a group** — its permissions and its `allowed_accounts` — on the create, update and delete paths. It does **not** bound the account dimension generally. The membership endpoint can still launder it: joining a wider group is not account-checked (and Administrators ships `allowed_accounts = ARRAY['*']`), and `guardGroupChange` returns early unless `addsNewGroup`, so a self-edit that only **removes** groups is unguarded entirely — dropping the scoping group leaves `[]`, read as all accounts. Removing the restriction grants the restriction. Tracked in **#1756**; do not read this PR as covering it.


## The defect

`CreateGroupAPI` / `UpdateGroupAPI` wrote the client-supplied permission list onto a group verbatim, with no check that the caller may grant what they are granting, and never consulted the `system_managed` column. Because `update:groups` is not one of the pairs carved out of the `admin:*` wildcard, any admin could void the #923 money separation-of-duties control tenant-wide in a single request:

```
PUT /api/groups/<administrators-uuid>
{"permissions":[{admin,*},{execute,purchases},{approve-any,purchases},{retry-any,purchases}]}
```

## Every write path to a group's permissions

Enumerated by grepping backwards from the store methods rather than trusting the two endpoints the issues named. There are exactly four; `group.Permissions = ` appears once outside tests.

| # | Path | Before | After |
|---|------|--------|-------|
| 1 | `POST /api/groups` -> `createGroup` -> `CreateGroupAPI` -> `Service.CreateGroup` -> `store.CreateGroup` | no ceiling | ceiling + carve-out |
| 2 | `PUT /api/groups/{id}` -> `updateGroup` -> `UpdateGroupAPI` -> `Service.UpdateGroup` -> `store.UpdateGroup` | no ceiling, no `system_managed` | ceiling + carve-out + `system_managed` |
| 3 | `DELETE /api/groups/{id}` -> `deleteGroup` -> adapter -> `Service.DeleteGroup` -> `store.DeleteGroup` | **unguarded, named in neither issue** | `system_managed` |
| 4 | SQL migrations 000059 / 000064 | trusted, out of band | unchanged |
| 5 | `PUT /api/users/{self}` -> `UpdateUser` -> `guardGroupChange` (**membership**, not permissions) | unguarded for money verbs | carved-out self-grant refused |

**#1550 and #1629 each named only two write paths; there are three.** Path 3 matters because dropping the seeded Purchaser group destroys the only holder of the carved-out money verbs, which nothing can then re-grant. The purchase path would be dead tenant-wide, the same end state #1629 describes, reached through a different verb. Refusing the permission wipe while permitting the delete would be a guard with a hole in the same shape as the one it closes, so it is in this PR rather than split out.

`SetupAdmin` creates users, not groups. User API keys carry their own scoped permission list (#1301/#1302), not group permissions.

## The two rules

**1. Ceiling.** A caller may only grant permissions their own effective set already holds, matched through the same carve-out-aware logic used at enforcement time (`grantCeilingAllows` mirrors `permissionsAllow` branch for branch, so the ceiling can never be looser than enforcement). It adds one requirement enforcement does not need: constraint containment. A holder capped at `MaxPurchaseAmount: 100`, or scoped to `providers: [aws]`, cannot hand out an uncapped or `[aws, azure]` copy. Without that the ceiling would be a shape check rather than a bound.

**2. The carve-out is not grantable at all.** The three verbs in `adminCarvedOuts` may never be *added* to a group, whoever the caller is.

**3. Blank `action` / `resource` are refused** (#1730, second commit). A blank resource is **not** a request for the `*` wildcard, but that is what it became: the group-edit form picks its option with `isDefault = !currentValue && resource === '*'`, so an empty stored resource renders as the selected `All (*)` entry and saves back as `view:*`, and nothing validated the list on the way in so the same widening was reachable from any API client with no form involved.

**This is a hole the ceiling does not close, which is why it needed its own guard.** Rule 1's `admin:*` branch grants any pair that is not carved out, and `("view", "")` is not carved out. Verified by execution before writing the fix:

```
empty resource -> err=<nil>      # written to the store by a full admin
```

`validateRequestedPermissions` runs ahead of the ceiling on both write paths, refuses blank (empty or whitespace-only) actions and resources naming the offending entry index, and fails **before** the actor lookup so the refusal does not depend on who is asking. Mapped to **400**, not 403: malformed input, not an authorization failure.

The two fields fail differently in the form, which is what shows the defect is in the defaulting and not the parsing: a blank action is silently **dropped** (index 0 is an empty placeholder) while a blank resource is silently **widened** (index 0 is the wildcard). Only the resource side escalates; both are refused, because a silently dropped permission is a different bug rather than an acceptable one. Unknown-but-non-blank values are deliberately still accepted (vocabulary validation is a separate concern, and rejecting values this endpoint can already have stored would break edits of existing groups); an explicit `"*"` stays legitimate and is gated by the ceiling instead.

#1730 has the mirror-image defect at the rendering layer. Closing it at the endpoint covers every caller, including the one that bypasses the form entirely — the same argument that makes #1550 the durable half of #1629.

### Did the "non-grantable at all" framing survive contact with the carve-out semantics?

Yes, but for a reason not stated in #1550, and it turns out to be load-bearing rather than belt-and-braces.

Migrations 000059 and 000064 both run an admin-backfill: every member of the Administrators group is auto-added to the Purchaser group. So in a default deployment a typical admin **explicitly holds** `execute:purchases`, `approve-any:purchases` and `retry-any:purchases`, not merely `admin:*`. A pure "you cannot grant what you do not hold" ceiling would therefore have left #1550 **open in the default configuration**: that admin holds the verbs and could relay them onto the Administrators group in one request. `TestGrantCeiling_CarvedOutNotGrantableByPurchaserAdmin` is that exact case.

The cost of rule 2 is that a money-granting group can only be provisioned by migration. That is already the only way it happens: the sole such group is seeded by SQL and is `system_managed`. To keep the rule from becoming a footgun, a carved-out permission **already stored on the target group** may be carried through an unrelated edit (a rename must not be forced to strip it), but only at constraints no broader than the ones already stored, so an edit cannot raise an existing cap either.

## Fail closed, and never silently narrow

An unidentified actor, or any error resolving the actor's permissions, refuses the write; there is no fall-through to allow. A refusal returns an error naming the specific permission and why (`permission ceiling exceeded: cannot grant delete:accounts because ...`), mapped to 403 by `mapGroupAuthError`. The requested list is never saved reduced to the allowed subset, which is the silent-corruption mode #1629 reports on the frontend side.

## The admin API key

The stateless admin API key has no user row, so a group-derived lookup cannot resolve it and a naive ceiling would have failed closed on every admin-key group write. It is now measured against a bare `{admin, *}` holding (`auth.AdminAPIKeyActorID`, which `internal/api`'s `apiKeyAdminUserID` aliases). It can still seed ordinary groups, but is subject to the same money carve-out as a human admin. That is option (a) of #1550's "either subject the admin API key to the carve-out, or document it as break-glass".

## Test evidence

37 new tests: 33 in `internal/auth/group_ceiling_test.go`, 4 in `internal/api/handler_groups_ceiling_test.go`.

### Two ways an assertion here could have been unfailable, both checked

**(a) A name-only `AssertNotCalled` cannot fail.** testify diffs an empty expectation against the real arguments and counts each as a difference, so `AssertNotCalled(t, "UpdateGroup")` passes even after a real call. Proven by execution rather than taken on trust:

```
name-only AssertNotCalled after a real call -> failed=false   (VACUOUS)
matcher  AssertNotCalled after a real call -> failed=true    (REAL)
```

All 19 `AssertNotCalled` calls in this PR pass one `mock.Anything` per parameter; a grep for the name-only form returns nothing.

**(b) The actor slot filled with `mock.Anything`.** For a grant ceiling the actor is *the* argument that must be pinned — the guard is "can **this actor** grant **this permission**". All six pre-existing `.On("CreateGroupAPI"/"UpdateGroupAPI")` sites pin the exact session user ID (`adminSession.UserID` / `"admin"`), not `mock.Anything`. Two of them previously pinned only the group ID; none now leaves the actor unpinned.

Separately, every refusal test stubs **no** `CreateGroup` / `UpdateGroup` / `DeleteGroup` expectation at all, so a removed guard makes the write reach the store and testify panics.

### Per-guard mutation matrix

Each guard removed **individually** (not in aggregate), then all 25 security tests run one at a time. A test that survives its own guard's removal is vacuous. Re-run from scratch after the rebase onto `c93724d38` rather than carried forward:

| Mutation | killed |
|---|---|
| M1 whole ceiling removed | 11/33 |
| M2 carve-out refusal removed (rule 2) | 4/33 |
| M3 holder ceiling removed (rule 1) | 4/33 |
| M4 constraint containment removed | 2/33 |
| M5 blank action/resource validation removed (#1730) | 1/33 |
| M6 fail-closed actor resolution removed | 1/33 |
| M7 `system_managed` on UPDATE removed | 1/33 |
| M8 `system_managed` on DELETE removed | 1/33 |
| M9 403/400 error mapping removed | 3/33 |
| M10 membership carved-out guard removed | 6/33 |
| M11 membership guard inverted (over-block) | 6/33 |
| M12 self-edit routing removed | 2/33 |
| M13 prior-membership snapshot swapped for post-change membership | 4/33 |
| M14 account ceiling removed | 4/33 |

**No mutation survives.**

> **Reproducing this requires per-test isolation.** A plain `go test ./internal/auth/` will NOT show these counts: a mock panic kills the test binary, so a package-level run under M13 reports **1** failure rather than 4. The harness runs each test alone (`-run '^Name$'`) for exactly that reason. Without this note the table reads as inflated.

**Three kills were strengthened after review.** Twelve of the original thirteen were panic-driven, and the panics were not equal. The strong ones panic on an unstubbed **write** — that panic *is* the security fact, because the write not happening is the property. The weak ones (M5, M7, `TestUpdateUser_SelfEscalationDenied`) panicked on an unstubbed **read** downstream of the guard, a kill that evaporates the moment anyone adds a permissive stub while tidying fixtures. Those three now register the downstream reads with `.Maybe()` so removing the guard **cannot** panic, which leaves the test's own assertions as the only thing that can fail it. M7 now dies on `require.Error` rather than a panic. `FailsClosedOnGroupLoadError` additionally asserts `errors.Is(err, loadErr)` instead of message text, so it pins error propagation rather than wording. Every guard is killed by the tests that specifically cover it, and the narrow ones (M5, M6, M7, M8) kill exactly the one test that covers them and nothing else.

M10/M11/M12 are complementary on purpose. Two membership tests assert the guard must *not* fire (`AdminMayAddAnotherUserToPurchaser`, `InternalCallerUnaffected`), so guard-removal cannot kill them **by construction** — they are killed by M12, the routing mutation, which is what actually threatens what they protect. Stating that is more useful than a clean-sweep claim that quietly includes two assertions incapable of failing that way.

**M13 is the regression barrier for the fragility above:** swapping the prior-membership snapshot for the post-change list — which is what a "simplifying" fresh row read degenerates to — kills 4 tests.

### Test file layout

`group_ceiling_test.go` grew past the repo's 500-line guideline and is split by concern, matching how the mutation matrix is organised so each file maps to a distinct set of mutations:

| file | lines |
|---|---|
| `group_ceiling_fixtures_test.go` | 58 (shared stubs only) |
| `group_ceiling_permissions_test.go` | 415 |
| `group_ceiling_validation_test.go` | 150 |
| `group_system_managed_test.go` | 97 |
| `group_account_ceiling_test.go` | 282 |

A split is exactly where a test gets silently dropped, so: **707 passing test names before, 707 after, sorted and diffed — identical.** Plus the full matrix re-run afterwards.

### Cyclomatic margin

`gocyclo -over 10` is the gate; nothing this PR adds or modifies exceeds **8**:

```
8  guardGroupChange          8  checkGrantCeiling
7  constraintsCover          7  UpdateGroupAPI          7  createGroup
6  listCovers                6  grantCeilingAllows      6  guardSelfCarvedOutGrant
5  permissionCoveredBy       5  permissionsForGroups    5  DeleteGroup ...
```

`guardGroupChange` briefly hit 11 during the membership work and was split into `guardSelfEscalation`; `GetUserPermissions` dropped to 4 by delegating to `permissionsForGroups`.

The flagship failure shows the write actually landing pre-fix:

```
--- FAIL: TestGrantCeiling_CarvedOutNotGrantableByPurchaserAdmin
    panic: mock: I don't know what to return because the method call was unexpected
      at: [internal/auth/test_helpers.go:110       <- MockStore.UpdateGroup
           internal/auth/service_group.go:31        <- Service.UpdateGroup
           internal/auth/service_api.go:359         <- UpdateGroupAPI
           internal/auth/group_ceiling_test.go:104]
```

One honest exception: `TestUpdateGroup_AdminAPIKeyActorIsSentinel` survives every mutation. It asserts `apiKeyAdminUserID == auth.AdminAPIKeyActorID` and that the handler threads that sentinel — wiring that only exists on this branch, so no guard-removal can break it. Reported rather than counted as evidence.

### No pre-existing test silently stopped running

Adding an argument to a mock changes what `.On(...)` matches, so the six edited call sites could have quietly stopped exercising what they used to. Checked against a baseline worktree at `origin/main`, running every test function in the three edited files:

```
49 test functions
baseline origin/main : 75 --- PASS: lines
this branch          : 75 --- PASS: lines
diff of the sorted passing names: IDENTICAL
```

### Gates

```
go build ./...                       ok
go vet ./...                         ok
go test ./...                        ok (exit 0, full suite)
gocyclo -over 10 -ignore "_test\.go" .   no output (CI's exact invocation)
golangci-lint v2.10.1 (CI-pinned)    0 issues, repo-wide
```

Two findings caught locally and fixed rather than shipped to review: a `govet` err-shadow in `updateGroup`, and a `misspell` hit.

## The membership route to the same bypass (third commit)

#1550's report names a "one-request alternative" that needs no group edit at all: `PUT /api/users/{self}` adding `DefaultPurchaserGroupID`. The pre-existing #907 self-escalation guard gates self-added groups on `update:users`, which `admin:*` grants — so it passed, and an admin could join the Purchaser group and pick up all three money verbs in one request.

Closing only the group-permission path would have left that open while `Closes #1550` auto-closed the issue over it, so it is in this PR. `guardSelfCarvedOutGrant` applies the ceiling's own rule to membership: **you cannot grant yourself a carved-out verb you do not already hold.** It keys off the permission, not off `DefaultPurchaserGroupID`, so a custom group carrying a money verb is blocked identically.

What it deliberately does *not* block, each with a negative-control test: adding a second group carrying a verb you already hold (not an escalation); an admin adding **another** user to Purchaser (that is the two-person control separation of duties exists to create); and trusted internal callers (`actorUserID == ""`), so bootstrap and seeding are unaffected.

### A latent fragility this surfaced: a guard that was correct only by accident of transaction timing

The old guard resolved the actor's permissions by **re-reading their row**, and `applyUpdateUserRequest` has already mutated the in-memory user by that point. It gave the right answer only because the write had not been committed yet — and a pre-existing test had to hand-construct "a distinct, unmutated viewer copy for that second read so it mirrors a real DB round-trip rather than aliasing the just-mutated object" to make it work. A guard whose correctness rests on that ordering defeats itself the moment a caller passes the already-mutated user.

`guardSelfEscalation` now resolves the actor's permissions from the **prior membership snapshot** via a new `permissionsForGroups` helper. This is not merely a fix: "did you hold this *before* the change?" is the question a self-escalation guard has to ask, so the correct implementation is also the simpler one. The second read is gone, and with it the test's hand-built copy and its explanatory comment. `GetUserPermissions` now delegates to the same helper rather than duplicating the group-walk loop.

**The next person to touch this will be tempted to "simplify" it back to a fresh read**, because that is the shorter spelling. A `DO NOT` comment on `guardSelfEscalation` records why that is a silent regression, and **mutation M13 enforces it**: swapping `prior` for `next` there must fail the suite.

## Can #1629 be closed? Only partially, and a claim in the first version of this body was wrong

**Correction.** An earlier version of this body said *"all seeded groups are `system_managed`, so the frontend defect can no longer corrupt any of them."* **That is false.** Traced through the migrations and confirmed:

| Group | UUID | `system_managed` | Set by |
|---|---|---|---|
| Administrators + 3 others | `…0001`–`…0004` | TRUE | `000059` UPDATE |
| **Standard Users** | `…0005` | **FALSE** | `000057` INSERT omits the column -> `DEFAULT FALSE` |
| **Read-Only Users** | `…0006` | **FALSE** | same |
| Purchaser | `…0007` | TRUE | `000064` |

`000074` only re-adds the column (`DEFAULT FALSE`); `000086` and `000088` edit those groups' permissions and never touch the column (grep count: 0 in both).

**So Standard Users and Read-Only Users remain corruptible through `PUT /api/groups/{id}`, and neither ceiling rule stops it:**

1. **The drop is invisible to the ceiling.** `checkGrantCeiling` iterates `requested` only; it never diffs against `existing` to detect **removals**. #1629's primary harm is the form silently dropping `cancel-own` / `retry-own` on `purchases` (both on Standard Users; `approve-own` was removed separately by `000086`), none of which the form's action list can represent. A purely narrowing write passes the ceiling untouched.
2. **The widening is allowed precisely when an admin does it**, which is #1629's scenario. `grantCeilingAllows` hits the `admin:*` branch first and `view:*` is not in `adminCarvedOuts`, so `view:history` -> `view:*` is granted.

#1629 names this group explicitly: *"The seeded user role-mirror group has the same shape."*

**Therefore:**
- This PR closes **#1550 completely** (see below).
- It closes **#1629 for `system_managed` groups only** — the Purchaser group and the four `…0001`–`…0004` groups, which covers #1629's headline scenario (the seeded Purchaser group edit that kills the approval path tenant-wide).
- **#1629 should NOT be closed by this PR**, and it carries no closing keyword.
- The residual gap on those two groups is tracked in **#1739**.

Deliberately **not** adding a migration to mark Standard Users and Read-Only Users `system_managed`: operators may legitimately customise Standard Users, so locking it is a product decision rather than a fix, and it is filed on #1739 for the owner to decide.

**#1550's `system_managed` status is irrelevant to its own closure**: the money carve-out is closed by rule 2, which applies to every group regardless of the column.

## Account scope: the fifth write path, folded in from #1738

Review found that an **`allowed_accounts`-only `PUT` never reached the ceiling at all.** `checkGrantCeiling` opens with `if len(requested) == 0 { return nil }`, and `APIUpdateGroupRequest`'s "empty means not sent" contract makes an accounts-only request the natural shape to send. Verified by execution before fixing, with an actor holding only `update:groups` in one group scoped to one account:

```
widen to more accounts        -> ACCEPTED  (stored [acct-A acct-B acct-C])
widen to [] (= unrestricted)  -> ACCEPTED  (stored [])
widen to ["*"]                -> ACCEPTED  (stored [*])
CONTROL: same call WITH permissions -> REFUSED
```

The control is what makes it decisive: widening `Permissions[].Constraints.AccountIDs` on the *same* call **was** correctly refused. The PR bounded one account dimension carefully and left its sibling wide open on the same request — worse than never hardening the endpoint, because the next reader would reasonably assume it was covered.

`checkAccountCeiling` is deliberately a **separate call**, not a branch inside `checkGrantCeiling`, precisely so it cannot inherit that early return. A write is in ceiling if it does not widen the group's existing scope, or if it stays within the actor's own.

Two traps handled explicitly:
- **Empty is not narrow.** `[]` and `["*"]` both mean *unrestricted* (`IsUnrestrictedAccess`), so this cannot be a subset test — the empty set is a subset of everything and means the opposite.
- **Create has no prior scope.** Passing `existing = nil` there would read as *unrestricted* and swallow every check, so `CreateGroupAPI` calls `checkAccountGrant` directly. An omitted `allowed_accounts` on create is checked too: it produces an unrestricted group, which for a scoped actor is the widest possible grant.

**Every refusal test sends `allowed_accounts` with no `permissions` key.** A test that included permissions alongside would pass with the bug present, because the permission ceiling would then run and refuse for an unrelated reason. That request shape is the whole finding.

### Fail-closed on an unresolvable actor scope

`IsUnrestrictedAccess(nil) == true` is load-bearing in this guard, so the actor's own scope resolution was traced across all four failure modes. Two of them failed **open**:

```
store error on user                    -> refused
user missing (nil, nil)                -> refused
actor's only group missing (ErrNoRows) -> ACCEPTED widening to ["*"]
actor's only group returns (nil, nil)  -> ACCEPTED widening to ["*"]
```

`collectGroupsAndAccounts` skips a missing or deleted group silently, so an actor whose groups all fail to load yields an empty list, read as "all accounts" — the ceiling becomes a no-op on exactly the path it guards, and nothing errors. **Note the asymmetry**: the permission ceiling already failed closed on the same input, because an empty permission set grants nothing. Only the account side failed open, which is the harder direction to spot.

Requiring at least one resolved group is the precise guard: partial resolution under-reports the actor's scope, which makes the ceiling *stricter*, so only total failure needed closing. Mutation-checked — removing it is killed by its own test and by nothing else.

### Every writer of `AllowedAccounts`, grepped

`group.AllowedAccounts` is written in exactly **two** places outside tests, and both are now guarded:

| site | path |
|---|---|
| `service_api.go:309` | `CreateGroupAPI` struct literal |
| `service_api.go:334` | `applyUpdateGroupRequest` |

The other matches are not group writers: `service_group.go:142`/`:179` build the read-side `AuthContext`, `store_postgres.go:844` is the row scanner, and `service_api.go:158` is the response conversion. **These two are the complete set** — recorded explicitly because the enumeration on this endpoint has already been wrong once.

**#1738 is closed by this.** `Closes #1550` stands unchanged: impact here is read-scope widening and non-money writes; the carve-out and Purchaser's `system_managed` status are untouched.

## Deliberately out of scope

- **Standard Users / Read-Only Users are not `system_managed`** — tracked in **#1739**, including the product decision about whether to mark them so. See the #1629 section above for why neither ceiling rule covers them.

- ~~`AllowedAccounts` has no ceiling (#1738)~~ — **fixed in this PR**, see above.
- **#1644 (`execute:ri-exchange` missing from `adminCarvedOuts`).** Not fixed here, as instructed; noted on that issue. It is now a one-line change: adding the pair to `adminCarvedOuts` makes both `permissionsAllow` and this ceiling pick it up automatically, and `grantCeilingAllows` re-checks the carve-out map inside its `admin:*` branch specifically so the two stay in lockstep when that set grows.
- **A user API key acts as its owning user** for ceiling purposes, so a narrowly-scoped key inherits the owner's grant ceiling. No escalation beyond the owner, but it is the same key-scope gap tracked by #1301/#1302.

## CI

Expect `npm audit` red (`js-yaml` / `nanoid`) — unrelated, being fixed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authorization safeguards for group permissions and account-scope changes.
  * Prevented users from granting themselves restricted permissions or widening access beyond their authority.
  * Added protection for system-managed groups, which can no longer be modified or deleted.

* **Bug Fixes**
  * Group authorization failures now return clearer client errors, including appropriate 400 or 403 responses.
  * Group changes now consistently evaluate the acting user’s permissions and identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->