### PR TITLE
fix(test): repair 30 unfailable mock assertions and guard the class

### DIFF
--- a/cmd/multi_service_test.go
+++ b/cmd/multi_service_test.go
@@ -1346,7 +1346,7 @@ func TestProcessPurchaseLoopEmptyRecommendations(t *testing.T) {
 	results := processPurchaseLoop(ctx, []common.Recommendation{}, "us-east-1", false, mockClient, toolCfg)
 
 	assert.Empty(t, results)
-	mockClient.AssertNotCalled(t, "PurchaseCommitment")
+	mockClient.AssertNotCalled(t, "PurchaseCommitment", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestProcessServicePurchasesUserCancellation(t *testing.T) {
@@ -1408,7 +1408,7 @@ func TestProcessServicePurchasesDryRunMultiple(t *testing.T) {
 		assert.Equal(t, recs[i].ResourceType, result.Recommendation.ResourceType)
 	}
 
-	mockClient.AssertNotCalled(t, "PurchaseCommitment")
+	mockClient.AssertNotCalled(t, "PurchaseCommitment", mock.Anything, mock.Anything, mock.Anything)
 }
 
 // ==================== New Extracted Function Tests ====================
@@ -1483,7 +1483,7 @@ func TestProcessPurchaseLoopDryRun(t *testing.T) {
 	}
 
 	// Mock should not be called in dry run mode
-	mockClient.AssertNotCalled(t, "PurchaseCommitment")
+	mockClient.AssertNotCalled(t, "PurchaseCommitment", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestProcessPurchaseLoopActualPurchase(t *testing.T) {

--- a/internal/api/executed_notification_flow_test.go
+++ b/internal/api/executed_notification_flow_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/LeanerCloud/CUDly/internal/email"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -244,7 +245,7 @@ func TestExecutedNotification_SessionApprovePath(t *testing.T) {
 	// Admin approved, so the executor recorded in the body is the admin.
 	assertExecutedNotificationFingerprints(t, notifier, contact, adminEmail, "valid-token")
 	mockPurchase.AssertExpectations(t)
-	mockPurchase.AssertNotCalled(t, "ApproveExecution")
+	mockPurchase.AssertNotCalled(t, "ApproveExecution", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestExecutedNotification_DirectExecutePath is the regression test for the

--- a/internal/api/handler_analytics_test.go
+++ b/internal/api/handler_analytics_test.go
@@ -201,7 +201,7 @@ func TestHandler_getHistoryAnalytics_InvalidProvider(t *testing.T) {
 	_, err := handler.getHistoryAnalytics(ctx, req, map[string]string{"provider": "oracle"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid provider")
-	mockClient.AssertNotCalled(t, "QueryHistory")
+	mockClient.AssertNotCalled(t, "QueryHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestHandler_getHistoryAnalytics_InvalidDateRange(t *testing.T) {
@@ -256,7 +256,7 @@ func TestHandler_getHistoryAnalytics_ScopedUser_RequiresAccountID(t *testing.T) 
 	_, err := handler.getHistoryAnalytics(ctx, req, map[string]string{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "account_id is required")
-	mockClient.AssertNotCalled(t, "QueryHistory")
+	mockClient.AssertNotCalled(t, "QueryHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestHandler_getHistoryBreakdown_Success(t *testing.T) {
@@ -411,7 +411,7 @@ func TestHandler_triggerAnalyticsCollection_NonAdmin(t *testing.T) {
 	_, err := handler.triggerAnalyticsCollection(ctx, req, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "admin access required")
-	mockCollector.AssertNotCalled(t, "Collect")
+	mockCollector.AssertNotCalled(t, "Collect", mock.Anything)
 }
 
 func TestParseDateRange(t *testing.T) {
@@ -636,7 +636,7 @@ func TestHandler_getAnalyticsTrends_ScopedUser_RequiresAccountID(t *testing.T) {
 	_, err := handler.getAnalyticsTrends(ctx, req, map[string]string{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "account_id is required")
-	mockSnap.AssertNotCalled(t, "QueryMonthlyTotals")
+	mockSnap.AssertNotCalled(t, "QueryMonthlyTotals", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestHandler_getAnalyticsTrends_ScopedUser_OutsideScope returns not-found when
@@ -659,5 +659,5 @@ func TestHandler_getAnalyticsTrends_ScopedUser_OutsideScope(t *testing.T) {
 
 	_, err := handler.getAnalyticsTrends(ctx, req, map[string]string{"account_id": "other-acct"})
 	require.Error(t, err)
-	mockSnap.AssertNotCalled(t, "QueryMonthlyTotals")
+	mockSnap.AssertNotCalled(t, "QueryMonthlyTotals", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }

--- a/internal/api/handler_auth_test.go
+++ b/internal/api/handler_auth_test.go
@@ -965,7 +965,7 @@ func TestHandler_updateProfile_RejectsInvalidEmail(t *testing.T) {
 	assert.Equal(t, 400, ce.code)
 	assert.Contains(t, ce.message, "email")
 	// Confirm UpdateUserProfile was never reached.
-	mockAuth.AssertNotCalled(t, "UpdateUserProfile")
+	mockAuth.AssertNotCalled(t, "UpdateUserProfile", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestHandler_updateProfile_AcceptsValidEmail verifies that a well-formed

--- a/internal/api/handler_per_account_perms_test.go
+++ b/internal/api/handler_per_account_perms_test.go
@@ -363,7 +363,7 @@ func TestPerAccountPerms_HistoryAnalytics_CrossAccountRejected(t *testing.T) {
 		"cross-account analytics must return 404; got: %v", err)
 
 	// The analytics backend must never be called — the scope check fires first.
-	mockClient.AssertNotCalled(t, "QueryHistory")
+	mockClient.AssertNotCalled(t, "QueryHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestPerAccountPerms_HistoryAnalytics_AllowedAccountSucceeds is the paired
@@ -463,7 +463,7 @@ func TestPerAccountPerms_HistoryBreakdown_CrossAccountRejected(t *testing.T) {
 	assert.True(t, IsNotFoundError(err),
 		"cross-account breakdown must return 404; got: %v", err)
 
-	mockClient.AssertNotCalled(t, "QueryBreakdown")
+	mockClient.AssertNotCalled(t, "QueryBreakdown", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 // ─── 6. GET /dashboard/summary ───────────────────────────────────────────────

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -153,7 +153,7 @@ func TestHandler_approvePurchase_RejectsMismatchedSession(t *testing.T) {
 	// asserts nothing by construction; a .On(...) entry above would create
 	// a false positive, so we pin the negative by confirming the error is
 	// the authz error, not an approval-manager error.
-	mockPurchase.AssertNotCalled(t, "ApproveExecution")
+	mockPurchase.AssertNotCalled(t, "ApproveExecution", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestHandler_approvePurchase_RejectsMissingContactEmail covers the
@@ -204,7 +204,7 @@ func TestHandler_approvePurchase_RejectsMissingContactEmail(t *testing.T) {
 	_, err := handler.approvePurchase(ctx, req, execID, "valid-token")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no per-account contact email")
-	mockPurchase.AssertNotCalled(t, "ApproveExecution")
+	mockPurchase.AssertNotCalled(t, "ApproveExecution", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestHandler_approvePurchase_RejectsMissingSession(t *testing.T) {
@@ -328,7 +328,7 @@ func TestHandler_approvePurchase_SessionApproveAnyChainsToExecute(t *testing.T) 
 	require.NoError(t, err)
 	assert.Equal(t, "completed", result.(map[string]string)["status"])
 	mockPurchase.AssertExpectations(t)
-	mockPurchase.AssertNotCalled(t, "ApproveExecution")
+	mockPurchase.AssertNotCalled(t, "ApproveExecution", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestHandler_approvePurchase_SessionExecuteFailureSurfacesAs409 pins the
@@ -678,7 +678,7 @@ func TestHandler_approvePurchase_RejectsGlobalNotifyWhenContactSet(t *testing.T)
 	_, err := handler.approvePurchase(ctx, req, execID, "valid-token")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not the authorized approver")
-	mockPurchase.AssertNotCalled(t, "ApproveExecution")
+	mockPurchase.AssertNotCalled(t, "ApproveExecution", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestHandler_approvePurchase_RejectsCreatorWithoutApprovePermission is the
@@ -741,8 +741,8 @@ func TestHandler_approvePurchase_RejectsCreatorWithoutApprovePermission(t *testi
 	require.True(t, ok, "expected a ClientError, got %T: %v", err, err)
 	assert.Equal(t, 403, ce.code, "creator without approve permission must be denied 403")
 	// Purchase manager must never be reached.
-	mockPurchase.AssertNotCalled(t, "ApproveExecution")
-	mockPurchase.AssertNotCalled(t, "ApproveAndExecute")
+	mockPurchase.AssertNotCalled(t, "ApproveExecution", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockPurchase.AssertNotCalled(t, "ApproveAndExecute", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestRouter_approvePurchaseHandler_RateLimited is a regression test for issue #400.

--- a/internal/api/handler_ri_exchange_test.go
+++ b/internal/api/handler_ri_exchange_test.go
@@ -968,7 +968,7 @@ func TestListExchangeableAzureRIs_SubscriptionIDOutOfScope(t *testing.T) {
 	// AssertExpectations above passes whether it was called or not; assert it
 	// explicitly to prove the scope gate refuses the request before the
 	// tenant-wide listing is ever fetched.
-	opsClient.AssertNotCalled(t, "ListExchangeableReservations")
+	opsClient.AssertNotCalled(t, "ListExchangeableReservations", mock.Anything)
 }
 
 // TestListExchangeableAzureRIs_SubscriptionIDFiltersToOwnRows exercises

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -766,7 +766,7 @@ func TestService_Logout_EmptyToken(t *testing.T) {
 	assert.Contains(t, err.Error(), "token is required")
 
 	// DeleteSession must not be called
-	mockStore.AssertNotCalled(t, "DeleteSession")
+	mockStore.AssertNotCalled(t, "DeleteSession", mock.Anything, mock.Anything)
 }
 
 func TestService_Logout_NilStore(t *testing.T) {

--- a/internal/email/mute_test.go
+++ b/internal/email/mute_test.go
@@ -57,7 +57,7 @@ func TestSendPurchaseApprovalRequest_MutedRecipient_NoSESCall(t *testing.T) {
 		Return(true, nil)
 	t.Cleanup(func() {
 		mc.AssertExpectations(t)
-		ses.AssertNotCalled(t, "SendEmail")
+		ses.AssertNotCalled(t, "SendEmail", mock.Anything, mock.Anything)
 	})
 
 	s := newSenderWithMute(ses, mc)
@@ -146,7 +146,7 @@ func TestSendRIExchangePendingApproval_MutedRecipient_NoSESCall(t *testing.T) {
 		Return(true, nil).Once()
 	t.Cleanup(func() {
 		mc.AssertExpectations(t)
-		ses.AssertNotCalled(t, "SendEmail")
+		ses.AssertNotCalled(t, "SendEmail", mock.Anything, mock.Anything)
 	})
 
 	s := newSenderWithMute(ses, mc)

--- a/internal/mocks/assertions_test.go
+++ b/internal/mocks/assertions_test.go
@@ -78,7 +78,13 @@ func TestAssertNotCalled_NameOnlyFormMatchesCallWithArguments(t *testing.T) {
 	// testify's promoted implementation is the behavior being replaced: it
 	// still passes, because WithTx never reached mock.Called and because an
 	// empty expectation cannot match a two-argument call.
-	assert.True(t, m.Mock.AssertNotCalled(&recordingT{}, "WithTx"))
+	//
+	// Hoisted to a local rather than written as m.Mock.AssertNotCalled(...):
+	// TestNoUnfailableMockAssertions cannot resolve a selector receiver and
+	// correctly reports such a site for hand review, which this deliberate
+	// call into the broken implementation would otherwise trip forever.
+	promoted := &m.Mock
+	assert.True(t, promoted.AssertNotCalled(&recordingT{}, "WithTx"))
 }
 
 // TestAssertNotCalled_WrongMatcherCountFailsLoudly pins the third way these

--- a/internal/mocks/vacuous_assertion_guard_test.go
+++ b/internal/mocks/vacuous_assertion_guard_test.go
@@ -28,9 +28,12 @@ import (
 // detected, not hardcoded, so a future mock that adopts the same pattern is
 // covered automatically.
 //
-// The check is syntactic and package-scoped: a mock and the tests that use it
-// live in the same package throughout this repo. It parses rather than builds,
-// so it costs milliseconds.
+// The check is syntactic. Mocks are resolved within the using package first and
+// then, for mocks declared elsewhere and aliased in (MockConfigStore is the
+// repo's one such case), through a repo-wide index by type name. A receiver it
+// still cannot place is reported rather than skipped: a skip that says nothing
+// is the same shape of defect the guard exists to catch. It parses rather than
+// builds, so it costs milliseconds.
 
 // mockType is one testify mock in one package.
 type mockType struct {
@@ -39,8 +42,12 @@ type mockType struct {
 	// signature arity: MockSESClient.SendEmail takes three parameters but calls
 	// m.Called(ctx, input).
 	calledArity map[string]int
-	// shadows is true when the type defines its own assertion helpers.
-	shadows bool
+	// shadowed records which assertion helpers the type defines itself, keyed by
+	// helper name. Per-helper rather than per-type: a mock that shadows only
+	// AssertNotCalled leaves AssertCalled going through testify, where the
+	// name-only form is still unfailable, so exempting the whole type would
+	// hand back the very hole this guard closes.
+	shadowed map[string]bool
 }
 
 type assertSite struct {
@@ -76,9 +83,15 @@ func TestNoUnfailableMockAssertions(t *testing.T) {
 		t.Fatalf("walk %s: %v", root, err)
 	}
 
-	var findings []string
-	var skipped []string
-	checked := 0
+	// Mocks are usually declared in the package that uses them, but not always:
+	// MockConfigStore lives in internal/mocks and is aliased into internal/api,
+	// internal/purchase and internal/scheduler. A per-package map alone does not
+	// recognize it there, so those sites would be skipped -- and a skip that
+	// reports nothing is the very defect this guard exists to catch. Index every
+	// mock in the repo by type name as a fallback for exactly that case.
+	global := map[string][]*mockType{}
+	parsed := map[string][]*ast.File{}
+	fsets := map[string]*token.FileSet{}
 	for _, dir := range sortedKeys(pkgFiles) {
 		fset := token.NewFileSet()
 		var files []*ast.File
@@ -92,6 +105,19 @@ func TestNoUnfailableMockAssertions(t *testing.T) {
 			}
 			files = append(files, f)
 		}
+		parsed[dir] = files
+		fsets[dir] = fset
+		for name, m := range collectMocks(files) {
+			global[name] = append(global[name], m)
+		}
+	}
+
+	var findings []string
+	var skipped []string
+	checked := 0
+	for _, dir := range sortedKeys(pkgFiles) {
+		fset := fsets[dir]
+		files := parsed[dir]
 		mocks := collectMocks(files)
 		if len(mocks) == 0 {
 			continue
@@ -101,24 +127,43 @@ func TestNoUnfailableMockAssertions(t *testing.T) {
 				recvType, resolved := resolveRecvType(f, site)
 				m, isMock := mocks[recvType]
 				if resolved && !isMock {
-					// Resolved to a concrete type that is not a testify mock.
-					// Nothing to say about it, and no blind spot either.
-					continue
+					var reason string
+					m, isMock, reason = resolveCrossPackage(global, recvType, site.method)
+					if !isMock {
+						skipped = append(skipped, fmt.Sprintf(
+							"%s: %s.%s(t, %q) -- receiver resolves to %s, which this check "+
+								"could not analyze (%s). Review by hand.",
+							site.pos, site.recv, site.assertFn, site.method, recvType, reason))
+						continue
+					}
 				}
 				if !resolved {
 					// The receiver was not assigned from a mock literal in this
 					// file. Only report it when the method name belongs to some
 					// mock in the package and would be unfailable if it were one,
 					// so an unreviewed blind spot cannot hide behind a pass.
-					if unresolvedLooksRisky(site, mocks) {
+					if unresolvedLooksRisky(site, mocks, global) {
 						skipped = append(skipped, fmt.Sprintf(
 							"%s: %s.%s(t, %q) -- receiver type could not be resolved; "+
 								"review this site by hand", site.pos, site.recv, site.assertFn, site.method))
 					}
 					continue
 				}
+				if m.shadowed[site.assertFn] {
+					// This type implements the helper being used, so it defines
+					// what the matchers mean. See MockConfigStore in assertions.go.
+					continue
+				}
 				arity, known := m.calledArity[site.method]
-				if !known || m.shadows {
+				if !known {
+					// The method exists on a mock but never calls m.Called itself
+					// (it delegates to a sibling), so there is no arity to check
+					// against. Report it: "checked nothing" must never be silent,
+					// which is the same reason checked == 0 is fatal below.
+					skipped = append(skipped, fmt.Sprintf(
+						"%s: %s.%s(t, %q) -- %s does not call m.Called directly, so its "+
+							"argument count cannot be derived. Review by hand.",
+						site.pos, site.recv, site.assertFn, site.method, site.method))
 					continue
 				}
 				checked++
@@ -180,11 +225,11 @@ func collectMocks(files []*ast.File) map[string]*mockType {
 			}
 			m := mocks[typeName]
 			if m == nil {
-				m = &mockType{calledArity: map[string]int{}}
+				m = &mockType{calledArity: map[string]int{}, shadowed: map[string]bool{}}
 				mocks[typeName] = m
 			}
 			if fd.Name.Name == "AssertCalled" || fd.Name.Name == "AssertNotCalled" {
-				m.shadows = true
+				m.shadowed[fd.Name.Name] = true
 			}
 			ast.Inspect(fd.Body, func(n ast.Node) bool {
 				call, ok := n.(*ast.CallExpr)
@@ -355,22 +400,45 @@ func sortedKeys(m map[string][]string) []string {
 // resolved names a method that some mock in the package implements with a
 // non-zero m.Called arity and without shadowing the helpers. Those are the
 // unresolved sites that could be hiding the defect.
-func unresolvedLooksRisky(site assertSite, mocks map[string]*mockType) bool {
-	if site.matchers > 0 {
-		// A site carrying matchers is only wrong if the count is off, which
-		// cannot be judged without knowing which mock it is. Ambiguous rather
-		// than risky, and reporting every one would drown the real findings.
-		return false
+func unresolvedLooksRisky(site assertSite, mocks map[string]*mockType, global map[string][]*mockType) bool {
+	// Any matcher count can be wrong, not just zero: a non-zero count that does
+	// not match the real arity is the third vacuity mode from #1735. Both are
+	// reported, since neither can be judged without knowing the type.
+	looks := func(m *mockType) bool {
+		if m.shadowed[site.assertFn] {
+			return false
+		}
+		arity, ok := m.calledArity[site.method]
+		return ok && arity > 0
 	}
 	for _, m := range mocks {
-		if m.shadows {
-			continue
-		}
-		if arity, ok := m.calledArity[site.method]; ok && arity > 0 {
+		if looks(m) {
 			return true
 		}
 	}
+	for _, defs := range global {
+		for _, m := range defs {
+			if looks(m) {
+				return true
+			}
+		}
+	}
 	return false
+}
+
+// sameShadowing reports whether two same-named mocks define the same set of
+// assertion helpers, so the cross-package fallback does not exempt a site on one
+// mock's opt-out while the real type has none.
+func sameShadowing(a, b *mockType) bool {
+	if len(a.shadowed) != len(b.shadowed) {
+		return false
+	}
+	for k := range a.shadowed {
+		if !b.shadowed[k] {
+			return false
+		}
+	}
+	return true
 }
 
 // TestVacuousAssertionGuardDetects exercises the guard's analysis on synthetic
@@ -434,12 +502,15 @@ func Test(t *testing.T) {
 		if got, ok := m.calledArity["None"]; !ok || got != 0 {
 			t.Errorf("MockThing.None arity = %d (present=%v), want 0", got, ok)
 		}
-		if m.shadows {
+		if len(m.shadowed) != 0 {
 			t.Error("MockThing does not define its own helpers and must not count as shadowing")
 		}
 	}
-	if m, ok := mocks["MockShadowed"]; !ok || !m.shadows {
-		t.Error("MockShadowed defines AssertNotCalled and must count as shadowing")
+	if m, ok := mocks["MockShadowed"]; !ok || !m.shadowed["AssertNotCalled"] {
+		t.Error("MockShadowed defines AssertNotCalled and must be recorded as shadowing it")
+	} else if m.shadowed["AssertCalled"] {
+		t.Error("MockShadowed does not define AssertCalled; shadowing must be per-helper, " +
+			"or its name-only AssertCalled sites would be exempted while still unfailable")
 	}
 
 	type verdict struct {
@@ -447,6 +518,13 @@ func Test(t *testing.T) {
 		matchers int
 		vacuous  bool
 	}
+	// The synthetic source is a single package, so the repo-wide index used by
+	// the real run is just this package's mocks.
+	global := map[string][]*mockType{}
+	for name, m := range mocks {
+		global[name] = append(global[name], m)
+	}
+
 	var got []verdict
 	unresolved := 0
 	for _, site := range collectAssertSites(fset, f) {
@@ -456,13 +534,13 @@ func Test(t *testing.T) {
 			continue
 		}
 		if !resolved {
-			if unresolvedLooksRisky(site, mocks) {
+			if unresolvedLooksRisky(site, mocks, global) {
 				unresolved++
 			}
 			continue
 		}
 		arity, known := m.calledArity[site.method]
-		if !known || m.shadows || arity == 0 {
+		if m.shadowed[site.assertFn] || !known || arity == 0 {
 			continue
 		}
 		got = append(got, verdict{site.method, site.matchers, site.matchers != arity})
@@ -484,5 +562,89 @@ func Test(t *testing.T) {
 	}
 	if unresolved != 1 {
 		t.Errorf("unresolved risky sites = %d, want 1 (the `unknown` receiver)", unresolved)
+	}
+}
+
+// resolveCrossPackage finds a mock declared outside the package that uses it,
+// keyed by type name. Type names are not unique across the repo (MockEmailSender
+// and MockHTTPClient each have several unrelated definitions), so a single
+// candidate is used directly and multiple candidates are accepted only when they
+// agree about the method in question. Anything else is reported rather than
+// assumed, because guessing here would silently attribute one mock's arity to
+// another.
+func resolveCrossPackage(global map[string][]*mockType, typeName, method string) (*mockType, bool, string) {
+	candidates := global[typeName]
+	switch len(candidates) {
+	case 0:
+		return nil, false, "no mock of that name is declared anywhere in the repo"
+	case 1:
+		return candidates[0], true, ""
+	}
+	first := candidates[0]
+	wantArity, wantKnown := first.calledArity[method]
+	for _, c := range candidates[1:] {
+		arity, known := c.calledArity[method]
+		if known != wantKnown || arity != wantArity || !sameShadowing(c, first) {
+			return nil, false, fmt.Sprintf(
+				"%d mocks share that name and disagree about %s", len(candidates), method)
+		}
+	}
+	return first, true, ""
+}
+
+// TestResolveCrossPackage pins the fallback used for mocks declared outside the
+// package that asserts on them. Before it existed, MockConfigStore was
+// unrecognized in internal/api, internal/purchase and internal/scheduler, so
+// every site there was silently skipped: absent from the checked count, absent
+// from the report. Removing MockConfigStore's shadowed helpers took the guard
+// from 6 findings to 56 once this landed, the 50 difference being exactly those
+// cross-package sites.
+//
+// Type names are not unique across this repo (MockHTTPClient has five unrelated
+// definitions), so the fallback must refuse to guess rather than attribute one
+// mock's arity to another.
+func TestResolveCrossPackage(t *testing.T) {
+	twoArgs := &mockType{calledArity: map[string]int{"Do": 2}, shadowed: map[string]bool{}}
+	twoArgsAgain := &mockType{calledArity: map[string]int{"Do": 2}, shadowed: map[string]bool{}}
+	threeArgs := &mockType{calledArity: map[string]int{"Do": 3}, shadowed: map[string]bool{}}
+	shadowed := &mockType{calledArity: map[string]int{"Do": 2}, shadowed: map[string]bool{"AssertNotCalled": true}}
+
+	tests := []struct {
+		name       string
+		candidates []*mockType
+		wantOK     bool
+	}{
+		{"single definition is used", []*mockType{twoArgs}, true},
+		{"no definition anywhere", nil, false},
+		{"duplicates that agree", []*mockType{twoArgs, twoArgsAgain}, true},
+		{"duplicates disagreeing on arity", []*mockType{twoArgs, threeArgs}, false},
+		{"duplicates disagreeing on shadowing", []*mockType{twoArgs, shadowed}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			global := map[string][]*mockType{"MockThing": tt.candidates}
+			got, ok, reason := resolveCrossPackage(global, "MockThing", "Do")
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (reason %q)", ok, tt.wantOK, reason)
+			}
+			if ok && got == nil {
+				t.Error("resolved but returned no mock")
+			}
+			if !ok && reason == "" {
+				t.Error("refused to resolve but gave no reason; the skip would be silent")
+			}
+		})
+	}
+}
+
+// TestResolveCrossPackage_UnknownMethodStillDisagrees covers the case where one
+// candidate implements the method and another does not: that is a disagreement,
+// not a match, and must not resolve.
+func TestResolveCrossPackage_UnknownMethodStillDisagrees(t *testing.T) {
+	has := &mockType{calledArity: map[string]int{"Do": 2}, shadowed: map[string]bool{}}
+	hasNot := &mockType{calledArity: map[string]int{"Other": 1}, shadowed: map[string]bool{}}
+	global := map[string][]*mockType{"MockThing": {has, hasNot}}
+	if _, ok, reason := resolveCrossPackage(global, "MockThing", "Do"); ok {
+		t.Errorf("resolved across candidates that disagree about Do (reason %q)", reason)
 	}
 }

--- a/internal/mocks/vacuous_assertion_guard_test.go
+++ b/internal/mocks/vacuous_assertion_guard_test.go
@@ -1,0 +1,488 @@
+package mocks
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// This guard closes the class of defect behind #1595 and #1740 for code not yet
+// written, rather than only the instances that exist today.
+//
+// testify's AssertCalled / AssertNotCalled diff the matchers they are given
+// against the arguments a mock recorded. An empty matcher list is diffed too,
+// and each real argument counts as a difference, so a name-only
+// AssertNotCalled(t, "Method") never matches a method that passes arguments to
+// m.Called: it reports success no matter what the code under test did. The same
+// goes for any matcher count that differs from that method's real arity.
+//
+// A mock may opt out by defining its own AssertCalled / AssertNotCalled -- as
+// MockConfigStore does in assertions.go, where the shadowed versions read a
+// callLog and name-only deliberately means "not called at all". That opt-out is
+// detected, not hardcoded, so a future mock that adopts the same pattern is
+// covered automatically.
+//
+// The check is syntactic and package-scoped: a mock and the tests that use it
+// live in the same package throughout this repo. It parses rather than builds,
+// so it costs milliseconds.
+
+// mockType is one testify mock in one package.
+type mockType struct {
+	// calledArity maps method name -> number of arguments the method hands to
+	// m.Called. This is what testify diffs against, and it is NOT always the
+	// signature arity: MockSESClient.SendEmail takes three parameters but calls
+	// m.Called(ctx, input).
+	calledArity map[string]int
+	// shadows is true when the type defines its own assertion helpers.
+	shadows bool
+}
+
+type assertSite struct {
+	pos      token.Position
+	recv     string
+	assertFn string
+	method   string
+	matchers int
+}
+
+func TestNoUnfailableMockAssertions(t *testing.T) {
+	root := repoRoot(t)
+
+	pkgFiles := map[string][]string{}
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules", "vendor", ".terraform":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(path, ".go") {
+			dir := filepath.Dir(path)
+			pkgFiles[dir] = append(pkgFiles[dir], path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+
+	var findings []string
+	var skipped []string
+	checked := 0
+	for _, dir := range sortedKeys(pkgFiles) {
+		fset := token.NewFileSet()
+		var files []*ast.File
+		for _, p := range pkgFiles[dir] {
+			f, err := parser.ParseFile(fset, p, nil, 0)
+			if err != nil {
+				// A file that does not parse is the compiler's problem, not this
+				// guard's; skipping it cannot hide a vacuous assertion, because a
+				// package that does not compile has no passing tests either.
+				continue
+			}
+			files = append(files, f)
+		}
+		mocks := collectMocks(files)
+		if len(mocks) == 0 {
+			continue
+		}
+		for _, f := range files {
+			for _, site := range collectAssertSites(fset, f) {
+				recvType, resolved := resolveRecvType(f, site)
+				m, isMock := mocks[recvType]
+				if resolved && !isMock {
+					// Resolved to a concrete type that is not a testify mock.
+					// Nothing to say about it, and no blind spot either.
+					continue
+				}
+				if !resolved {
+					// The receiver was not assigned from a mock literal in this
+					// file. Only report it when the method name belongs to some
+					// mock in the package and would be unfailable if it were one,
+					// so an unreviewed blind spot cannot hide behind a pass.
+					if unresolvedLooksRisky(site, mocks) {
+						skipped = append(skipped, fmt.Sprintf(
+							"%s: %s.%s(t, %q) -- receiver type could not be resolved; "+
+								"review this site by hand", site.pos, site.recv, site.assertFn, site.method))
+					}
+					continue
+				}
+				arity, known := m.calledArity[site.method]
+				if !known || m.shadows {
+					continue
+				}
+				checked++
+				if arity == 0 {
+					continue
+				}
+				switch {
+				case site.matchers == 0:
+					findings = append(findings, fmt.Sprintf(
+						"%s: %s.%s(t, %q) passes no matchers, but %s hands %d argument(s) to m.Called. "+
+							"testify diffs the empty matcher list against those arguments and counts each as a "+
+							"difference, so this assertion can never fail. Pass %d matcher(s) (mock.Anything is fine).",
+						site.pos, site.recv, site.assertFn, site.method, site.method, arity, arity))
+				case site.matchers != arity:
+					findings = append(findings, fmt.Sprintf(
+						"%s: %s.%s(t, %q) passes %d matcher(s), but %s hands %d argument(s) to m.Called. "+
+							"A count that differs from the real arity can never match, so this assertion can "+
+							"never fail. Pass %d matcher(s).",
+						site.pos, site.recv, site.assertFn, site.method, site.matchers, site.method, arity, arity))
+				}
+			}
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("guard checked no assertion sites; its mock or receiver detection has broken " +
+			"and it would report success on a repo full of unfailable assertions")
+	}
+	t.Logf("checked %d mock assertion site(s)", checked)
+
+	// An unresolved receiver is not proof of safety. Surface it rather than
+	// letting the count quietly shrink.
+	if len(skipped) > 0 {
+		sort.Strings(skipped)
+		t.Errorf("%d assertion site(s) could not be checked:\n\n%s",
+			len(skipped), strings.Join(skipped, "\n\n"))
+	}
+
+	if len(findings) > 0 {
+		sort.Strings(findings)
+		t.Errorf("%d unfailable mock assertion(s):\n\n%s", len(findings), strings.Join(findings, "\n\n"))
+	}
+}
+
+// collectMocks finds every type in the package that has at least one method
+// dispatching through m.Called, which is what makes it a testify mock for the
+// purposes of this check.
+func collectMocks(files []*ast.File) map[string]*mockType {
+	mocks := map[string]*mockType{}
+	for _, f := range files {
+		for _, d := range f.Decls {
+			fd, ok := d.(*ast.FuncDecl)
+			if !ok || fd.Recv == nil || len(fd.Recv.List) != 1 || fd.Body == nil {
+				continue
+			}
+			typeName := recvTypeIdent(fd.Recv.List[0].Type)
+			if typeName == "" {
+				continue
+			}
+			m := mocks[typeName]
+			if m == nil {
+				m = &mockType{calledArity: map[string]int{}}
+				mocks[typeName] = m
+			}
+			if fd.Name.Name == "AssertCalled" || fd.Name.Name == "AssertNotCalled" {
+				m.shadows = true
+			}
+			ast.Inspect(fd.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				switch sel.Sel.Name {
+				case "Called":
+					m.calledArity[fd.Name.Name] = len(call.Args)
+				case "MethodCalled":
+					if len(call.Args) >= 1 {
+						m.calledArity[fd.Name.Name] = len(call.Args) - 1
+					}
+				}
+				return true
+			})
+		}
+	}
+	// A type with no m.Called anywhere is not a mock.
+	for name, m := range mocks {
+		if len(m.calledArity) == 0 {
+			delete(mocks, name)
+		}
+	}
+	return mocks
+}
+
+func collectAssertSites(fset *token.FileSet, f *ast.File) []assertSite {
+	var out []assertSite
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel.Name != "AssertCalled" && sel.Sel.Name != "AssertNotCalled" {
+			return true
+		}
+		recv, ok := sel.X.(*ast.Ident)
+		if !ok || len(call.Args) < 2 {
+			return true
+		}
+		lit, ok := call.Args[1].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		if call.Ellipsis.IsValid() {
+			// AssertNotCalled(t, "M", args...) spreads a slice whose length is
+			// not knowable here. Counting the spread expression as one matcher
+			// would invent a mismatch, so the site is left alone.
+			return true
+		}
+		out = append(out, assertSite{
+			pos:      fset.Position(call.Pos()),
+			recv:     recv.Name,
+			assertFn: sel.Sel.Name,
+			method:   strings.Trim(lit.Value, `"`),
+			matchers: len(call.Args) - 2,
+		})
+		return true
+	})
+	return out
+}
+
+// resolveRecvType maps the assertion's receiver identifier back to the type it
+// was assigned from within the file: mockStore := &MockX{}, new(MockX), or
+// MockX{}. It reports the type name whether or not that type is a mock, so the
+// caller can tell "this is not a mock" (nothing to check) apart from "we could
+// not tell what this is" (an unreviewed blind spot).
+func resolveRecvType(f *ast.File, site assertSite) (string, bool) {
+	var found string
+	ast.Inspect(f, func(n ast.Node) bool {
+		var lhs, rhs []ast.Expr
+		switch v := n.(type) {
+		case *ast.AssignStmt:
+			lhs, rhs = v.Lhs, v.Rhs
+		case *ast.ValueSpec:
+			for _, name := range v.Names {
+				lhs = append(lhs, name)
+			}
+			rhs = v.Values
+		default:
+			return true
+		}
+		if len(lhs) != len(rhs) {
+			return true
+		}
+		for i, l := range lhs {
+			id, ok := l.(*ast.Ident)
+			if !ok || id.Name != site.recv {
+				continue
+			}
+			if name := mockTypeOfExpr(rhs[i]); name != "" {
+				found = name
+			}
+		}
+		return true
+	})
+	return found, found != ""
+}
+
+// mockTypeOfExpr extracts T from &T{...}, T{...} and new(T).
+func mockTypeOfExpr(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.UnaryExpr:
+		if v.Op == token.AND {
+			return mockTypeOfExpr(v.X)
+		}
+	case *ast.CompositeLit:
+		if id, ok := v.Type.(*ast.Ident); ok {
+			return id.Name
+		}
+	case *ast.CallExpr:
+		if id, ok := v.Fun.(*ast.Ident); ok && id.Name == "new" && len(v.Args) == 1 {
+			if t, ok := v.Args[0].(*ast.Ident); ok {
+				return t.Name
+			}
+		}
+	}
+	return ""
+}
+
+func recvTypeIdent(e ast.Expr) string {
+	if star, ok := e.(*ast.StarExpr); ok {
+		e = star.X
+	}
+	if id, ok := e.(*ast.Ident); ok {
+		return id.Name
+	}
+	return ""
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("no go.mod found above the working directory")
+		}
+		dir = parent
+	}
+}
+
+func sortedKeys(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// unresolvedLooksRisky reports whether an assertion whose receiver could not be
+// resolved names a method that some mock in the package implements with a
+// non-zero m.Called arity and without shadowing the helpers. Those are the
+// unresolved sites that could be hiding the defect.
+func unresolvedLooksRisky(site assertSite, mocks map[string]*mockType) bool {
+	if site.matchers > 0 {
+		// A site carrying matchers is only wrong if the count is off, which
+		// cannot be judged without knowing which mock it is. Ambiguous rather
+		// than risky, and reporting every one would drown the real findings.
+		return false
+	}
+	for _, m := range mocks {
+		if m.shadows {
+			continue
+		}
+		if arity, ok := m.calledArity[site.method]; ok && arity > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// TestVacuousAssertionGuardDetects exercises the guard's analysis on synthetic
+// source covering each case it must separate. Without this, the guard could
+// break into reporting nothing and the repo-wide run would still look green --
+// the exact failure mode #1595 was about.
+func TestVacuousAssertionGuardDetects(t *testing.T) {
+	const src = `package p
+
+type MockThing struct{ mock.Mock }
+
+func (m *MockThing) Two(a, b int) error  { return m.Called(a, b).Error(0) }
+func (m *MockThing) None() error         { return m.Called().Error(0) }
+
+type MockShadowed struct{ mock.Mock }
+
+func (m *MockShadowed) Two(a, b int) error                  { return m.Called(a, b).Error(0) }
+func (m *MockShadowed) AssertNotCalled(t T, s string, a ...interface{}) bool { return true }
+
+type NotAMock struct{}
+
+func (n *NotAMock) Two(a, b int) error { return nil }
+
+func Test(t *testing.T) {
+	thing := &MockThing{}
+	thing.AssertNotCalled(t, "Two")                               // want: vacuous
+	thing.AssertNotCalled(t, "Two", mock.Anything)                // want: wrong count
+	thing.AssertNotCalled(t, "Two", mock.Anything, mock.Anything) // want: ok
+	thing.AssertCalled(t, "Two")                                  // want: vacuous
+	thing.AssertNotCalled(t, "None")                              // want: ok, arity 0
+
+	shadowed := new(MockShadowed)
+	shadowed.AssertNotCalled(t, "Two") // want: ok, type shadows the helpers
+
+	plain := &NotAMock{}
+	plain.AssertNotCalled(t, "Two") // want: ignored, not a mock
+
+	unknown.AssertNotCalled(t, "Two") // want: reported as unresolved
+
+	spread := &MockThing{}
+	spread.AssertNotCalled(t, "Two", anyArgs...) // want: ignored, count unknowable
+}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "synthetic.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	files := []*ast.File{f}
+	mocks := collectMocks(files)
+
+	if _, ok := mocks["NotAMock"]; ok {
+		t.Error("NotAMock has no m.Called and must not be treated as a mock")
+	}
+	if m, ok := mocks["MockThing"]; !ok {
+		t.Fatal("MockThing not detected as a mock")
+	} else {
+		if got := m.calledArity["Two"]; got != 2 {
+			t.Errorf("MockThing.Two arity = %d, want 2", got)
+		}
+		if got, ok := m.calledArity["None"]; !ok || got != 0 {
+			t.Errorf("MockThing.None arity = %d (present=%v), want 0", got, ok)
+		}
+		if m.shadows {
+			t.Error("MockThing does not define its own helpers and must not count as shadowing")
+		}
+	}
+	if m, ok := mocks["MockShadowed"]; !ok || !m.shadows {
+		t.Error("MockShadowed defines AssertNotCalled and must count as shadowing")
+	}
+
+	type verdict struct {
+		method   string
+		matchers int
+		vacuous  bool
+	}
+	var got []verdict
+	unresolved := 0
+	for _, site := range collectAssertSites(fset, f) {
+		recvType, resolved := resolveRecvType(f, site)
+		m, isMock := mocks[recvType]
+		if resolved && !isMock {
+			continue
+		}
+		if !resolved {
+			if unresolvedLooksRisky(site, mocks) {
+				unresolved++
+			}
+			continue
+		}
+		arity, known := m.calledArity[site.method]
+		if !known || m.shadows || arity == 0 {
+			continue
+		}
+		got = append(got, verdict{site.method, site.matchers, site.matchers != arity})
+	}
+
+	want := []verdict{
+		{"Two", 0, true},  // name-only
+		{"Two", 1, true},  // wrong count
+		{"Two", 2, false}, // correct
+		{"Two", 0, true},  // AssertCalled, name-only
+	}
+	if len(got) != len(want) {
+		t.Fatalf("checked %d site(s), want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("site %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+	if unresolved != 1 {
+		t.Errorf("unresolved risky sites = %d, want 1 (the `unknown` receiver)", unresolved)
+	}
+}

--- a/internal/mocks/vacuous_assertion_guard_test.go
+++ b/internal/mocks/vacuous_assertion_guard_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -56,6 +57,17 @@ type assertSite struct {
 	assertFn string
 	method   string
 	matchers int
+	// unsupported is non-empty when the site was recognized as a mock
+	// assertion but has a shape this check cannot analyze. Such sites are
+	// reported, never dropped: silently ignoring a shape is the same defect
+	// the guard exists to catch.
+	unsupported string
+	// scopes is the chain of function bodies enclosing the site, innermost
+	// first. Resolution walks it outward like Go's own lexical scoping: a
+	// t.Cleanup closure that references a mock declared in the enclosing test
+	// still resolves, while two tests in one file that both declare mockStore
+	// no longer bleed into each other.
+	scopes []ast.Node
 }
 
 func TestNoUnfailableMockAssertions(t *testing.T) {
@@ -124,7 +136,7 @@ func TestNoUnfailableMockAssertions(t *testing.T) {
 		}
 		for _, f := range files {
 			for _, site := range collectAssertSites(fset, f) {
-				recvType, resolved := resolveRecvType(f, site)
+				recvType, resolved := resolveRecvType(site.scopes, site)
 				m, isMock := mocks[recvType]
 				if resolved && !isMock {
 					var reason string
@@ -263,52 +275,137 @@ func collectMocks(files []*ast.File) map[string]*mockType {
 
 func collectAssertSites(fset *token.FileSet, f *ast.File) []assertSite {
 	var out []assertSite
-	ast.Inspect(f, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
+	// Innermost enclosing function body for each site, so receiver resolution
+	// is scoped rather than file-wide.
+	var stack []ast.Node
+	var walk func(n ast.Node) bool
+	walk = func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.FuncDecl:
+			if v.Body != nil {
+				stack = append(stack, v.Body)
+				defer func() { stack = stack[:len(stack)-1] }()
+				ast.Inspect(v.Body, walk)
+				return false
+			}
+		case *ast.FuncLit:
+			if v.Body != nil {
+				stack = append(stack, v.Body)
+				defer func() { stack = stack[:len(stack)-1] }()
+				ast.Inspect(v.Body, walk)
+				return false
+			}
+		case *ast.CallExpr:
+			sel, ok := v.Fun.(*ast.SelectorExpr)
+			if !ok || (sel.Sel.Name != "AssertCalled" && sel.Sel.Name != "AssertNotCalled") {
+				return true
+			}
+			// Copy innermost-first; stack is mutated as the walk unwinds.
+			chain := make([]ast.Node, 0, len(stack))
+			for i := len(stack) - 1; i >= 0; i-- {
+				chain = append(chain, stack[i])
+			}
+			site := assertSite{pos: fset.Position(v.Pos()), assertFn: sel.Sel.Name, scopes: chain}
+
+			recv, ok := sel.X.(*ast.Ident)
+			if !ok {
+				site.recv = exprString(sel.X)
+				site.unsupported = "receiver is not a plain identifier (e.g. a field or nested selector)"
+				out = append(out, site)
+				return true
+			}
+			site.recv = recv.Name
+
+			if len(v.Args) < 2 {
+				site.unsupported = "fewer than two arguments; not a well-formed mock assertion"
+				out = append(out, site)
+				return true
+			}
+			lit, ok := v.Args[1].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				site.unsupported = "method name is not a string literal"
+				out = append(out, site)
+				return true
+			}
+			// strconv.Unquote rather than strings.Trim: Trim mishandles escapes
+			// and silently accepts a raw-string literal, which is also
+			// token.STRING but has different contents.
+			name, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				site.unsupported = "method name literal could not be unquoted: " + err.Error()
+				out = append(out, site)
+				return true
+			}
+			site.method = name
+			if v.Ellipsis.IsValid() {
+				// AssertNotCalled(t, "M", args...) spreads a slice whose length
+				// is not knowable here. Counting the spread expression as one
+				// matcher would invent a mismatch.
+				site.unsupported = "matchers are passed as a variadic spread; the count is not statically known"
+				out = append(out, site)
+				return true
+			}
+			site.matchers = len(v.Args) - 2
+			out = append(out, site)
 			return true
 		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return true
-		}
-		if sel.Sel.Name != "AssertCalled" && sel.Sel.Name != "AssertNotCalled" {
-			return true
-		}
-		recv, ok := sel.X.(*ast.Ident)
-		if !ok || len(call.Args) < 2 {
-			return true
-		}
-		lit, ok := call.Args[1].(*ast.BasicLit)
-		if !ok || lit.Kind != token.STRING {
-			return true
-		}
-		if call.Ellipsis.IsValid() {
-			// AssertNotCalled(t, "M", args...) spreads a slice whose length is
-			// not knowable here. Counting the spread expression as one matcher
-			// would invent a mismatch, so the site is left alone.
-			return true
-		}
-		out = append(out, assertSite{
-			pos:      fset.Position(call.Pos()),
-			recv:     recv.Name,
-			assertFn: sel.Sel.Name,
-			method:   strings.Trim(lit.Value, `"`),
-			matchers: len(call.Args) - 2,
-		})
 		return true
-	})
+	}
+	ast.Inspect(f, walk)
 	return out
 }
 
-// resolveRecvType maps the assertion's receiver identifier back to the type it
-// was assigned from within the file: mockStore := &MockX{}, new(MockX), or
-// MockX{}. It reports the type name whether or not that type is a mock, so the
-// caller can tell "this is not a mock" (nothing to check) apart from "we could
-// not tell what this is" (an unreviewed blind spot).
-func resolveRecvType(f *ast.File, site assertSite) (string, bool) {
+// exprString renders a receiver expression for a report message.
+func exprString(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		return exprString(v.X) + "." + v.Sel.Name
+	case *ast.CallExpr:
+		return exprString(v.Fun) + "()"
+	case *ast.IndexExpr:
+		return exprString(v.X) + "[...]"
+	}
+	return "<expr>"
+}
+
+// resolveRecvType maps the assertion's receiver identifier to the type it was
+// assigned from, searching ONLY the innermost function body containing the site.
+// A file-wide search would keep the last matching assignment, so two tests in
+// one file that both name a variable mockStore would resolve every site to
+// whichever type happened to appear last -- comparing matcher counts against the
+// wrong arity and either inventing a finding or accepting a real one. This repo
+// reuses names like mockStore and mockFactory across many tests in a file, so
+// that is a live hazard, not a theoretical one.
+//
+// Conflicting bindings inside a single scope return unresolved rather than a
+// guess: the site then reaches the skipped report, which is the direction this
+// check degrades in everywhere else.
+func resolveRecvType(scopes []ast.Node, site assertSite) (string, bool) {
+	for _, scope := range scopes {
+		name, ok, conflict := bindingInScope(scope, site.recv)
+		if conflict {
+			return "", false
+		}
+		if ok {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// bindingInScope looks for assignments of name directly within one function
+// body, without descending into nested function literals (those are their own
+// scopes and are searched separately). It reports the bound mock type, whether
+// one was found, and whether the scope binds the name to two different types.
+func bindingInScope(scope ast.Node, recv string) (string, bool, bool) {
 	var found string
-	ast.Inspect(f, func(n ast.Node) bool {
+	conflict := false
+	ast.Inspect(scope, func(n ast.Node) bool {
+		if fl, ok := n.(*ast.FuncLit); ok && fl.Body != scope {
+			return false
+		}
 		var lhs, rhs []ast.Expr
 		switch v := n.(type) {
 		case *ast.AssignStmt:
@@ -326,16 +423,21 @@ func resolveRecvType(f *ast.File, site assertSite) (string, bool) {
 		}
 		for i, l := range lhs {
 			id, ok := l.(*ast.Ident)
-			if !ok || id.Name != site.recv {
+			if !ok || id.Name != recv {
 				continue
 			}
-			if name := mockTypeOfExpr(rhs[i]); name != "" {
-				found = name
+			name := mockTypeOfExpr(rhs[i])
+			if name == "" {
+				continue
 			}
+			if found != "" && found != name {
+				conflict = true
+			}
+			found = name
 		}
 		return true
 	})
-	return found, found != ""
+	return found, found != "", conflict
 }
 
 // mockTypeOfExpr extracts T from &T{...}, T{...} and new(T).
@@ -479,7 +581,15 @@ func Test(t *testing.T) {
 	unknown.AssertNotCalled(t, "Two") // want: reported as unresolved
 
 	spread := &MockThing{}
-	spread.AssertNotCalled(t, "Two", anyArgs...) // want: ignored, count unknowable
+	spread.AssertNotCalled(t, "Two", anyArgs...) // want: unsupported, count unknowable
+
+	h.mockThing.AssertNotCalled(t, "Two") // want: unsupported, receiver is a selector
+	thing.AssertNotCalled(t, methodName)  // want: unsupported, method not a literal
+
+	// A second test in the same file binding the same name to another type: the
+	// site above must not resolve to this one.
+	other := &MockShadowed{}
+	other.AssertNotCalled(t, "Two")
 }
 `
 	fset := token.NewFileSet()
@@ -526,9 +636,13 @@ func Test(t *testing.T) {
 	}
 
 	var got []verdict
-	unresolved := 0
+	unresolved, unsupported := 0, 0
 	for _, site := range collectAssertSites(fset, f) {
-		recvType, resolved := resolveRecvType(f, site)
+		if site.unsupported != "" {
+			unsupported++
+			continue
+		}
+		recvType, resolved := resolveRecvType(site.scopes, site)
 		m, isMock := mocks[recvType]
 		if resolved && !isMock {
 			continue
@@ -544,6 +658,11 @@ func Test(t *testing.T) {
 			continue
 		}
 		got = append(got, verdict{site.method, site.matchers, site.matchers != arity})
+	}
+	// Three shapes the check cannot analyze must be REPORTED, not dropped:
+	// a variadic spread, a selector receiver, and a non-literal method name.
+	if unsupported != 3 {
+		t.Errorf("unsupported shapes reported = %d, want 3 (spread, selector receiver, non-literal method)", unsupported)
 	}
 
 	want := []verdict{
@@ -646,5 +765,66 @@ func TestResolveCrossPackage_UnknownMethodStillDisagrees(t *testing.T) {
 	global := map[string][]*mockType{"MockThing": {has, hasNot}}
 	if _, ok, reason := resolveCrossPackage(global, "MockThing", "Do"); ok {
 		t.Errorf("resolved across candidates that disagree about Do (reason %q)", reason)
+	}
+}
+
+// TestResolveRecvTypeScoping pins the scoping rules for receiver resolution.
+// Before this, the search covered the whole file and kept the LAST matching
+// assignment, so two tests in one file both naming a variable mockStore
+// resolved every site to whichever type appeared last — comparing the matcher
+// count against the wrong arity, which either invents a finding or accepts a
+// genuinely unfailable assertion. Wrong attribution is the failure direction
+// that gets a guard deleted rather than fixed.
+func TestResolveRecvTypeScoping(t *testing.T) {
+	const src = `package p
+
+func TestA(t *testing.T) {
+	mockStore := &MockAlpha{}
+	mockStore.AssertNotCalled(t, "Do")
+}
+
+func TestB(t *testing.T) {
+	mockStore := &MockBeta{}
+	mockStore.AssertNotCalled(t, "Do")
+}
+
+func TestClosure(t *testing.T) {
+	ses := &MockGamma{}
+	t.Cleanup(func() {
+		ses.AssertNotCalled(t, "Do")
+	})
+}
+
+func TestConflict(t *testing.T) {
+	dup := &MockAlpha{}
+	dup = &MockBeta{}
+	dup.AssertNotCalled(t, "Do")
+}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "scoping.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, site := range collectAssertSites(fset, f) {
+		typ, ok := resolveRecvType(site.scopes, site)
+		if !ok {
+			typ = "<unresolved>"
+		}
+		got[fmt.Sprintf("%s@%d", site.recv, site.pos.Line)] = typ
+	}
+
+	want := map[string]string{
+		"mockStore@5":  "MockAlpha",    // TestA's own binding, not TestB's
+		"mockStore@10": "MockBeta",     // TestB's own binding, not TestA's
+		"ses@16":       "MockGamma",    // closure resolves through the enclosing scope
+		"dup@23":       "<unresolved>", // one scope, two types: refuse to guess
+	}
+	for k, w := range want {
+		if got[k] != w {
+			t.Errorf("%s resolved to %q, want %q", k, got[k], w)
+		}
 	}
 }

--- a/internal/mocks/vacuous_assertion_guard_test.go
+++ b/internal/mocks/vacuous_assertion_guard_test.go
@@ -35,6 +35,9 @@ import (
 // still cannot place is reported rather than skipped: a skip that says nothing
 // is the same shape of defect the guard exists to catch. It parses rather than
 // builds, so it costs milliseconds.
+//
+// Receiver resolution walks enclosing function bodies innermost-outward, which
+// approximates Go's lexical scoping rather than implementing it.
 
 // mockType is one testify mock in one package.
 type mockType struct {
@@ -136,65 +139,15 @@ func TestNoUnfailableMockAssertions(t *testing.T) {
 		}
 		for _, f := range files {
 			for _, site := range collectAssertSites(fset, f) {
-				recvType, resolved := resolveRecvType(site.scopes, site)
-				m, isMock := mocks[recvType]
-				if resolved && !isMock {
-					var reason string
-					m, isMock, reason = resolveCrossPackage(global, recvType, site.method)
-					if !isMock {
-						skipped = append(skipped, fmt.Sprintf(
-							"%s: %s.%s(t, %q) -- receiver resolves to %s, which this check "+
-								"could not analyze (%s). Review by hand.",
-							site.pos, site.recv, site.assertFn, site.method, recvType, reason))
-						continue
-					}
-				}
-				if !resolved {
-					// The receiver was not assigned from a mock literal in this
-					// file. Only report it when the method name belongs to some
-					// mock in the package and would be unfailable if it were one,
-					// so an unreviewed blind spot cannot hide behind a pass.
-					if unresolvedLooksRisky(site, mocks, global) {
-						skipped = append(skipped, fmt.Sprintf(
-							"%s: %s.%s(t, %q) -- receiver type could not be resolved; "+
-								"review this site by hand", site.pos, site.recv, site.assertFn, site.method))
-					}
-					continue
-				}
-				if m.shadowed[site.assertFn] {
-					// This type implements the helper being used, so it defines
-					// what the matchers mean. See MockConfigStore in assertions.go.
-					continue
-				}
-				arity, known := m.calledArity[site.method]
-				if !known {
-					// The method exists on a mock but never calls m.Called itself
-					// (it delegates to a sibling), so there is no arity to check
-					// against. Report it: "checked nothing" must never be silent,
-					// which is the same reason checked == 0 is fatal below.
-					skipped = append(skipped, fmt.Sprintf(
-						"%s: %s.%s(t, %q) -- %s does not call m.Called directly, so its "+
-							"argument count cannot be derived. Review by hand.",
-						site.pos, site.recv, site.assertFn, site.method, site.method))
-					continue
-				}
-				checked++
-				if arity == 0 {
-					continue
-				}
-				switch {
-				case site.matchers == 0:
-					findings = append(findings, fmt.Sprintf(
-						"%s: %s.%s(t, %q) passes no matchers, but %s hands %d argument(s) to m.Called. "+
-							"testify diffs the empty matcher list against those arguments and counts each as a "+
-							"difference, so this assertion can never fail. Pass %d matcher(s) (mock.Anything is fine).",
-						site.pos, site.recv, site.assertFn, site.method, site.method, arity, arity))
-				case site.matchers != arity:
-					findings = append(findings, fmt.Sprintf(
-						"%s: %s.%s(t, %q) passes %d matcher(s), but %s hands %d argument(s) to m.Called. "+
-							"A count that differs from the real arity can never match, so this assertion can "+
-							"never fail. Pass %d matcher(s).",
-						site.pos, site.recv, site.assertFn, site.method, site.matchers, site.method, arity, arity))
+				verdict, msg := classifySite(site, mocks, global)
+				switch verdict {
+				case verdictSkipped:
+					skipped = append(skipped, msg)
+				case verdictFinding:
+					checked++
+					findings = append(findings, msg)
+				case verdictChecked:
+					checked++
 				}
 			}
 		}
@@ -317,6 +270,9 @@ func collectAssertSites(fset *token.FileSet, f *ast.File) []assertSite {
 			site.recv = recv.Name
 
 			if len(v.Args) < 2 {
+				// Defensive only: testify's signature requires a method name, so
+				// this shape cannot appear in code that compiles. It is exercised
+				// from the parse-only synthetic fixture in the self-test.
 				site.unsupported = "fewer than two arguments; not a well-formed mock assertion"
 				out = append(out, site)
 				return true
@@ -355,6 +311,91 @@ func collectAssertSites(fset *token.FileSet, f *ast.File) []assertSite {
 	return out
 }
 
+// siteVerdict is what the guard has to say about a single assertion site.
+type siteVerdict int
+
+const (
+	verdictIgnore  siteVerdict = iota // nothing to say: not a mock, shadowed, or zero-arity
+	verdictChecked                    // analyzed and sound
+	verdictFinding                    // an assertion that cannot fail
+	verdictSkipped                    // could not be analyzed, and must be reported as such
+)
+
+// classifySite is the ONE dispatch for an assertion site. The repo-wide run and
+// the self-test both call it, so the self-test cannot pass against a code path
+// that exists only inside the test.
+//
+// That is not hypothetical: the unsupported-shape reporting below was once
+// written in five places and read in none that actually ran, because the
+// self-test re-implemented this dispatch with the branch the real loop lacked.
+// A test asserting on its own private copy of the logic is the same defect this
+// whole guard exists to catch, one level up.
+func classifySite(site assertSite, mocks map[string]*mockType, global map[string][]*mockType) (siteVerdict, string) {
+	if site.unsupported != "" {
+		return verdictSkipped, fmt.Sprintf(
+			"%s: %s.%s(t, %q) -- %s. Review by hand.",
+			site.pos, site.recv, site.assertFn, site.method, site.unsupported)
+	}
+
+	recvType, resolved := resolveRecvType(site.scopes, site)
+	m, isMock := mocks[recvType]
+	if resolved && !isMock {
+		var reason string
+		m, isMock, reason = resolveCrossPackage(global, recvType, site.method)
+		if !isMock {
+			return verdictSkipped, fmt.Sprintf(
+				"%s: %s.%s(t, %q) -- receiver resolves to %s, which this check "+
+					"could not analyze (%s). Review by hand.",
+				site.pos, site.recv, site.assertFn, site.method, recvType, reason)
+		}
+	}
+	if !resolved {
+		// Only report an unresolved receiver when the method name belongs to
+		// some mock and would be unfailable if it were one, so an unreviewed
+		// blind spot cannot hide behind a pass without drowning the report.
+		if unresolvedLooksRisky(site, mocks, global) {
+			return verdictSkipped, fmt.Sprintf(
+				"%s: %s.%s(t, %q) -- receiver type could not be resolved; "+
+					"review this site by hand", site.pos, site.recv, site.assertFn, site.method)
+		}
+		return verdictIgnore, ""
+	}
+	if m.shadowed[site.assertFn] {
+		// This type implements the helper being used, so it defines what the
+		// matchers mean. See MockConfigStore in assertions.go.
+		return verdictIgnore, ""
+	}
+	arity, known := m.calledArity[site.method]
+	if !known {
+		// The method exists on a mock but never calls m.Called itself (it
+		// delegates to a sibling), so there is no arity to check against.
+		// "Checked nothing" must never be silent -- the same reason checked == 0
+		// is fatal.
+		return verdictSkipped, fmt.Sprintf(
+			"%s: %s.%s(t, %q) -- %s does not call m.Called directly, so its "+
+				"argument count cannot be derived. Review by hand.",
+			site.pos, site.recv, site.assertFn, site.method, site.method)
+	}
+	if arity == 0 {
+		return verdictChecked, ""
+	}
+	switch {
+	case site.matchers == 0:
+		return verdictFinding, fmt.Sprintf(
+			"%s: %s.%s(t, %q) passes no matchers, but %s hands %d argument(s) to m.Called. "+
+				"testify diffs the empty matcher list against those arguments and counts each as a "+
+				"difference, so this assertion can never fail. Pass %d matcher(s) (mock.Anything is fine).",
+			site.pos, site.recv, site.assertFn, site.method, site.method, arity, arity)
+	case site.matchers != arity:
+		return verdictFinding, fmt.Sprintf(
+			"%s: %s.%s(t, %q) passes %d matcher(s), but %s hands %d argument(s) to m.Called. "+
+				"A count that differs from the real arity can never match, so this assertion can "+
+				"never fail. Pass %d matcher(s).",
+			site.pos, site.recv, site.assertFn, site.method, site.matchers, site.method, arity, arity)
+	}
+	return verdictChecked, ""
+}
+
 // exprString renders a receiver expression for a report message.
 func exprString(e ast.Expr) string {
 	switch v := e.(type) {
@@ -371,7 +412,11 @@ func exprString(e ast.Expr) string {
 }
 
 // resolveRecvType maps the assertion's receiver identifier to the type it was
-// assigned from, searching ONLY the innermost function body containing the site.
+// assigned from, searching the enclosing function bodies from the innermost
+// outward. This approximates Go's lexical scoping closely enough for the shapes
+// mock assertions are written in; it is not a full implementation of it. Only
+// function bodies are walked, so a package-level mock var is not resolved (see
+// the limitation noted in the PR description).
 // A file-wide search would keep the last matching assignment, so two tests in
 // one file that both name a variable mockStore would resolve every site to
 // whichever type happened to appear last -- comparing matcher counts against the
@@ -384,13 +429,18 @@ func exprString(e ast.Expr) string {
 // check degrades in everywhere else.
 func resolveRecvType(scopes []ast.Node, site assertSite) (string, bool) {
 	for _, scope := range scopes {
-		name, ok, conflict := bindingInScope(scope, site.recv)
-		if conflict {
+		name, binds, conflict := bindingInScope(scope, site.recv)
+		if !binds {
+			continue // not bound here; look outward
+		}
+		// The innermost scope that binds the name wins, exactly as it shadows
+		// an outer binding at run time. If its type cannot be determined, or it
+		// binds two types, report unresolved rather than adopting an outer type
+		// the code would never actually use.
+		if conflict || name == "" {
 			return "", false
 		}
-		if ok {
-			return name, true
-		}
+		return name, true
 	}
 	return "", false
 }
@@ -398,9 +448,15 @@ func resolveRecvType(scopes []ast.Node, site assertSite) (string, bool) {
 // bindingInScope looks for assignments of name directly within one function
 // body, without descending into nested function literals (those are their own
 // scopes and are searched separately). It reports the bound mock type, whether
-// one was found, and whether the scope binds the name to two different types.
+// the scope binds the name AT ALL, and whether it binds it to two different
+// types.
+//
+// "Binds it at all" is deliberately separate from "we could type it": a scope
+// that does `mockStore := newStore()` shadows any outer mockStore, so the walk
+// must stop there rather than continue outward and adopt an unrelated type.
 func bindingInScope(scope ast.Node, recv string) (string, bool, bool) {
 	var found string
+	binds := false
 	conflict := false
 	ast.Inspect(scope, func(n ast.Node) bool {
 		if fl, ok := n.(*ast.FuncLit); ok && fl.Body != scope {
@@ -426,6 +482,7 @@ func bindingInScope(scope ast.Node, recv string) (string, bool, bool) {
 			if !ok || id.Name != recv {
 				continue
 			}
+			binds = true
 			name := mockTypeOfExpr(rhs[i])
 			if name == "" {
 				continue
@@ -437,7 +494,7 @@ func bindingInScope(scope ast.Node, recv string) (string, bool, bool) {
 		}
 		return true
 	})
-	return found, found != "", conflict
+	return found, binds, conflict
 }
 
 // mockTypeOfExpr extracts T from &T{...}, T{...} and new(T).
@@ -585,6 +642,7 @@ func Test(t *testing.T) {
 
 	h.mockThing.AssertNotCalled(t, "Two") // want: unsupported, receiver is a selector
 	thing.AssertNotCalled(t, methodName)  // want: unsupported, method not a literal
+	thing.AssertNotCalled(t)              // want: unsupported, fewer than two arguments
 
 	// A second test in the same file binding the same name to another type: the
 	// site above must not resolve to this one.
@@ -623,64 +681,58 @@ func Test(t *testing.T) {
 			"or its name-only AssertCalled sites would be exempted while still unfailable")
 	}
 
-	type verdict struct {
-		method   string
-		matchers int
-		vacuous  bool
-	}
-	// The synthetic source is a single package, so the repo-wide index used by
-	// the real run is just this package's mocks.
+	// The synthetic source is a single package, so the repo-wide index the real
+	// run consults is just this package's mocks.
 	global := map[string][]*mockType{}
 	for name, m := range mocks {
 		global[name] = append(global[name], m)
 	}
 
-	var got []verdict
-	unresolved, unsupported := 0, 0
+	// Drive the REAL dispatch, not a copy of it. An earlier revision of this
+	// test re-implemented the main loop's branching, so it asserted on an
+	// unsupported-shape branch the production path did not have.
+	counts := map[siteVerdict]int{}
+	var findings, skips []string
 	for _, site := range collectAssertSites(fset, f) {
-		if site.unsupported != "" {
-			unsupported++
-			continue
+		v, msg := classifySite(site, mocks, global)
+		counts[v]++
+		switch v {
+		case verdictFinding:
+			findings = append(findings, msg)
+		case verdictSkipped:
+			skips = append(skips, msg)
 		}
-		recvType, resolved := resolveRecvType(site.scopes, site)
-		m, isMock := mocks[recvType]
-		if resolved && !isMock {
-			continue
-		}
-		if !resolved {
-			if unresolvedLooksRisky(site, mocks, global) {
-				unresolved++
-			}
-			continue
-		}
-		arity, known := m.calledArity[site.method]
-		if m.shadowed[site.assertFn] || !known || arity == 0 {
-			continue
-		}
-		got = append(got, verdict{site.method, site.matchers, site.matchers != arity})
-	}
-	// Three shapes the check cannot analyze must be REPORTED, not dropped:
-	// a variadic spread, a selector receiver, and a non-literal method name.
-	if unsupported != 3 {
-		t.Errorf("unsupported shapes reported = %d, want 3 (spread, selector receiver, non-literal method)", unsupported)
 	}
 
-	want := []verdict{
-		{"Two", 0, true},  // name-only
-		{"Two", 1, true},  // wrong count
-		{"Two", 2, false}, // correct
-		{"Two", 0, true},  // AssertCalled, name-only
+	// Three unfailable assertions: name-only Two, wrong-count Two, name-only
+	// AssertCalled on Two. The correct-count and zero-arity sites are sound.
+	if counts[verdictFinding] != 3 {
+		t.Errorf("findings = %d, want 3:\n%s", counts[verdictFinding], strings.Join(findings, "\n"))
 	}
-	if len(got) != len(want) {
-		t.Fatalf("checked %d site(s), want %d: %+v", len(got), len(want), got)
+
+	// Every shape the check cannot analyze must be REPORTED, never dropped:
+	// four unsupported syntactic shapes plus a receiver typed to something that
+	// is not a mock and a receiver that cannot be resolved at all.
+	if counts[verdictSkipped] != 6 {
+		t.Errorf("skipped = %d, want 6:\n%s", counts[verdictSkipped], strings.Join(skips, "\n"))
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("site %d = %+v, want %+v", i, got[i], want[i])
+	for _, want := range []string{
+		"variadic spread",
+		"not a plain identifier",
+		"not a string literal",
+		"fewer than two arguments",
+		"no mock of that name is declared",
+		"could not be resolved",
+	} {
+		found := false
+		for _, got := range skips {
+			if strings.Contains(got, want) {
+				found = true
+			}
 		}
-	}
-	if unresolved != 1 {
-		t.Errorf("unresolved risky sites = %d, want 1 (the `unknown` receiver)", unresolved)
+		if !found {
+			t.Errorf("no skipped entry mentions %q; got:\n%s", want, strings.Join(skips, "\n"))
+		}
 	}
 }
 

--- a/internal/purchase/execution_test.go
+++ b/internal/purchase/execution_test.go
@@ -660,7 +660,7 @@ func TestExecuteForAccount_CredentialFailure_MarksFailed(t *testing.T) {
 			// The provider factory must NEVER be invoked when credentials
 			// fail to resolve. If this fires, something is attempting an
 			// ambient-credential fallback — exactly the bug 9531681a4 closed.
-			mockFactory.AssertNotCalled(t, "CreateAndValidateProvider")
+			mockFactory.AssertNotCalled(t, "CreateAndValidateProvider", mock.Anything, mock.Anything, mock.Anything)
 		})
 	}
 }
@@ -726,7 +726,7 @@ func TestExecuteForAccount_CredentialFailure_SaveErrorSurfaced(t *testing.T) {
 		"the original credential failure must not be masked by the save failure")
 
 	// No provider may ever be constructed when credentials fail to resolve.
-	mockFactory.AssertNotCalled(t, "CreateAndValidateProvider")
+	mockFactory.AssertNotCalled(t, "CreateAndValidateProvider", mock.Anything, mock.Anything, mock.Anything)
 	mockStore.AssertExpectations(t)
 }
 
@@ -1819,7 +1819,7 @@ func TestProcessPurchaseRecommendations_GlobalConfigError_FailsInsteadOfDefaulti
 
 	// PurchaseCommitment must NEVER be called: assert the factory was never
 	// invoked, which is the clearest proxy for "no cloud API call happened".
-	mockFactory.AssertNotCalled(t, "CreateAndValidateProvider")
+	mockFactory.AssertNotCalled(t, "CreateAndValidateProvider", mock.Anything, mock.Anything, mock.Anything)
 
 	mockStore.AssertExpectations(t)
 	t.Cleanup(func() { mockStore.AssertExpectations(t) })

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -627,7 +627,7 @@ func TestScheduler_CollectRecommendations_WithNotification(t *testing.T) {
 	assert.Equal(t, 0, result.Recommendations)
 
 	// Verify no email was sent
-	mockEmail.AssertNotCalled(t, "SendNewRecommendationsNotification")
+	mockEmail.AssertNotCalled(t, "SendNewRecommendationsNotification", mock.Anything, mock.Anything)
 }
 
 // Test that verifies the struct implements expected interface.

--- a/providers/aws/services/savingsplans/client_test.go
+++ b/providers/aws/services/savingsplans/client_test.go
@@ -387,7 +387,7 @@ func TestClient_findOfferingID_RejectsMismatchedPlanType(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not match client scope")
 	// AWS API must not be called — the mismatch should be caught
 	// client-side before any DescribeSavingsPlansOfferings request.
-	mockSP.AssertNotCalled(t, "DescribeSavingsPlansOfferings")
+	mockSP.AssertNotCalled(t, "DescribeSavingsPlansOfferings", mock.Anything, mock.Anything)
 }
 
 func TestClient_GetValidResourceTypes(t *testing.T) {
@@ -973,7 +973,7 @@ func TestClient_FindOfferingID_AllPaymentOptions(t *testing.T) {
 			if tt.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unsupported Savings Plans payment option")
-				mockSP.AssertNotCalled(t, "DescribeSavingsPlansOfferings")
+				mockSP.AssertNotCalled(t, "DescribeSavingsPlansOfferings", mock.Anything, mock.Anything)
 			} else {
 				assert.NoError(t, err)
 			}
@@ -1029,7 +1029,7 @@ func TestClient_FindOfferingID_TermVariations(t *testing.T) {
 			if tt.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unsupported Savings Plans term")
-				mockSP.AssertNotCalled(t, "DescribeSavingsPlansOfferings")
+				mockSP.AssertNotCalled(t, "DescribeSavingsPlansOfferings", mock.Anything, mock.Anything)
 			} else {
 				assert.NoError(t, err)
 			}
@@ -1532,7 +1532,7 @@ func TestEC2InstanceSP_CEProvidedOfferingIDUsedDirectly(t *testing.T) {
 	}
 
 	// DescribeSavingsPlansOfferings must NOT be called when CE supplies the ID.
-	mockSP.AssertNotCalled(t, "DescribeSavingsPlansOfferings")
+	mockSP.AssertNotCalled(t, "DescribeSavingsPlansOfferings", mock.Anything, mock.Anything)
 
 	id, err := client.findOfferingID(context.Background(), rec, "test-exec")
 	require.NoError(t, err)

--- a/providers/aws/services/savingsplans/client_test.go
+++ b/providers/aws/services/savingsplans/client_test.go
@@ -1531,11 +1531,13 @@ func TestEC2InstanceSP_CEProvidedOfferingIDUsedDirectly(t *testing.T) {
 		},
 	}
 
-	// DescribeSavingsPlansOfferings must NOT be called when CE supplies the ID.
-	mockSP.AssertNotCalled(t, "DescribeSavingsPlansOfferings", mock.Anything, mock.Anything)
-
 	id, err := client.findOfferingID(context.Background(), rec, "test-exec")
 	require.NoError(t, err)
 	assert.Equal(t, "ce-provided-offering-id-abc123", id,
 		"CE-provided OfferingID must be used directly, skipping DescribeSavingsPlansOfferings")
+
+	// DescribeSavingsPlansOfferings must NOT be called when CE supplies the ID.
+	// Asserted after the call: before it, the mock has recorded nothing and this
+	// passes for any implementation, whatever the matcher count.
+	mockSP.AssertNotCalled(t, "DescribeSavingsPlansOfferings", mock.Anything, mock.Anything)
 }


### PR DESCRIPTION
Closes #1740

## The defect

testify diffs the matchers an assertion is given against the arguments a mock recorded — and it diffs an **empty** matcher list too, counting each real argument as a difference. So a name-only `AssertNotCalled(t, "Method")` never matches a method that passes arguments to `m.Called`, and reports success whatever the code under test did.

PR #1735 fixed this for `MockConfigStore` by shadowing the helpers with `callLog`-backed versions. Those shadows are on `*MockConfigStore` only; every other mock in the repo still had the underlying behaviour.

## The real count: 30, measured rather than estimated

The issue quoted **82 name-only sites / roughly 30 vacuous**, explicitly flagged as a static count of call sites rather than of dangerous ones, and asked for the real number. Measured three ways:

| | count |
|---|---|
| `AssertCalled` / `AssertNotCalled` sites, repo-wide, all six modules | 337 |
| of those, name-only | 84 |
| of those, **structurally unfailable** (arity > 0, mock does not shadow the helpers) | **30** |
| of those 30, genuinely silent (an expectation was registered, so no panic fires) | **1** |

The 30 matches the issue's estimate, but not for the reason the estimate assumed — see the honesty note below. The other 54 name-only sites are legitimate: the guard added here passes on this branch, which is precisely the statement that none of them can be unfailable (they are on `MockConfigStore`'s shadowed helpers or on zero-argument methods).

Distribution of the 30: `internal/api` 16, `providers/aws` 4, `internal/purchase` 3, `cmd` 3, `internal/email` 2, `internal/auth` 1, `internal/scheduler` 1.

Reconciliation: 84 name-only on `main` − 30 repaired = 54, plus 6 name-only forms inside the new guard's synthetic test fixture = 60 matches on this branch.

**The four `providers/aws` sites were invisible to a type-checked sweep of the root module.** This repo is a Go *workspace* (`go.work`: `.`, `pkg`, `providers/aws`, `providers/azure`, `providers/gcp`, `tests/e2e`), and `packages.Load("./...")` from the root sees only the root module. The guard added here walks the filesystem instead, so it covers every module.

## Money path first

`cmd/multi_service_test.go:1349`, `:1411`, `:1486` assert that `--dry-run` never reaches `PurchaseCommitment` — the check standing between a dry run and real money. `MockServiceClient.PurchaseCommitment` hands 3 arguments to `m.Called`; all three assertions passed none, so none could fail.

Verified against a **real production mutation** (`processPurchaseLoop` issuing a purchase on the dry-run branch), with a permissive expectation registered so the assertion rather than testify's panic decides the outcome:

```
PurchaseCommitment actually called: true
name-only AssertNotCalled  -> failures=0   <-- silently passes
3-matcher AssertNotCalled  -> failures=1   <-- fires
```

## Honesty note: what the panic backstop means

Of the 30 sites, **only 1** (`handler_ri_exchange_test.go:971`) had a registered expectation for the asserted method and therefore passed silently. For the other 29, the mock reaches `m.Called` unconditionally with no expectation registered, so the forbidden call hits testify's unexpected-call path and **panics** — the test fails loudly, but at `mocks_test.go` and with a message about an unexpected call rather than about the invariant.

Determined by a runtime probe: testify was replaced with an instrumented copy that logged, at every `AssertNotCalled`, the matcher count, the recorded arity and whether an expectation existed. Cross-checked statically — none of the 30 mock methods has an `isExpected` short-circuit or `Fn` escape that would let the call return quietly.

So the honest framing is: **1 caught bug that would otherwise have shipped, and 29 assertions that claimed to check something they could not check.** The backstop is accidental, not designed — it disappears the moment anyone registers an expectation for that method, which is exactly the shape #1735 found 77 instances of. Overstating this would be the same defect class the PR is about.

## Per-site mutation verification, both directions

Not verified in aggregate. For each of the 27 non-money-path sites, the forbidden call was injected directly into the mock's log immediately before the assertion — the exact state the mock would be in had the guarded bug fired, with nothing else changed, so the assertion is isolated from the panic:

```go
recv.Calls = append(recv.Calls, mock.Call{Method: "M", Arguments: mock.Arguments{nil, ...}})
```

| form | result |
|---|---|
| original name-only | **27/27 PASS** — the forbidden call happened and nothing fired |
| repaired (N matchers) | **27/27 FAIL** |

Plus the 3 money-path sites against a real production mutation, above. 30/30.

## Preventing the mode rather than fixing instances

`TestNoUnfailableMockAssertions` (`internal/mocks/vacuous_assertion_guard_test.go`) parses every package in every module, derives each mock method's **`m.Called` arity**, and rejects any `AssertCalled` / `AssertNotCalled` whose matcher count cannot match — both name-only and any wrong count (the third variant #1735 hardened `matching()` against).

Deliberate design points:

- **Arity comes from `m.Called`, not the signature.** `MockSESClient.SendEmail` takes three parameters but calls `m.Called(ctx, input)`. An earlier version of this analysis used signature arity and produced two false findings on exactly that method; testify diffs against what `m.Called` receives.
- **Opting out is detected, not hardcoded.** A mock that defines its own `AssertCalled`/`AssertNotCalled` is exempt, so `MockConfigStore`'s 53 name-only sites keep their `callLog` meaning and any future mock adopting the pattern is covered without editing an allowlist.
- **Unresolvable receivers are reported, not skipped** — a blind spot cannot hide behind a pass. This includes receivers whose type is declared in another package: mocks are indexed repo-wide by type name so `MockConfigStore` (declared in `internal/mocks`, aliased into `internal/api`, `internal/purchase` and `internal/scheduler`) is actually analysed there rather than silently passed over. Names are not unique across the repo — `MockHTTPClient` is declared in five separate packages and `MockEmailSender` in four — so multiple candidates resolve only when they agree about the method *and* about which helpers they shadow; anything else is reported rather than guessed. The two facts the safety argument rests on are that same-name collisions are common enough to matter, and that **`MockConfigStore` is declared in exactly one package** (`internal/mocks`), so its fallback is unambiguous. (An earlier revision said "24 of 142 mock type names are multi-package". That counted every `func (m *T)` receiver name rather than only types that dispatch through `m.Called`. Counting the way the guard defines a mock — at least one method calling `m.Called`, grouped by package directory — gives **12 of 39**. A third count using a different grouping gives 13 of 49. The precise figure is method-dependent, so it is stated here with its method rather than quoted bare.)
- **Scope-aware receiver resolution.** A receiver is resolved by walking the enclosing function scopes outward, the way Go's own lexical scoping works. A file-wide search that kept the last match would resolve two tests in one file that both name a variable `mockStore` to whichever type appeared last, comparing matcher counts against the wrong arity. Conflicting bindings inside one scope return unresolved rather than a guess.
- **The guard is immune to #1751.** It walks the filesystem rather than relying on `go test ./...`, so it analyses `providers/*`, `pkg` and `tests/e2e` even though CI does not currently run those modules' tests. That is exactly how the four `providers/aws` sites surfaced: a type-checked sweep of the root module could not see them, and neither could CI. It keeps working regardless of how #1751 is resolved.
- **Variadic spread is left alone.** `AssertNotCalled(t, "M", args...)` has no statically knowable count; counting the spread expression as one matcher would invent a mismatch.
- **`checked == 0` is a hard failure**, so the guard cannot silently stop finding anything.

It parses rather than builds: ~0.4s, no new dependencies.

### What this guard does NOT cover

`AssertNotCalled` has a **fourth** vacuity mode the guard does not detect: an assertion positioned **before** the call under test. The mock has recorded nothing when it runs, so it passes for any implementation whatever its matcher count. One such site existed in this PR (`savingsplans/client_test.go:1535`) and is fixed here.

The guard checks matcher count against arity; it has no notion of "the call under test", and building one is not cheap. A prototype detector (innermost-scope aware, skipping `t.Cleanup` bodies whose contents run after the test) produced **10 findings across the touched files, 9 of them false positives** — assertions inside subtests, and calls appearing only as arguments to other assertions. A check with that ratio gets deleted rather than fixed, which is the failure direction this PR is built to avoid.

So the claim in this PR is narrowed accordingly: **it closes the matcher-count modes (name-only, and any count that cannot match), not assertion ordering.** The ordering mode is filed as **#1761** with the prototype's results and two candidate approaches that might make it tractable.

### Known limitations, recorded deliberately

- **Package-level mock vars are not resolved.** The scope chain contains only function bodies, so `var pkgMock = &MockAlpha{}` at package scope degrades into the unresolved path and would be reported as "receiver type could not be resolved" rather than analysed. **Zero instances today.** The older file-wide search happened to resolve these; the scoped walk trades that for correctness on the far more common same-name-in-two-tests case. Noted so it does not surprise anyone later.
- **Assertion ordering is not detected** — see #1761 and the section above.
- **The "fewer than two arguments" branch is unreachable in compilable Go.** testify's signature requires a method name, so that shape only exists in parse-only synthetic source. It stays as a defensive branch and is marked as such in the code.

### Review findings addressed (head `14dfddfff`)

**F1 (blocking, fourth review).** `site.unsupported` was written in five places and read in exactly one — inside the self-test. The repo-wide run never consulted it, so **no reason string reached `skipped` on the path that actually runs**. The self-test passed because it *re-implemented* the main loop's dispatch, and its copy had the branch the real one lacked. A test asserting on its own private copy of the logic is the defect this guard exists to catch, one level up.

Verified on an isolated module (scratch `go.mod`, one package, guard otherwise unmodified). Before:

| shape | behaviour on the real path |
|---|---|
| `p.AssertNotCalled(t, "Two", anyArgs...)` | **false finding** — "passes no matchers, but Two hands 2 arguments" |
| `h.mockProbe.AssertNotCalled(t, "Two")` | silently dropped — neither checked nor reported |
| `p.AssertNotCalled(t, methodName)` | reported with the **wrong** reason |

After, on the same probe — three reports, each with its own reason, and **zero findings**:

```
checked 1 mock assertion site(s)
3 assertion site(s) could not be checked:
  shapes_test.go:16: p.AssertNotCalled(...) -- matchers are passed as a variadic spread...
  shapes_test.go:17: h.mockProbe.AssertNotCalled(...) -- receiver is not a plain identifier...
  shapes_test.go:18: p.AssertNotCalled(...) -- method name is not a string literal...
```

Both halves are fixed, since either alone leaves the blind spot: the per-site dispatch is now a single `classifySite` called by **both** the repo-wide run and the self-test, so the self-test can no longer pass against a branch production does not have.

Routing reports through the real path immediately surfaced one live site the dead code had been swallowing: `assertions_test.go` called testify's promoted implementation as `m.Mock.AssertNotCalled(...)`, a selector receiver. Hoisted to a local so the deliberate call into the broken implementation stays without tripping the report forever.

**F2.** The outward scope walk over-reached: a scope binding a name from a non-literal (`mockStore := newStore()`) yielded no type, so the walk continued outward and could adopt an unrelated outer type. The innermost binding scope now wins whether or not its type is determinable, matching what shadowing does at run time.

**F3.** "the way Go's own lexical scoping works" overstated it — the walk *approximates* Go's scoping for the shapes mock assertions take. Wording corrected.

### Earlier review findings (head `67cced118`)

- **F1 (blocking).** `collectMocks` was per-directory, so the one cross-package mock was unrecognized in the three packages that alias it: those sites hit the "resolved to a non-mock" branch and were **silently skipped** — not counted, not reported. Renaming `MockConfigStore`'s shadowed helpers took the old guard from 6 findings to 6, when it should have been 56. The suggested cheap fix (report the skip) was **measured first and rejected**: it yields 183 findings, all `MockConfigStore`, which would leave the guard permanently red and therefore ignored. The repo-wide index above fixes it properly; with both helpers renamed the guard now reports **56 across `checked 323`** — the 6 in-package plus the 50 cross-package sites that were invisible.
- **F2.** Shadowing is recorded **per helper**, not per type. A mock defining only `AssertNotCalled` left `AssertCalled` going through testify while the whole type was exempt. Renaming only `MockConfigStore.AssertCalled` now surfaces a name-only `AssertCalled` site the old logic exempted.
- **F3.** A method that never calls `m.Called` itself has no derivable arity; those assertions were dropped without a word and are now reported, for the same reason `checked == 0` is fatal.
- **F4.** An unresolved receiver is reported whatever its matcher count. Restricting it to name-only sites left out the wrong-count mode — the third vacuity cause from #1735.

F3 and F4 were each **measured at zero sites** before being changed, so neither adds noise today. `TestResolveCrossPackage` pins the ambiguity rules (single candidate, none, agreeing duplicates, duplicates disagreeing on arity or on shadowing).

`TestVacuousAssertionGuardDetects` exercises the analysis on synthetic source covering name-only, wrong count, correct count, a zero-arity method, a shadowed type, a non-mock, an unresolvable receiver and a variadic spread. It was written after an earlier revision of the guard reported a resolved-but-non-mock receiver as an unreviewed blind spot, and each case was confirmed to fail with the corresponding logic disabled. Verified end-to-end by injecting a fresh name-only assertion into `internal/auth/service_test.go`, which the guard flagged.

## Gates

Root module: `go build ./...`, `go vet ./...`, `go test -race -count=1 ./...` (6734 passed, 43 packages), `gocyclo -over 10 -ignore "_test\.go" .` (exit 0, empty), `golangci-lint run` at the CI-pinned **v2.10.1** (exit 0, "0 issues"). `providers/aws` module: build, vet, `go test -race` (1212 passed, 12 packages).

`golangci-lint` on `providers/aws` is red on `main` (**272** issues by golangci's own summary, mostly `godot` 140 / `misspell` 67 / `gocritic` 43) and is **identically red with and without this change** — 272 both ways with an identical per-linter breakdown, zero new. CI lints the root module only, so this is pre-existing debt this PR neither adds to nor masks.

<sub>Correction: an earlier revision of this section said 276. That came from grepping for lines ending in a parenthesised word, which also matched four prose lines; golangci's own summary reports 272. The comparison was run the same way on both sides, so "zero new" was unaffected.</sub>

## Out of scope, flagged not fixed

- **CI's unit-test job runs `go test ./...` from the root only**, which under `go.work` covers the root module alone — so `providers/*`, `pkg` and `tests/e2e` tests are not run by that job, though `govulncheck` does loop over every module. The guard added here lives in the root module and scans all of them, so it is enforced regardless. Worth a separate issue.
- The one genuinely-silent site and the 29 panic-backstopped ones are all repaired here; no follow-up assertion work is outstanding.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened mock interaction checks across service, API, authentication, purchase, scheduling, email, and provider tests.
  * Added automated safeguards to detect incomplete or ineffective mock assertions.
  * Expanded coverage for assertion edge cases, including variadic methods, shadowed helpers, unresolved mocks, and cross-package references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

