### PR TITLE
ci: run unit and integration tests in every workspace module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,37 +91,112 @@ jobs:
 
       - name: Download dependencies
         run: |
-          go mod download
-          go mod verify
+          # Multi-module repo: `go mod download` resolves the current module
+          # only, so running it at the root left pkg/ and providers/* unverified
+          # (issue #1751). Mirror the govulncheck per-module loop below.
+          set -e
+          for mod in . pkg providers/aws providers/azure providers/gcp tests/e2e; do
+            echo "==> go mod download/verify in $mod"
+            (cd "$mod" && go mod download && go mod verify)
+          done
 
-      - name: Run unit tests
+      - name: Run unit tests (all modules)
         run: |
-          go test -v -race -short -coverprofile=coverage.out -covermode=atomic ./...
+          # Multi-module repo: each ./... only walks the current module, so
+          # running from the root alone never compiled or asserted pkg/,
+          # providers/* or tests/e2e -- roughly 1600 test functions that had
+          # never gated a merge (issue #1751). Mirror the govulncheck and gosec
+          # per-module loops, collect one coverage profile per module, then
+          # merge for the upload steps below.
+          #
+          # A failing module must not abort the loop. Aborting would hide every
+          # later module's result behind the first failure, which is the same
+          # shape as the gosec bug in issue #1717. Guard each run, record the
+          # status, and fail at the end so every module is reported.
+          set -uo pipefail
+          status=0
+          for mod in . pkg providers/aws providers/azure providers/gcp tests/e2e; do
+            tag=$(echo "$mod" | tr './' '--' | sed 's/^-/root/')
+            log="$RUNNER_TEMP/unit-${tag}.log"
+            # tests/e2e holds only //go:build e2e files, so `go test ./...`
+            # there matches no packages and exits 1 -- it cannot be run like the
+            # others. Its tests need the running stack and are executed by the
+            # e2e-tests job over docker compose; what this job can add is a
+            # type-check under that tag, which nothing else here does. Handled
+            # by name, not by a pattern, so the difference is visible in review.
+            if [ "$mod" = "tests/e2e" ]; then
+              echo "==> type-check $mod under -tags=e2e (tests run in the e2e-tests job)"
+              if ! (cd "$mod" && go vet -tags=e2e ./...) 2>&1 | tee "$log"; then
+                echo "::error::$mod failed to type-check under -tags=e2e"
+                status=1
+              fi
+              continue
+            fi
+            echo "==> unit tests in $mod"
+            # Profiles go to $RUNNER_TEMP, not the checkout: never leave working
+            # files in the repository root (repo coding guideline).
+            if ! (cd "$mod" && go test -v -race -short \
+                    -coverprofile="$RUNNER_TEMP/coverage-${tag}.out" \
+                    -covermode=atomic ./...) 2>&1 | tee "$log"; then
+              echo "::error::unit tests failed in $mod"
+              status=1
+            fi
+            # A module that runs zero tests is issue #1751 wearing a new
+            # costume: the loop would "cover" it while asserting nothing. Count
+            # top-level results (subtest lines are indented) and fail loudly.
+            ran=$(grep -cE '^--- (PASS|FAIL|SKIP)' "$log" || true)
+            echo "==> $mod ran $ran top-level test(s)"
+            if [ "$ran" -eq 0 ]; then
+              echo "::error::$mod ran zero tests -- it is in the loop but asserting nothing"
+              status=1
+            fi
+          done
+
+          # Merge the per-module profiles into the single file the steps below
+          # expect. A Go profile is one "mode:" header followed by block lines,
+          # so keep one header and concatenate the bodies.
+          shopt -s nullglob
+          profiles=("$RUNNER_TEMP"/coverage-*.out)
+          if [ "${#profiles[@]}" -eq 0 ]; then
+            echo "::error::no module produced a coverage profile" >&2
+            exit 1
+          fi
+          # Take the mode header from the first profile rather than hardcoding
+          # it: go test picks the default covermode itself (atomic whenever
+          # -race is on), so a literal here would silently mislabel the merge if
+          # the flags change.
+          merged="$RUNNER_TEMP/coverage.out"
+          head -n 1 "${profiles[0]}" > "$merged"
+          for p in "${profiles[@]}"; do
+            tail -n +2 "$p" >> "$merged"
+          done
+          echo "Merged ${#profiles[@]} coverage profile(s), $(( $(wc -l < "$merged") - 1 )) block(s)"
+          exit "$status"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
-          files: ./coverage.out
+          files: ${{ runner.temp }}/coverage.out
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
 
       - name: Generate coverage report
         run: |
-          go tool cover -html=coverage.out -o coverage.html
+          go tool cover -html="$RUNNER_TEMP/coverage.out" -o "$RUNNER_TEMP/coverage.html"
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: coverage-report
           path: |
-            coverage.out
-            coverage.html
+            ${{ runner.temp }}/coverage.out
+            ${{ runner.temp }}/coverage.html
           retention-days: 30
 
       - name: Check coverage threshold
         run: |
-          coverage=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
+          coverage=$(go tool cover -func="$RUNNER_TEMP/coverage.out" | grep total | awk '{print $3}' | sed 's/%//')
           echo "Total coverage: ${coverage}%"
           if (( $(echo "$coverage < 80" | bc -l) )); then
             echo "::warning::Coverage is below 80% (current: ${coverage}%)"
@@ -186,13 +261,65 @@ jobs:
           DB_PASSWORD: test_password  # CI-only throwaway password — not used in any real environment
           DB_SSL_MODE: disable
         run: |
-          go test -v -race -tags=integration -coverprofile=coverage-integration.out ./...
+          # Same multi-module gap as the unit job (issue #1751): a bare ./...
+          # here only ever walked the root module. Mirror the same loop.
+          #
+          # Note that -tags=integration ADDS a build tag rather than selecting
+          # only tagged files, so each module runs its untagged tests too. Today
+          # every //go:build integration file lives in the root module, so for
+          # pkg/ and providers/* this run is a compile-under-tag check plus a
+          # re-run of their unit tests. That is the point: it is what makes an
+          # integration test added to those modules later actually gate.
+          set -uo pipefail
+          status=0
+          for mod in . pkg providers/aws providers/azure providers/gcp tests/e2e; do
+            tag=$(echo "$mod" | tr './' '--' | sed 's/^-/root/')
+            log="$RUNNER_TEMP/integration-${tag}.log"
+            # See the unit job: tests/e2e has no package to test without its own
+            # tag, so it gets a type-check here too rather than a run.
+            if [ "$mod" = "tests/e2e" ]; then
+              echo "==> type-check $mod under -tags=e2e (tests run in the e2e-tests job)"
+              if ! (cd "$mod" && go vet -tags=e2e ./...) 2>&1 | tee "$log"; then
+                echo "::error::$mod failed to type-check under -tags=e2e"
+                status=1
+              fi
+              continue
+            fi
+            echo "==> integration tests in $mod"
+            if ! (cd "$mod" && go test -v -race -tags=integration \
+                    -coverprofile="$RUNNER_TEMP/coverage-integration-${tag}.out" \
+                    ./...) 2>&1 | tee "$log"; then
+              echo "::error::integration tests failed in $mod"
+              status=1
+            fi
+            ran=$(grep -cE '^--- (PASS|FAIL|SKIP)' "$log" || true)
+            echo "==> $mod ran $ran top-level test(s)"
+            if [ "$ran" -eq 0 ]; then
+              echo "::error::$mod ran zero tests -- it is in the loop but asserting nothing"
+              status=1
+            fi
+          done
+
+          # Merge per-module profiles for the upload step (see the unit job).
+          shopt -s nullglob
+          profiles=("$RUNNER_TEMP"/coverage-integration-*.out)
+          if [ "${#profiles[@]}" -eq 0 ]; then
+            echo "::error::no module produced an integration coverage profile" >&2
+            exit 1
+          fi
+          merged="$RUNNER_TEMP/coverage-integration.out"
+          head -n 1 "${profiles[0]}" > "$merged"
+          for p in "${profiles[@]}"; do
+            tail -n +2 "$p" >> "$merged"
+          done
+          echo "Merged ${#profiles[@]} integration coverage profile(s)"
+          exit "$status"
 
       - name: Upload integration coverage
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: integration-coverage
-          path: coverage-integration.out
+          path: ${{ runner.temp }}/coverage-integration.out
           retention-days: 30
 
   # Docker image build test


### PR DESCRIPTION
Closes #1751

## The gap

`go.work` declares six modules. Under a workspace, `./...` expands to packages in the **current module only**, and both test steps ran bare from the repository root. So `pkg`, `providers/aws`, `providers/azure`, `providers/gcp` and `tests/e2e` were compiled by nothing and asserted by nothing in CI.

Measured: **1,646 test functions** across those five modules had never gated a merge.

This was not an unknown hazard. The workflow documents it twice in its own comments and already loops over all six modules for `govulncheck` (`ci.yml:312`) and for the gosec SARIF scan (`:333`). Only the test steps were never updated. Both now mirror that loop.

## Sizing first: the gate surfaces zero pre-existing failures

Run locally exactly as the new loop runs them, before writing the fix:

| module | result |
|---|---|
| `.` | 3591 pass, 0 fail (6 skip) |
| `pkg` | 351 pass, 0 fail |
| `providers/aws` | 525 pass, 0 fail |
| `providers/azure` | 577 pass, 0 fail |
| `providers/gcp` | 193 pass, 0 fail |
| `tests/e2e` | no runnable package — see below |

So this stays one reviewable PR: nothing is being suppressed, because there is nothing red to suppress. No `-skip`, no build tags excluding modules, no `continue-on-error`, no narrowing of the module list.

## What the loop does beyond looping

**It does not abort on the first failing module.** Aborting would hide every later module behind the first failure — the gosec bug from #1717 in a new place. Each run is guarded, the status recorded, and the step fails at the end with all six reported.

**Every module must report a non-zero test count.** A module sitting in the loop while asserting nothing is the original defect wearing a new costume, and it now fails the step by name:

```
::error::providers/gcp ran zero tests -- it is in the loop but asserting nothing
```

The count comes from `^--- (PASS|FAIL|SKIP)` — top-level only, since subtest lines are indented.

**`tests/e2e` is handled by name, not by a pattern.** The sizing run caught what a comment-only reading would have missed: every file in that module is behind `//go:build e2e`, so `go test ./...` there matches no packages and **exits 1**. A naive loop would have failed permanently on it. It gets `go vet -tags=e2e` instead, which type-checks a suite nothing else in this job compiles; its tests continue to run in the existing `e2e-tests` job over docker compose. Both facts are stated in the workflow so a reader can see exactly what that module does and does not get.

**Coverage** moves to one profile per module merged into the single file the upload steps already expect, following the SARIF step's collect-then-merge shape. The `mode:` header is read from the first profile rather than hardcoded, because `go test` chooses the covermode itself and defaults to `atomic` under `-race` — a literal would have silently mislabelled the merge. Profiles are written to `$RUNNER_TEMP`, so no working files land in the checkout.

**`go mod download` / `go mod verify`** was root-only for the same reason and is looped too. Without it, five modules' dependencies were never verified.

## Verification

**1. The gate is live — proven in real CI, both directions.** Two throwaway branches, each with the *same* deliberate break (`TestAWSProvider_Name` in `providers/aws` asserting a wrong value), dispatched via `workflow_dispatch`:

| branch | contents | Unit Tests | Integration Tests |
|---|---|---|---|
| `scratch/1751-proof-nofix` | break only, `main`'s workflow | ✅ **success** — the bug | ✅ success |
| `scratch/1751-proof-withfix` | break + this workflow change | ❌ **failure** | ❌ failure |

A knowingly broken `providers/aws` test passes CI on `main` today. With this change it fails, attributed to the right module:

```
--- FAIL: TestAWSProvider_Name (0.00s)
        expected: "DELIBERATELY-BROKEN-1751"
```

Runs [31237364977](https://github.com/LeanerCloud/CUDly/actions/runs/31237364977) (control) and [31237371707](https://github.com/LeanerCloud/CUDly/actions/runs/31237371707) (with fix). Both branches are deleted; they exist only as evidence.

**Every module reported a non-zero count, and the loop did not abort at the failure.** From the with-fix run — note `providers/azure` and `providers/gcp` still ran *after* `providers/aws` failed:

```
==> . ran 3597 top-level test(s)
==> pkg ran 351 top-level test(s)
==> providers/aws ran 525 top-level test(s)      <-- contains the failure
==> providers/azure ran 577 top-level test(s)
==> providers/gcp ran 193 top-level test(s)
Merged 5 coverage profile(s), 21194 block(s)
```

The integration job reports the same five, with the root module at 3701 rather than 3597 — the ~104 `//go:build integration` tests that only that job adds.

**2. Shell logic tested against a stub `go`**, under `bash -e` (the shell Actions actually uses for `run:` blocks, confirmed in the `act` log). Four scenarios:

| scenario | expected | result |
|---|---|---|
| all modules pass | exit 0 | ✅ |
| `providers/azure` fails | exit 1, **and modules after it still run** | ✅ |
| `providers/gcp` runs zero tests | exit 1, named error | ✅ |
| `tests/e2e` fails type-check | exit 1, named error | ✅ |

The second row is the one that matters: it is the #1717 property.

**3. The merged coverage profile is real.** Merged two actual per-module profiles (`pkg` + `providers/gcp`, 2334 lines) and fed the result to `go tool cover`: `-func` reports 84.0% total, `-html` produces a 587 KB report. Cross-module merge is valid, not just concatenation that happens to parse.

**4. `act`** — `act -n -j unit-tests` passes. A full local `act` run confirmed the step shell is `bash -e` (which is what the stub-`go` harness above reproduces) and that the per-module `go mod download/verify` loop runs, reporting `all modules verified` for all six.

That run did **not** finish: `go mod download` alone took 17m05s inside Docker on this machine, and my own 50-minute `timeout` cancelled it partway through the root module's tests — `context canceled`, exit 124, everything green up to that point. It is an incomplete run, not a failing one, and I am not counting it as a pass. The GitHub CI evidence above exercised the identical steps end to end on real runners and is the actual proof.

## Cost

The integration job gains a second execution of the four non-root modules' unit suites. `-tags=integration` *adds* a tag rather than selecting only tagged files, and every `//go:build integration` file currently lives in the root module, so for `pkg` and `providers/*` that run is a compile-under-tag check plus a re-run. That is deliberate and commented: it is what makes an integration test added to those modules later actually gate.

## Out of scope, filed separately

**#1754** — the `lint` job is root-only for the same reason, and the five unlinted modules carry **1291** `golangci-lint` findings (`pkg` 205, `providers/aws` 272, `providers/azure` 592, `providers/gcp` 222; `tests/e2e` needs `--build-tags=e2e` to lint at all). Not folded in here: mixing a lint-debt excavation into a CI-gating fix buries both. That issue flags the non-cosmetic subset — 193 `bodyclose` in `providers/azure`, 18 `errcheck` across modules — as needing triage ahead of any mass cosmetic fix.

