### PR TITLE
fix(azure): surface the read error that decides purchase retry-vs-abort

### DIFF
--- a/providers/azure/services/internal/reservations/purchase.go
+++ b/providers/azure/services/internal/reservations/purchase.go
@@ -472,11 +472,24 @@ func doPurchase(ctx context.Context, httpClient HTTPClient, purchaseURL string, 
 	if err != nil {
 		return fmt.Errorf("failed to purchase reservation: %w", err)
 	}
-	body, _ := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	resp.Body.Close() // #nosec G104 -- body fully drained by io.ReadAll before Close; transport close error does not affect correctness
 
+	// Success is decided by the status code alone, so an unreadable body cannot
+	// turn a completed purchase into a failure.
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusAccepted {
 		return nil
+	}
+	if readErr != nil {
+		// IsSessionTimeout classifies this error by searching its text for the
+		// fragment Azure puts in the body, and DoPurchaseTwoStep retries only
+		// when that matches. Discarding the read error therefore made a
+		// retryable session timeout look permanent whenever the body failed to
+		// read, abandoning the purchase on its first attempt with an empty
+		// diagnostic. Surface the read failure rather than classifying
+		// retryability from a body that was never fully received.
+		return fmt.Errorf("reservation purchase failed with status %d and its response body could not be read, so retryability is unknown (partial body: %q): %w",
+			resp.StatusCode, string(body), readErr)
 	}
 	return fmt.Errorf("reservation purchase failed with status %d: %s", resp.StatusCode, string(body))
 }

--- a/providers/azure/services/internal/reservations/purchase.go
+++ b/providers/azure/services/internal/reservations/purchase.go
@@ -42,6 +42,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -209,6 +210,21 @@ type calculatePriceResponse struct {
 // phrasing changes in future API versions.
 const sessionTimeoutFragment = "Session timed out"
 
+// errRetryabilityUnknown marks a purchase failure whose retryability could not
+// be determined because the response body did not read completely.
+//
+// IsSessionTimeout classifies by searching the error text for a fragment Azure
+// puts in the body, so a truncated read cannot be distinguished from a genuinely
+// permanent failure by inspecting the message. Carrying the state out of band
+// lets DoPurchaseTwoStep retry instead of silently abandoning a purchase that
+// the retry loop exists to recover.
+//
+// Retrying is safe here: a non-2xx means the order did not commit, the loop is
+// bounded by purchaseMaxAttempts, and re-drives across invocations are guarded
+// by DoIdempotentPurchaseTwoStep, which refuses to purchase when its idempotency
+// lookup fails.
+var errRetryabilityUnknown = errors.New("purchase retryability unknown: response body did not read completely")
+
 // IsSessionTimeout reports whether err looks like the "Session timed out"
 // 400 error from the Azure Reservations purchase endpoint. It matches the
 // error message produced by DoPurchaseTwoStep so callers can distinguish
@@ -255,7 +271,10 @@ func DoPurchaseTwoStep(ctx context.Context, httpClient HTTPClient, calcURL strin
 			return orderID, nil
 		}
 
-		if IsSessionTimeout(purchaseErr) && attempt < purchaseMaxAttempts {
+		// An unreadable body is retried alongside a recognized session timeout:
+		// without this the truncated case was abandoned on its first attempt,
+		// because IsSessionTimeout can only classify what it can read.
+		if (IsSessionTimeout(purchaseErr) || errors.Is(purchaseErr, errRetryabilityUnknown)) && attempt < purchaseMaxAttempts {
 			log.Printf("reservation purchase session timed out (attempt %d/%d), re-running calculatePrice in %s",
 				attempt, purchaseMaxAttempts, purchaseRetryDelay)
 			select {
@@ -481,15 +500,12 @@ func doPurchase(ctx context.Context, httpClient HTTPClient, purchaseURL string, 
 		return nil
 	}
 	if readErr != nil {
-		// IsSessionTimeout classifies this error by searching its text for the
-		// fragment Azure puts in the body, and DoPurchaseTwoStep retries only
-		// when that matches. Discarding the read error therefore made a
-		// retryable session timeout look permanent whenever the body failed to
-		// read, abandoning the purchase on its first attempt with an empty
-		// diagnostic. Surface the read failure rather than classifying
-		// retryability from a body that was never fully received.
-		return fmt.Errorf("reservation purchase failed with status %d and its response body could not be read, so retryability is unknown (partial body: %q): %w",
-			resp.StatusCode, string(body), readErr)
+		// The body did not read completely, so its text cannot be used to
+		// classify retryability. Surface the read failure AND tag the error
+		// with errRetryabilityUnknown so the retry loop treats it as retryable
+		// rather than abandoning the purchase on its first attempt.
+		return fmt.Errorf("reservation purchase failed with status %d (partial body: %q): %w: %w",
+			resp.StatusCode, string(body), errRetryabilityUnknown, readErr)
 	}
 	return fmt.Errorf("reservation purchase failed with status %d: %s", resp.StatusCode, string(body))
 }

--- a/providers/azure/services/internal/reservations/purchase.go
+++ b/providers/azure/services/internal/reservations/purchase.go
@@ -210,8 +210,8 @@ type calculatePriceResponse struct {
 // phrasing changes in future API versions.
 const sessionTimeoutFragment = "Session timed out"
 
-// errRetryabilityUnknown marks a purchase failure whose retryability could not
-// be determined because the response body did not read completely.
+// errRetryabilityUnknown marks a 400 purchase failure whose retryability could
+// not be determined because the response body did not read completely.
 //
 // IsSessionTimeout classifies by searching the error text for a fragment Azure
 // puts in the body, so a truncated read cannot be distinguished from a genuinely
@@ -219,10 +219,21 @@ const sessionTimeoutFragment = "Session timed out"
 // lets DoPurchaseTwoStep retry instead of silently abandoning a purchase that
 // the retry loop exists to recover.
 //
-// Retrying is safe here: a non-2xx means the order did not commit, the loop is
-// bounded by purchaseMaxAttempts, and re-drives across invocations are guarded
-// by DoIdempotentPurchaseTwoStep, which refuses to purchase when its idempotency
-// lookup fails.
+// Deliberately scoped to 400, matching IsSessionTimeout's own status scope and
+// the only scenario issue #1766 reports. The wider non-2xx surface is excluded
+// on purpose: a truncated response is mechanistically different from a cleanly
+// read one, because the server may have finished processing and begun writing
+// when the connection died. Whether a 409 or 5xx can follow a purchase that
+// actually committed is unverified for this API, and a retry on an unverified
+// commit-ambiguous status is a double-buy risk that buys nothing -- every such
+// case keeps its pre-existing behavior, which nobody has reported as broken.
+//
+// Note what does NOT bound this: DoIdempotentPurchaseTwoStep performs its
+// idempotency lookup exactly once, before DoPurchaseTwoStep is entered, and
+// there is no recheck between attempts. Each retry mints a fresh
+// reservationOrderId via doCalculatePrice, so the guard covers a re-drive
+// ACROSS invocations, not the loop within one. The bound here is
+// purchaseMaxAttempts.
 var errRetryabilityUnknown = errors.New("purchase retryability unknown: response body did not read completely")
 
 // IsSessionTimeout reports whether err looks like the "Session timed out"
@@ -499,9 +510,12 @@ func doPurchase(ctx context.Context, httpClient HTTPClient, purchaseURL string, 
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusAccepted {
 		return nil
 	}
-	if readErr != nil {
-		// The body did not read completely, so its text cannot be used to
-		// classify retryability. Surface the read failure AND tag the error
+	// Scoped to 400: see errRetryabilityUnknown. Other statuses keep their
+	// pre-existing behavior rather than entering the retry loop on a body that
+	// could not be read.
+	if readErr != nil && resp.StatusCode == http.StatusBadRequest {
+		// A 400 whose body did not read completely: its text cannot be used to
+		// classify retryability, so surface the read failure AND tag the error
 		// with errRetryabilityUnknown so the retry loop treats it as retryable
 		// rather than abandoning the purchase on its first attempt.
 		return fmt.Errorf("reservation purchase failed with status %d (partial body: %q): %w: %w",

--- a/providers/azure/services/internal/reservations/purchase_test.go
+++ b/providers/azure/services/internal/reservations/purchase_test.go
@@ -946,3 +946,62 @@ func TestDoPurchase_UnreadableBodyOnSuccessStillSucceeds(t *testing.T) {
 	require.NoError(t, doPurchase(ctx, m, "https://example.invalid/purchase", []byte(testBody), "tok"))
 	m.AssertExpectations(t)
 }
+
+// TestDoPurchase_TruncatedNon400IsNotRetryable pins the deliberate narrowing of
+// errRetryabilityUnknown to 400.
+//
+// Without this the sentinel fires on ANY non-2xx whose body fails to read --
+// 409, 500, 502, 504 alike -- which is far broader than IsSessionTimeout, whose
+// existing scope is a 400 plus an Azure-authored message. Breadth matters here
+// because DoIdempotentPurchaseTwoStep performs its idempotency lookup exactly
+// once, BEFORE DoPurchaseTwoStep is entered: there is no recheck between
+// attempts, and each retry mints a fresh reservationOrderId. So an in-loop
+// retry after a status that might follow a committed purchase is a double-buy
+// risk that the guard does not cover (tracked separately as issue #1774).
+//
+// Issue #1766's defect is a 400 "Session timed out" with a truncated body, so
+// narrowing costs no coverage and removes the unverified commit-ambiguous
+// statuses from the retry surface entirely.
+func TestDoPurchase_TruncatedNon400IsNotRetryable(t *testing.T) {
+	ctx := context.Background()
+	for _, status := range []int{
+		http.StatusConflict,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusGatewayTimeout,
+	} {
+		m := &mockHTTPClient{}
+		m.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: status,
+			Body:       &truncatingBody{data: []byte(`{"error":"truncated"}`), n: 6},
+			Header:     make(http.Header),
+		}, nil).Once()
+
+		err := doPurchase(ctx, m, "https://example.invalid/purchase", []byte(testBody), "tok")
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, errRetryabilityUnknown,
+			"status %d with a truncated body must NOT be marked retryable: a retry there could "+
+				"re-purchase after a commit the idempotency guard does not re-check for (issue #1774)", status)
+		m.AssertExpectations(t)
+	}
+}
+
+// TestDoPurchaseTwoStep_TruncatedNon400DoesNotRetry is the behavioral half of
+// the narrowing: the sentinel scoping must actually keep the retry loop out of
+// the commit-ambiguous statuses, not merely leave the error untagged.
+func TestDoPurchaseTwoStep_TruncatedNon400DoesNotRetry(t *testing.T) {
+	c := &countingPurchaseClient{
+		purchaseResp: func() *http.Response {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       &truncatingBody{data: []byte(`{"error":"truncated"}`), n: 6},
+				Header:     make(http.Header),
+			}
+		},
+	}
+	_, err := DoPurchaseTwoStep(context.Background(), c, calcURL, []byte(testBody), "tok")
+	require.Error(t, err)
+	assert.Equal(t, 1, c.purchases,
+		"a truncated 500 must be attempted exactly once; retrying it risks re-purchasing after "+
+			"a commit that the once-only idempotency lookup cannot see (issue #1774)")
+}

--- a/providers/azure/services/internal/reservations/purchase_test.go
+++ b/providers/azure/services/internal/reservations/purchase_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations"
@@ -809,4 +810,84 @@ func TestBillingPlanForPaymentOption_UnrecognizedIsNotBlamedOnPartialUpfront(t *
 	_, paddedErr := BillingPlanForPaymentOption("  Partial-Upfront  ")
 	require.Error(t, paddedErr)
 	assert.Contains(t, paddedErr.Error(), "partial-upfront has no azure equivalent")
+}
+
+// truncatingBody yields the first n bytes of data and then fails, modeling a
+// response whose body is cut short mid-transfer.
+type truncatingBody struct {
+	data []byte
+	n    int
+	off  int
+}
+
+func (b *truncatingBody) Read(p []byte) (int, error) {
+	if b.off >= b.n {
+		return 0, errors.New("unexpected EOF reading response body")
+	}
+	k := copy(p, b.data[b.off:b.n])
+	b.off += k
+	return k, nil
+}
+
+func (b *truncatingBody) Close() error { return nil }
+
+// TestDoPurchase_UnreadableBodyDoesNotSilentlyLookPermanent is the regression
+// test for the retry-classification defect.
+//
+// doPurchase's error text is the ONLY input to IsSessionTimeout, and
+// DoPurchaseTwoStep retries only when that predicate matches. When the read
+// error was discarded, a 400 whose body was truncated before the
+// "Session timed out" fragment produced a bare `status 400: <partial>` error.
+// IsSessionTimeout then returned false and the purchase was abandoned on its
+// first attempt — the precise condition purchaseMaxAttempts exists to survive —
+// with no indication that anything had gone wrong reading the response.
+//
+// The fix must not classify retryability from a body that was never fully
+// received. Pre-fix this test fails: the error carries neither the read failure
+// nor the session-timeout fragment, so both assertions below are false.
+func TestDoPurchase_UnreadableBodyDoesNotSilentlyLookPermanent(t *testing.T) {
+	ctx := context.Background()
+	full := `{"error":{"code":"BadRequest","message":"Session timed out - Call CalculatePrice again"}}`
+
+	m := &mockHTTPClient{}
+	m.On("Do", mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusBadRequest,
+		// Cut short well before the "Session timed out" fragment.
+		Body:   &truncatingBody{data: []byte(full), n: 12},
+		Header: make(http.Header),
+	}, nil).Once()
+
+	err := doPurchase(ctx, m, "https://example.invalid/purchase", []byte(testBody), "tok")
+	require.Error(t, err)
+
+	assert.ErrorContains(t, err, "could not be read",
+		"a failed body read must be surfaced, not discarded: the retry decision is made from this error's text")
+	assert.ErrorContains(t, err, "unexpected EOF reading response body",
+		"the underlying read error must be wrapped so the operator can see why retryability is unknown")
+
+	// The essential property: the failure must not be silently classified as a
+	// permanent, non-retryable error on the strength of a body that never
+	// arrived. Either it is recognizably retryable, or the read failure is
+	// visible — never a bare status line that quietly means "give up".
+	assert.True(t,
+		IsSessionTimeout(err) || strings.Contains(err.Error(), "could not be read"),
+		"an unreadable body must not silently produce a non-retryable classification")
+
+	m.AssertExpectations(t)
+}
+
+// TestDoPurchase_UnreadableBodyOnSuccessStillSucceeds guards the opposite
+// direction: success is decided by the status code alone, so a body that fails
+// to read must not turn a completed purchase into a reported failure.
+func TestDoPurchase_UnreadableBodyOnSuccessStillSucceeds(t *testing.T) {
+	ctx := context.Background()
+	m := &mockHTTPClient{}
+	m.On("Do", mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       &truncatingBody{data: []byte(`{"ok":true}`), n: 3},
+		Header:     make(http.Header),
+	}, nil).Once()
+
+	require.NoError(t, doPurchase(ctx, m, "https://example.invalid/purchase", []byte(testBody), "tok"))
+	m.AssertExpectations(t)
 }

--- a/providers/azure/services/internal/reservations/purchase_test.go
+++ b/providers/azure/services/internal/reservations/purchase_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations"
@@ -498,7 +497,7 @@ func TestFindReservationOrderByIdempotencyToken_PaginatedFollowsNextLink(t *test
 // TestDoIdempotentPurchaseTwoStep_EmptyToken_NoLookup pins the CLI legacy path:
 // when no idempotency token is supplied the wrapper falls straight through to
 // the raw DoPurchaseTwoStep (no list call), preserving the pre-issue-721
-// behaviour for callers without an owning execution.
+// behavior for callers without an owning execution.
 func TestDoIdempotentPurchaseTwoStep_EmptyToken_NoLookup(t *testing.T) {
 	m := &mockHTTPClient{}
 	ctx := context.Background()
@@ -644,7 +643,7 @@ func TestDoIdempotentPurchaseTwoStep_DifferentTokens_DistinctReservations(t *tes
 // TestDoIdempotentPurchaseTwoStep_PreservesTwoStepFlow verifies the two-step
 // flow's session-timeout retry semantics from PR #680 still work under the
 // new wrapper -- the wrapper is purely additive for the lookup, and once it
-// falls through to DoPurchaseTwoStep the original retry behaviour applies.
+// falls through to DoPurchaseTwoStep the original retry behavior applies.
 func TestDoIdempotentPurchaseTwoStep_PreservesTwoStepFlow(t *testing.T) {
 	m := &mockHTTPClient{}
 	ctx := context.Background()
@@ -860,20 +859,76 @@ func TestDoPurchase_UnreadableBodyDoesNotSilentlyLookPermanent(t *testing.T) {
 	err := doPurchase(ctx, m, "https://example.invalid/purchase", []byte(testBody), "tok")
 	require.Error(t, err)
 
-	assert.ErrorContains(t, err, "could not be read",
-		"a failed body read must be surfaced, not discarded: the retry decision is made from this error's text")
+	assert.ErrorContains(t, err, "did not read completely",
+		"a failed body read must be surfaced, not discarded")
 	assert.ErrorContains(t, err, "unexpected EOF reading response body",
 		"the underlying read error must be wrapped so the operator can see why retryability is unknown")
 
-	// The essential property: the failure must not be silently classified as a
-	// permanent, non-retryable error on the strength of a body that never
-	// arrived. Either it is recognizably retryable, or the read failure is
-	// visible — never a bare status line that quietly means "give up".
-	assert.True(t,
-		IsSessionTimeout(err) || strings.Contains(err.Error(), "could not be read"),
-		"an unreadable body must not silently produce a non-retryable classification")
+	// Retryability is carried out of band, because it cannot be read off a body
+	// that never fully arrived. Asserting the sentinel rather than the message
+	// is the point: the message is not what the retry loop consults.
+	assert.ErrorIs(t, err, errRetryabilityUnknown,
+		"an unreadable body must mark retryability unknown rather than leave it inferred from text")
 
 	m.AssertExpectations(t)
+}
+
+// countingPurchaseClient answers calculatePrice with a fixed order ID and counts
+// purchase attempts, minting a NEW response per call because the truncating body
+// is stateful and cannot be replayed across attempts.
+type countingPurchaseClient struct {
+	purchases    int
+	purchaseResp func() *http.Response
+}
+
+func (c *countingPurchaseClient) Do(req *http.Request) (*http.Response, error) {
+	if req.URL.String() == PurchaseURL("order-1") {
+		c.purchases++
+		return c.purchaseResp(), nil
+	}
+	return fakeResp(http.StatusOK, `{"properties":{"reservationOrderId":"order-1"}}`), nil
+}
+
+// TestDoPurchaseTwoStep_TruncatedSessionTimeoutStillRetries is the regression
+// test for the retry decision, and it is deliberately an ATTEMPT-COUNT
+// assertion rather than a message assertion.
+//
+// An earlier revision of this fix surfaced the read error in the message and
+// asserted on that text. That assertion passed while the purchase was still
+// abandoned on its first attempt, because retryability was still being inferred
+// from a truncated body: the message changed, the behavior did not. Only
+// counting attempts tells the two apart.
+//
+// The readable control is included so this measures the loop rather than a
+// constant. If the control ever stops reaching the cap, the second half is no
+// longer evidence about anything.
+func TestDoPurchaseTwoStep_TruncatedSessionTimeoutStillRetries(t *testing.T) {
+	ctx := context.Background()
+	full := `{"error":{"code":"BadRequest","message":"Session timed out - Call CalculatePrice again"}}`
+
+	control := &countingPurchaseClient{
+		purchaseResp: func() *http.Response { return fakeResp(http.StatusBadRequest, full) },
+	}
+	_, err := DoPurchaseTwoStep(ctx, control, calcURL, []byte(testBody), "tok")
+	require.Error(t, err)
+	require.Equal(t, purchaseMaxAttempts, control.purchases,
+		"control: a readable session-timeout 400 must retry to the cap, or this test measures nothing")
+
+	truncated := &countingPurchaseClient{
+		purchaseResp: func() *http.Response {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				// Cut short well before the "Session timed out" fragment.
+				Body:   &truncatingBody{data: []byte(full), n: 12},
+				Header: make(http.Header),
+			}
+		},
+	}
+	_, err = DoPurchaseTwoStep(ctx, truncated, calcURL, []byte(testBody), "tok")
+	require.Error(t, err)
+	assert.Equal(t, purchaseMaxAttempts, truncated.purchases,
+		"a session timeout whose body did not read completely must still be retried; "+
+			"pre-fix this was 1 attempt because retryability was inferred from a truncated body")
 }
 
 // TestDoPurchase_UnreadableBodyOnSuccessStillSucceeds guards the opposite


### PR DESCRIPTION
Closes #1766

## The defect

`doPurchase` discarded the `io.ReadAll` error, and its error string is the **only** input to the retry decision:

```go
body, _ := io.ReadAll(resp.Body)
...
return fmt.Errorf("reservation purchase failed with status %d: %s", resp.StatusCode, string(body))
```

```go
func IsSessionTimeout(err error) bool {
    return strings.Contains(err.Error(), sessionTimeoutFragment)   // "Session timed out"
}
```

```go
if IsSessionTimeout(purchaseErr) && attempt < purchaseMaxAttempts {
    continue   // re-run calculatePrice and retry
}
return "", purchaseErr
```

So a 400 whose body was truncated before the fragment produced a bare `status 400: <partial>`, `IsSessionTimeout` returned false, and the purchase was **abandoned on its first attempt** — the exact condition `purchaseMaxAttempts` exists to survive. Nothing in the message indicated the response had not been fully read.

**Direction: fails closed.** It abandons a purchase, it does not double-buy — hence `severity/medium`. But a designed-retryable failure became permanent silently, and the diagnostic that would have explained it is the thing that went missing.

Found while triaging #1754's 49 production findings. It is the only one of them where a discarded error feeds **control flow** rather than a message — full triage [here](https://github.com/LeanerCloud/CUDly/issues/1754#issuecomment-5224587371).

## The fix

> **Correction (head `c4d2d85b1`).** The first revision of this PR surfaced the read error in the message but **did not change the retry decision** — `IsSessionTimeout` still ran `strings.Contains` over a string built from a truncated body, so the purchase was still abandoned on its first attempt. The message improved; the behaviour did not, and `Closes #1766` overstated the diff. Measured on the real loop with a counting client (fresh response per attempt, since the truncating body is stateful):
>
> | scenario | purchase attempts, first revision |
> |---|---|
> | readable session-timeout 400 (control) | **3** |
> | truncated session-timeout 400 (defect) | **1** |
>
> The control moves, so the probe measures the loop rather than a constant.

**Retryability is now carried out of band.** `doPurchase` wraps a new `errRetryabilityUnknown` sentinel when a non-2xx body fails to read, and `DoPurchaseTwoStep` treats `errors.Is(err, errRetryabilityUnknown)` as retryable alongside `IsSessionTimeout`. The retry decision no longer depends on text parsed from a body that never fully arrived, so `Closes #1766` now matches the diff.

**Scoped to 400** — matching `IsSessionTimeout`'s own status scope and the only scenario #1766 reports.

That scoping is not cosmetic. The safety review established that **the idempotency guard does not cover in-loop retries**: `DoIdempotentPurchaseTwoStep` calls `FindReservationOrderByIdempotencyToken` exactly once, *before* `DoPurchaseTwoStep` is entered, and there is no recheck between attempts — each retry mints a fresh `reservationOrderId` via `doCalculatePrice`. Verified here: **zero** lookups occur inside the loop. So the guard covers a re-drive *across* invocations and nothing within one, and the bound is `purchaseMaxAttempts`, not the guard.

That makes "a non-2xx means the order did not commit" the only thing between a truncated read and a double purchase — and that premise is unverified for this API on 409 and 5xx. A **truncated** response is also mechanistically different from a cleanly read one: truncation is the transport-failure class associated with genuine commit ambiguity, since the server may have finished processing and begun writing when the connection died. A cleanly read 500 is a deliberate synchronous statement. An earlier revision of this PR treated the two as equivalent, and its safety comment asserted the non-commit premise outright; both are corrected.

Narrowing costs no coverage — #1766's defect is a 400 with a truncated body, the only case in the issue and in every regression test here — while removing the unverified commit-ambiguous statuses from the retry surface entirely.

**The missing in-loop recheck is pre-existing** on the `IsSessionTimeout` path since #677/#1550. This PR widens what reaches it; the 400 scoping is the mitigation. Tracked separately as **#1774** and deliberately not addressed here.

Success still depends on the status code alone, so an unreadable body cannot turn a completed purchase into a reported failure — verified by mutation (hoisting the `readErr` check above the 2xx short-circuit makes the guard fire).

## Regression tests, both directions

Driven by a body that yields 12 bytes then fails, modeling a response cut short mid-transfer.

**`TestDoPurchaseTwoStep_TruncatedSessionTimeoutStillRetries`** is the regression test for the retry decision, and it is deliberately an **attempt-count** assertion rather than a message assertion. It fails against the message-only first revision with `expected: 3, actual: 1`.

This matters beyond this PR. The first revision's test asserted on the error *text* and passed while the purchase was still abandoned — the assertion was tautological once the message changed, while being **labelled** as pinning retryability, a property that did not hold. That is the same defect class as #1595 and #1740: an assertion reading as a guarantee it does not provide, written during the very work that was removing them. Only counting attempts distinguishes a changed message from changed behaviour.

The test carries the readable control (which must reach `purchaseMaxAttempts`) so it measures the loop rather than a constant; if the control ever stops retrying, the test stops being evidence.

`TestDoPurchase_UnreadableBodyDoesNotSilentlyLookPermanent` now asserts `errors.Is(err, errRetryabilityUnknown)` — the thing the loop actually consults — rather than substrings of the message.

**Two further tests pin the 400 scoping so it cannot be silently widened again**, since nothing else in the code would notice:

- `TestDoPurchase_TruncatedNon400IsNotRetryable` — 409, 500, 502 and 504 with truncated bodies must not carry the sentinel.
- `TestDoPurchaseTwoStep_TruncatedNon400DoesNotRetry` — a truncated 500 must be attempted exactly once.

Both fail when the condition is widened back to any non-2xx, with the message naming the double-buy risk and #1774.

**`TestDoPurchase_UnreadableBodyOnSuccessStillSucceeds`** — guards the opposite direction: a truncated body on a 200 must still succeed.

## Siblings checked, not assumed

The two other `io.ReadAll` discards in this file are **not** affected, verified individually:

- **`:287` `doCalculatePrice`** — truncation fails `json.Unmarshal`, and an empty `ReservationOrderID` is separately guarded.
- **`:390` `fetchReservationOrdersPage`** — backs the idempotency-token lookup. Truncation fails `json.Unmarshal`, and the caller `DoIdempotentPurchaseTwoStep` **explicitly refuses to purchase on a lookup error** rather than falling through, so there is no double-buy path. That code is well guarded.

## Gates

`providers/azure`: `gofmt` clean, `go build ./...`, `go vet ./...`, `go test -race -count=1 ./...` **851 passed / 14 packages**. Root module: build, vet, `gocyclo -over 10 -ignore "_test\.go" .` exit 0 empty, `golangci-lint` v2.10.1 **exit 0 with a genuine `0 issues.` line** (both asserted, since a missing `--out-format` or a concurrent invocation exits 3 with zero findings and reads like a clean run).

Rebased onto `6d5275c85`. `golangci-lint` on `providers/azure` compared as a **set diff against `origin/main`, not by totals**:

```
base (main): 592    head: 589
only in HEAD (new):    (none)
only in BASE (fixed):  purchase.go:: Error return value of `io.ReadAll` is not checked (errcheck)
                       purchase_test.go:: `behaviour` is a misspelling of `behavior` (misspell)  x2
```

**Drive-by, disclosed:** a global spelling fix in this test file also corrected two pre-existing `behaviour` misspellings that `main` already carried. Two words in a file this PR already rewrites; flagged rather than reverted, since reverting means deliberately restoring a misspelling.

The set-diff method earned itself twice here. An intermediate revision removed one finding and added two `misspell` in new comments (net 592→593); a later one added one `behaviour` that exactly offset the removed `errcheck`, leaving the total at **592 — unchanged, and wrong**. Totals alone would have passed both times. I also had to re-derive the baseline twice: `git checkout -- <path>` restores from the index, i.e. my own commit, not `main`. The comparison above uses `git checkout origin/main -- providers/azure/`.

`providers/azure` carries 589 pre-existing findings tracked in #1754 and #1759; this PR neither adds to them nor masks them.

**Known-red inherited from `main`:** `TestGrantCeiling_ConstraintContainment` in `internal/auth` fails on `main` today (#1737 and #1758 colliding on `execute:ri-exchange`). This branch changes only `providers/azure/services/internal/reservations/` — confirmed by `git diff origin/main --name-only` — so that failure is inherited, not caused, and a separate fix is in flight.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete Azure reservation purchase responses.
  * Automatically retries purchases when response data is truncated or a session timeout occurs.
  * Preserves successful status handling even when response bodies cannot be fully read.
  * Avoids unnecessary retries for other non-retryable response errors.
  * Ensures retry attempts stop at the configured limit while returning the appropriate error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
