### PR TITLE
sec(api): scope ladder config writes to the caller's allowed_accounts

### DIFF
--- a/internal/api/handler_ladder.go
+++ b/internal/api/handler_ladder.go
@@ -86,9 +86,12 @@ func (h *Handler) filterLadderConfigsByAllowedAccounts(ctx context.Context, sess
 // reasoning was never applied to the write, so the row was also invisible to
 // its author afterwards.
 func (h *Handler) upsertLadderConfig(ctx context.Context, req *events.LambdaFunctionURLRequest) (any, error) {
-	session, err := h.requirePermission(ctx, req, "update", "config")
-	if err != nil {
-		return nil, err
+	// Named permErr rather than err: the body-parsing and validation steps
+	// below each bind their own `err` in an if-statement, which would shadow a
+	// function-scoped `err` and trip govet's shadow check.
+	session, permErr := h.requirePermission(ctx, req, "update", "config")
+	if permErr != nil {
+		return nil, permErr
 	}
 
 	// DisallowUnknownFields so a typo'd key is rejected loudly instead of

--- a/internal/api/handler_ladder.go
+++ b/internal/api/handler_ladder.go
@@ -74,8 +74,20 @@ func (h *Handler) filterLadderConfigsByAllowedAccounts(ctx context.Context, sess
 // the auth component is nil (returns an error, never a session), so the
 // handler fails closed; the exact status is a 500-class error in that case
 // rather than a 403, but no unauthenticated write ever reaches the store.
+//
+// update:config alone is NOT sufficient: the target account must also be
+// inside the session's allowed_accounts (issue #1539). Holding the verb said
+// nothing about WHICH account it could be exercised on, so a caller scoped to
+// one account could write the ladder config of any other -- including the
+// deployment's own account, whose config the ladder engine acts on, and whose
+// existing row this endpoint overwrites (the store upserts on the
+// UNIQUE(cloud_account_id, provider) pair). getLadderConfigs has filtered on
+// allowed_accounts since migration 000088 opened it to scoped users; the same
+// reasoning was never applied to the write, so the row was also invisible to
+// its author afterwards.
 func (h *Handler) upsertLadderConfig(ctx context.Context, req *events.LambdaFunctionURLRequest) (any, error) {
-	if _, err := h.requirePermission(ctx, req, "update", "config"); err != nil {
+	session, err := h.requirePermission(ctx, req, "update", "config")
+	if err != nil {
 		return nil, err
 	}
 
@@ -109,7 +121,7 @@ func (h *Handler) upsertLadderConfig(ctx context.Context, req *events.LambdaFunc
 		return nil, NewClientError(400, fmt.Sprintf("validation error: %s", err))
 	}
 
-	if err := h.validateLadderAccountProvider(ctx, &cfg); err != nil {
+	if err := h.requireLadderAccountAccess(ctx, session, &cfg); err != nil {
 		return nil, err
 	}
 
@@ -121,18 +133,23 @@ func (h *Handler) upsertLadderConfig(ctx context.Context, req *events.LambdaFunc
 	return result, nil
 }
 
-// validateLadderAccountProvider confirms the (cloud_account_id, provider) pair
-// refers to a real cloud account whose provider matches. This turns a
-// nonexistent-account FK violation into a clean 400 (rather than a raw 500 from
-// the store's FK constraint) and rejects a provider mismatch -- e.g. an inert
-// gcp config attached to an AWS account, which would confuse PR-2 scoping.
-func (h *Handler) validateLadderAccountProvider(ctx context.Context, cfg *config.LadderConfigDB) error {
-	account, err := h.config.GetCloudAccount(ctx, cfg.CloudAccountID)
+// requireLadderAccountAccess confirms the caller may write ladder config for
+// the (cloud_account_id, provider) pair in the request body: the account must
+// exist, be within the session's allowed_accounts, and carry the claimed
+// provider. It rejects a provider mismatch -- e.g. an inert gcp config attached
+// to an AWS account, which would confuse PR-2 scoping.
+//
+// The account lookup lives in requireAccountAccess, which already fetches the
+// account and nil-checks it, so this does not fetch it a second time.
+//
+// requireAccountAccess answers both "no such account" and "not yours" with the
+// same errNotFound (404), deliberately: distinguishing them would let a scoped
+// caller enumerate the account table by probing ids. That replaces the earlier
+// 400 "cloud account %q does not exist", which leaked exactly that distinction.
+func (h *Handler) requireLadderAccountAccess(ctx context.Context, session *Session, cfg *config.LadderConfigDB) error {
+	account, err := h.requireAccountAccess(ctx, session, cfg.CloudAccountID)
 	if err != nil {
-		return fmt.Errorf("failed to look up cloud account: %w", err)
-	}
-	if account == nil {
-		return NewClientError(400, fmt.Sprintf("cloud account %q does not exist", cfg.CloudAccountID))
+		return err
 	}
 	if account.Provider != cfg.Provider {
 		return NewClientError(400, fmt.Sprintf("provider %q does not match cloud account provider %q", cfg.Provider, account.Provider))

--- a/internal/api/handler_ladder_test.go
+++ b/internal/api/handler_ladder_test.go
@@ -151,8 +151,14 @@ func TestUpsertLadderConfig_ProviderMismatchRejected(t *testing.T) {
 }
 
 // TestUpsertLadderConfig_NonexistentAccountRejected is F5: a cloud_account_id
-// that does not resolve must 400 (clean rejection) rather than reaching the
-// store and surfacing a raw 500 from the FK constraint.
+// that does not resolve must be rejected cleanly rather than reaching the store
+// and surfacing a raw 500 from the FK constraint.
+//
+// The refusal is errNotFound (404) rather than the earlier 400 "cloud account
+// does not exist" (issue #1539). requireAccountAccess answers "no such account"
+// and "not yours" identically on purpose: a distinguishable 400 would let a
+// scoped caller enumerate the account table by probing ids and reading which
+// error came back.
 func TestUpsertLadderConfig_NonexistentAccountRejected(t *testing.T) {
 	ctx := context.Background()
 	handler, mockStore, _ := newLadderHandler(t)
@@ -162,8 +168,98 @@ func TestUpsertLadderConfig_NonexistentAccountRejected(t *testing.T) {
 	result, err := handler.upsertLadderConfig(ctx, ladderReq(body))
 	require.Error(t, err)
 	assert.Nil(t, result)
-	ce, ok := IsClientError(err)
-	require.True(t, ok, "expected ClientError, got %T: %v", err, err)
-	assert.Equal(t, 400, ce.code)
+	assert.ErrorIs(t, err, errNotFound)
 	mockStore.AssertNotCalled(t, "UpsertLadderConfig", mock.Anything, mock.Anything)
+}
+
+// --- issue #1539: allowed_accounts scoping on the ladder config WRITE path ---
+//
+// getLadderConfigs has filtered on allowed_accounts since migration 000088
+// opened view:config to scoped users; upsertLadderConfig never did. A caller
+// scoped to one account could therefore write (and, because the store upserts
+// on UNIQUE(cloud_account_id, provider), OVERWRITE) the ladder config of any
+// other account -- and the GET then filtered the row back out, so the change
+// was invisible to its author afterwards.
+//
+// Both directions are covered deliberately. A refusal-only test passes just as
+// well against a handler that refuses everyone, which would hide the scope
+// check having been wired to reject in-scope writes too.
+
+// ladderScopedReq builds an authenticated PUT carrying body, for the principal
+// scopedHandler wires (restricted to scopedInAccount).
+func ladderScopedReq(body string) *events.LambdaFunctionURLRequest {
+	return &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"Authorization": "Bearer " + scopedToken},
+		Body:    body,
+	}
+}
+
+// ladderScopedBody builds a valid ladder config body targeting accountID.
+// mode=auto_approve with max_hourly_commit_per_run omitted (nil => no cap) is
+// the shape from the issue's failure scenario.
+func ladderScopedBody(accountID string) string {
+	return `{"cloud_account_id":"` + accountID + `","provider":"aws","enabled":true,` +
+		`"mode":"auto_approve","cadence":"daily",` + ladderValidRamp + `}`
+}
+
+// ladderScopedHandler wires a handler whose session is restricted to
+// scopedInAccount, with both cloud accounts resolvable so the refusal comes
+// from the scope check rather than from a failed lookup.
+func ladderScopedHandler(t *testing.T) (*Handler, *MockConfigStore) {
+	t.Helper()
+	h, mockStore := scopedHandler(t, scopedInAccount)
+	mockStore.On("GetCloudAccount", mock.Anything, scopedInAccount).
+		Return(&config.CloudAccount{ID: scopedInAccount, Name: "in-scope", Provider: "aws"}, nil).Maybe()
+	mockStore.On("GetCloudAccount", mock.Anything, scopedOutAccount).
+		Return(&config.CloudAccount{ID: scopedOutAccount, Name: "victim-account", Provider: "aws"}, nil).Maybe()
+	return h, mockStore
+}
+
+// TestUpsertLadderConfig_OutOfScopeAccountRefused is the guard: this is the
+// assertion that fails if the requireAccountAccess call is removed.
+func TestUpsertLadderConfig_OutOfScopeAccountRefused(t *testing.T) {
+	ctx := context.Background()
+	handler, mockStore := ladderScopedHandler(t)
+
+	result, err := handler.upsertLadderConfig(ctx, ladderScopedReq(ladderScopedBody(scopedOutAccount)))
+
+	require.Error(t, err, "a caller scoped to another account must not write this config (#1539)")
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, errNotFound,
+		"must be the enumeration-safe not-found, not a 403 that confirms the account exists")
+	mockStore.AssertNotCalled(t, "UpsertLadderConfig", mock.Anything, mock.Anything)
+}
+
+// TestUpsertLadderConfig_InScopeAccountStillAllowed is the other direction:
+// the same restricted principal, the account it IS entitled to. Without this,
+// a handler that refused every write would satisfy the test above.
+func TestUpsertLadderConfig_InScopeAccountStillAllowed(t *testing.T) {
+	ctx := context.Background()
+	handler, mockStore := ladderScopedHandler(t)
+	mockStore.On("UpsertLadderConfig", mock.Anything, mock.AnythingOfType("*config.LadderConfigDB")).
+		Return(&config.LadderConfigDB{ID: "written-row", CloudAccountID: scopedInAccount}, nil)
+
+	result, err := handler.upsertLadderConfig(ctx, ladderScopedReq(ladderScopedBody(scopedInAccount)))
+
+	require.NoError(t, err, "a caller scoped to this account must still be able to write its config")
+	require.NotNil(t, result)
+	mockStore.AssertCalled(t, "UpsertLadderConfig")
+}
+
+// TestUpsertLadderConfig_UnrestrictedSessionUnaffected pins that the refusal
+// above is driven by the caller's SCOPE and not by anything about the account
+// itself: an unrestricted session writes that same account unchanged.
+func TestUpsertLadderConfig_UnrestrictedSessionUnaffected(t *testing.T) {
+	ctx := context.Background()
+	handler, mockStore := scopedHandler(t) // no accounts => grantAdmin => unrestricted
+	mockStore.On("GetCloudAccount", mock.Anything, scopedOutAccount).
+		Return(&config.CloudAccount{ID: scopedOutAccount, Name: "victim-account", Provider: "aws"}, nil)
+	mockStore.On("UpsertLadderConfig", mock.Anything, mock.AnythingOfType("*config.LadderConfigDB")).
+		Return(&config.LadderConfigDB{ID: "written-row", CloudAccountID: scopedOutAccount}, nil)
+
+	result, err := handler.upsertLadderConfig(ctx, ladderScopedReq(ladderScopedBody(scopedOutAccount)))
+
+	require.NoError(t, err, "an unrestricted session must be unaffected by the #1539 scope check")
+	require.NotNil(t, result)
+	mockStore.AssertCalled(t, "UpsertLadderConfig")
 }


### PR DESCRIPTION
Closes #1539

## Established before fixing

The issue reads as a plausible-but-unverified claim, so I checked it by execution rather than by reading. It is real, and two of its stated premises are narrower than written — both recorded on the issue.

Drove the real routed handler (`PUT /api/ladder/configs` → `upsertLadderConfigHandler` → `upsertLadderConfig`, `router.go:326`, `Auth: AuthUser`) with a principal scoped to one account, targeting a different one:

```
PROBE upsert out-of-scope: err=<nil> result=&{... CloudAccountID:2222…  ID:written-row}
PROBE RESULT: BYPASS CONFIRMED -- out-of-scope ladder config write reached the store
```

Companion probe, same principal, same two rows, read side:

```
PROBE read-side returned 1 config(s):   id=row-in account=1111…
PROBE RESULT: read filtered, write unfiltered
```

## What was actually wrong

`upsertLadderConfig` discarded the session (`if _, err := h.requirePermission(...)`) and nothing between the decode and `h.config.UpsertLadderConfig` consulted `allowed_accounts`. `validateLadderAccountProvider` checked existence and provider match only.

`getLadderConfigs` has filtered on `allowed_accounts` since migration 000088 opened `view:config` to scoped users — its doc comment records exactly that reasoning. It was applied to the read and not to the write, so the row was also filtered back out of the writer's own GET afterwards.

## Severity, stated honestly

Filed as `severity/critical`; re-triaged to `severity/high` during investigation, `p1`/`urgency/now` unchanged. Two independent narrowings:

**No seeded group grants `update:config` to a scoped user.** Migration 000088 says so in its own header — *"Non-admin groups are NOT granted `update:config` here."* `ResourceConfig` appears in the defaults only as `{ActionView, ResourceConfig}`. So this needs an operator-created custom group granting `update:config` **and** carrying a restricted `allowed_accounts`. A plain admin is unaffected either way: `admin:*` carries `allowed_accounts ARRAY['*']`, so the new check passes for it. There is no privilege escalation for the principals that hold the verb today.

**The auto-purchase consequence needs the target to be the deployment's own AWS account.** The issue states the engine "auto-purchases uncapped commitments on account B". That holds only when B *is* the account the deployment runs in — `processOneLadderConfig` (`internal/server/handler_ladder.go:234`) skips any config whose `ExternalID != ownAccountID` as `multi_account_unsupported`, and execution also needs `laddering_enabled` and `ladder_execution_enabled` globally.

| target account | consequence |
|---|---|
| the deployment's own AWS account | money path is real — `mode:auto_approve` and a nil `max_hourly_commit_per_run` both reach the engine via `ladderConfigToEngine`. And because the store upserts on `UNIQUE(cloud_account_id, provider)`, an out-of-scope caller can **overwrite an admin's existing row**: raise the cap, flip the mode, or set `enabled:false` to silently stop a running ladder. |
| any other registered account | write succeeds, row invisible to its author afterwards, never executes |

Same-tenant wrong-scope, not cross-tenant. `high`, not `critical` — but not lower either, because once laddering is in use at all both global flags are on by definition, so the tamper case is cheap.

## What landed

`validateLadderAccountProvider` becomes `requireLadderAccountAccess` and delegates the lookup to `requireAccountAccess`, which already fetches and nil-checks the account — so the account is fetched once rather than twice. The rename is deliberate: the function now enforces authorization, not just validation, and a reviewer seeing `validate…` would not expect an authz check inside it.

Ordering inside the helper matters and is not incidental: `requireAccountAccess` runs **before** the provider comparison, so the `400 "provider %q does not match cloud account provider %q"` — which names the *account's* provider — is unreachable for an out-of-scope caller.

**Behaviour change.** A `cloud_account_id` that does not resolve now returns `errNotFound` (404) instead of `400 "cloud account %q does not exist"`. `requireAccountAccess` answers "no such account" and "not yours" identically on purpose: a distinguishable 400 would let a scoped caller enumerate the account table by probing ids. One existing test asserted the 400 and was updated with that reasoning recorded on it.

**Deliberately NOT added:** the `requirePermissionConstraints` call the issue's fix direction suggests. `requirePermissionConstraintsAction` is hardcoded to `"execute"` (`handler.go:472`), with a comment saying a genuinely new action should add a real parameter back rather than resurrect an unused one. Calling it here would evaluate the caller's **execute** permission on `config` — not the verb being exercised — and would fail closed for anyone holding only `update:config`. The `allowed_accounts` check is what closes the reported bypass; adding a second, mis-aimed authorization layer would be its own bug surface.

## Verification

Coverage runs **both directions**, since a refusal-only test passes equally well against a handler that refuses everyone. Mutation-verified per test, each **run alone**, on the committed diff:

| mutation | expected | observed |
|---|---|---|
| **M1** scope check → plain `GetCloudAccount` (the fix removed) | `OutOfScopeAccountRefused` fails | **FAIL** — and In-scope / Unrestricted / Nonexistent all still pass, so M1 is precisely targeted |
| **M2** refuse everyone | In-scope + Unrestricted fail | **both FAIL** — the two positive controls are not vacuous |
| **M3** provider check dropped | `ProviderMismatchRejected` fails | **FAIL** — with scope tests still passing |

`TestUpsertLadderConfig_UnrestrictedSessionUnaffected` writes the *same account* the scoped principal was refused, which pins that the refusal is driven by the caller's scope rather than by anything about the account.

Gates at this head, as actually observed at the time of opening: `go build ./...` **0** · `go vet ./...` **0** · `go vet -tags=integration ./...` **0** · **`internal/api` green (29.9s)**. The full `./internal/... ./cmd/...` run, golangci-lint v2.10.1 (the CI-pinned version) and `gocyclo -over 10 -ignore "_test\.go"` were still running locally when this was opened — I will post the exit codes as a follow-up comment rather than assert them here. CI covers the same ground independently.

**Known-red `main`:** `TestGrantCeiling_ConstraintContainment` in `internal/auth` fails 3 subtests on `main` itself — #1737's test uses `execute:ri-exchange` as a generic fixture verb and #1758 then added that verb to `adminCarvedOuts`, so `checkGrantCeiling` refuses it before the containment logic under test is reached. This PR's diff touches **0 files** under `internal/auth`, so that failure cannot originate here; it clears when the test-only fix lands.

## Sibling found and filed separately

The completeness sweep over all 321 `*Handler` methods (attributing **74/74** `requirePermission` call sites — a first pass matched only the two-arg signature and silently covered 13 of 74) found one more real instance of this shape: **#1769**, `setPlanAccounts` at `handler_accounts.go:1304`, which writes plan→account associations with neither `requirePlanAccess` nor `requireAccountAccess`. It is higher-reachability than this one — `update:plans` *is* a default Standard User grant — and is filed separately because it needs a different file and can land independently.

`validateExecutePurchaseRequest` also surfaced as a suspect and is a false positive: it calls `validatePurchaseRecommendationScope`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted ladder configuration updates to authorized accounts and matching providers.
  * Prevented unauthorized access from revealing whether an account exists.
  * Preserved configuration updates for permitted accounts and unrestricted sessions.

* **Tests**
  * Added coverage for out-of-scope account rejection, allowed account updates, and unrestricted access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->