### PR TITLE
fix(azure): pair the recommended SKU with the count in its own units

### DIFF
--- a/providers/azure/internal/recommendations/converter.go
+++ b/providers/azure/internal/recommendations/converter.go
@@ -141,15 +141,16 @@ func extractLegacy(rec *armconsumption.LegacyReservationRecommendation) *Extract
 		return nil
 	}
 
+	resourceType, quantity := resolveLegacySKUAndQuantity(props)
 	out := &ExtractedFields{
 		Region:       strDeref(rec.Location),
-		ResourceType: resolveLegacyResourceType(props),
+		ResourceType: resourceType,
 		Term:         normaliseTerm(props.Term),
 		Scope:        strDeref(props.Scope),
 	}
 
-	if props.RecommendedQuantity != nil {
-		out.Count = int(*props.RecommendedQuantity)
+	if quantity != nil {
+		out.Count = int(*quantity)
 	}
 	if props.CostWithNoReservedInstances != nil {
 		out.OnDemandCost = *props.CostWithNoReservedInstances
@@ -194,15 +195,16 @@ func extractModern(rec *armconsumption.ModernReservationRecommendation) *Extract
 		region = strDeref(props.Location)
 	}
 
+	resourceType, quantity := resolveModernSKUAndQuantity(props)
 	out := &ExtractedFields{
 		Region:       region,
-		ResourceType: resolveModernResourceType(props),
+		ResourceType: resourceType,
 		Term:         normaliseTerm(props.Term),
 		Scope:        strDeref(props.Scope),
 	}
 
-	if props.RecommendedQuantity != nil {
-		out.Count = int(*props.RecommendedQuantity)
+	if quantity != nil {
+		out.Count = int(*quantity)
 	}
 	out.OnDemandCost = amountValue(props.CostWithNoReservedInstances)
 	out.CommitmentCost = amountValue(props.TotalCostWithReservedInstances)
@@ -222,29 +224,86 @@ func extractModern(rec *armconsumption.ModernReservationRecommendation) *Extract
 	return out
 }
 
-// resolveLegacyResourceType follows the Legacy field ladder:
-// NormalizedSize → SKUProperties[Name==SKUName|skuName].Value → first
-// non-empty SKUProperty.Value.
-func resolveLegacyResourceType(props *armconsumption.LegacyReservationRecommendationProperties) string {
-	if s := strDeref(props.NormalizedSize); s != "" {
-		return s
+// resolveLegacySKUAndQuantity returns the resource type together with the
+// quantity that counts THAT resource type, so the two are always in the same
+// units.
+//
+// Azure carries two quantities on a Legacy recommendation and they are not
+// interchangeable: RecommendedQuantity counts the actual SKU
+// (SKUProperties[SKUName]), while RecommendedQuantityNormalized counts
+// NormalizedSize. Resolving the two independently let the SKU come from one
+// and the count from the other, understating the purchase by the family's
+// instance-size-flexibility ratio -- 4 x Standard_D8s_v3 normalized to
+// 16 x Standard_D2s_v3 was bought as 4 x Standard_D2s_v3, a quarter of the
+// recommended capacity, with the full recommendation's savings still shown
+// against it (issue #1540). They are resolved together here so no branch can
+// produce a mixed pair.
+//
+// The actual SKU is preferred, matching resolveModernSKUAndQuantity, so EA and
+// MCA subscriptions with identical usage yield the same ResourceType. Its
+// partner RecommendedQuantity is also the *float64 field, avoiding the
+// *float32 rounding question on a purchase path.
+//
+// When only NormalizedSize is available the normalized quantity is its only
+// valid partner. If that partner is absent the count is left unset rather than
+// borrowed from RecommendedQuantity: an unpaired count is precisely the defect
+// above, and a zero count is refused downstream by the `Count <= 0` guard every
+// service applies before purchasing.
+func resolveLegacySKUAndQuantity(props *armconsumption.LegacyReservationRecommendationProperties) (resourceType string, quantity *float64) {
+	if s := resourceTypeFromSKUProperties(props.SKUProperties); s != "" {
+		return s, props.RecommendedQuantity
 	}
-	return resourceTypeFromSKUProperties(props.SKUProperties)
+	if normalized := strDeref(props.NormalizedSize); normalized != "" {
+		if props.RecommendedQuantityNormalized == nil {
+			logging.Warnf(
+				"azure recommendations: %q has a normalized size but no RecommendedQuantityNormalized "+
+					"and no SKU properties to pair RecommendedQuantity with; leaving the count unset "+
+					"rather than pairing mismatched units",
+				normalized,
+			)
+			return normalized, nil
+		}
+		return normalized, float64Ptr(float64(*props.RecommendedQuantityNormalized))
+	}
+	// No resource type from either source: there is no normalized size for the
+	// count to disagree with, so this degenerate payload keeps the behavior it
+	// had before the pairing fix.
+	return "", props.RecommendedQuantity
 }
 
-// resolveModernResourceType follows the Modern field ladder. Modern adds
-// a top-level SKUName pointer (the cleanest source), so the preference is
-// SKUName → NormalizedSize → SKUProperties fallback. The SKUProperties
-// fallback matches Legacy's contract so a switch between billing-account
-// types doesn't change ResourceType semantics.
-func resolveModernResourceType(props *armconsumption.ModernReservationRecommendationProperties) string {
+// resolveModernSKUAndQuantity is the Modern counterpart of
+// resolveLegacySKUAndQuantity, pairing each rung of the ladder with the
+// quantity expressed in that rung's units.
+//
+// The ladder is unchanged: Modern adds a top-level SKUName pointer (the
+// cleanest source), so the preference stays SKUName → NormalizedSize →
+// SKUProperties fallback, and the SKUProperties rung still matches Legacy's
+// contract so a switch between billing-account types does not change
+// ResourceType semantics.
+//
+// Both SKU rungs count the actual SKU and so pair with RecommendedQuantity;
+// only the NormalizedSize rung is counted by RecommendedQuantityNormalized.
+// Modern was not the reported instance of #1540 -- real MCA payloads carry
+// SKUName and take the first rung -- but its NormalizedSize rung mixed the
+// same two fields, so it is paired here rather than left as the one branch
+// that can still emit mismatched units.
+func resolveModernSKUAndQuantity(props *armconsumption.ModernReservationRecommendationProperties) (resourceType string, quantity *float64) {
 	if s := strDeref(props.SKUName); s != "" {
-		return s
+		return s, props.RecommendedQuantity
 	}
 	if s := strDeref(props.NormalizedSize); s != "" {
-		return s
+		if props.RecommendedQuantityNormalized == nil {
+			logging.Warnf(
+				"azure recommendations: modern recommendation %q has a normalized size but no "+
+					"RecommendedQuantityNormalized; leaving the count unset rather than pairing "+
+					"mismatched units",
+				s,
+			)
+			return s, nil
+		}
+		return s, float64Ptr(float64(*props.RecommendedQuantityNormalized))
 	}
-	return resourceTypeFromSKUProperties(props.SKUProperties)
+	return resourceTypeFromSKUProperties(props.SKUProperties), props.RecommendedQuantity
 }
 
 // resourceTypeFromSKUProperties scans a SKUProperties key/value list for

--- a/providers/azure/internal/recommendations/converter_test.go
+++ b/providers/azure/internal/recommendations/converter_test.go
@@ -96,20 +96,21 @@ func TestExtract_QuantityRoundsDown(t *testing.T) {
 	}
 }
 
-func TestExtract_ResourceTypePrefersNormalizedSize(t *testing.T) {
-	// When both NormalizedSize and SKUProperties are populated, NormalizedSize wins.
+func TestExtract_ResourceTypePrefersActualSKUOverNormalizedSize(t *testing.T) {
+	// When both are populated the actual SKU wins, because RecommendedQuantity
+	// counts THAT SKU. Preferring NormalizedSize here was issue #1540: the
+	// normalized size was paired with the un-normalized count.
 	rec := mocks.BuildLegacyReservationRecommendation(
 		mocks.WithNormalizedSize("Standard_D2s_v3"),
-		mocks.WithSKU("SHOULD_NOT_WIN"),
+		mocks.WithSKU("Standard_D8s_v3"),
 	)
 	f := Extract(rec)
 	require.NotNil(t, f)
-	assert.Equal(t, "Standard_D2s_v3", f.ResourceType)
+	assert.Equal(t, "Standard_D8s_v3", f.ResourceType)
 }
 
-func TestExtract_ResourceTypeFallsBackToSKUName(t *testing.T) {
+func TestExtract_ResourceTypeUsesSKUName(t *testing.T) {
 	rec := mocks.BuildLegacyReservationRecommendation(
-		// No NormalizedSize → should fall back to SKUProperties entry with Name="SKUName".
 		mocks.WithSKU("Standard_E4s_v5"),
 	)
 	f := Extract(rec)
@@ -118,8 +119,9 @@ func TestExtract_ResourceTypeFallsBackToSKUName(t *testing.T) {
 }
 
 func TestExtract_ResourceTypeFallsBackToFirstPropertyValue(t *testing.T) {
-	// No NormalizedSize, no SKUName-keyed property — fall back to the
-	// first non-empty value in the list (last-ditch fallback).
+	// No SKUName-keyed property — fall back to the first non-empty value in
+	// the list (last-ditch fallback). Still an actual-SKU rung, so it keeps
+	// RecommendedQuantity as its partner.
 	rec := mocks.BuildLegacyReservationRecommendation(
 		mocks.WithSKUProperty("Cores", "4"),
 		mocks.WithSKUProperty("MemoryGB", "16"),
@@ -127,6 +129,113 @@ func TestExtract_ResourceTypeFallsBackToFirstPropertyValue(t *testing.T) {
 	f := Extract(rec)
 	require.NotNil(t, f)
 	assert.Equal(t, "4", f.ResourceType)
+}
+
+func TestExtract_ResourceTypeFallsBackToNormalizedSize(t *testing.T) {
+	// No SKU properties at all — NormalizedSize is the only source left, and
+	// it is counted by RecommendedQuantityNormalized.
+	rec := mocks.BuildLegacyReservationRecommendation(
+		mocks.WithNormalizedSize("Standard_D2s_v3"),
+		mocks.WithQuantity(4),
+		mocks.WithNormalizedQuantity(16),
+	)
+	f := Extract(rec)
+	require.NotNil(t, f)
+	assert.Equal(t, "Standard_D2s_v3", f.ResourceType)
+	assert.Equal(t, 16, f.Count,
+		"the normalized size must be counted by RecommendedQuantityNormalized, not RecommendedQuantity")
+}
+
+// TestExtract_LegacySKUAndQuantityStayInMatchingUnits is the regression test
+// for issue #1540. Azure carries two quantities that are NOT interchangeable:
+// RecommendedQuantity counts SKUProperties[SKUName], RecommendedQuantityNormalized
+// counts NormalizedSize. Pairing the normalized SKU with the un-normalized count
+// understated every EA purchase by the family's instance-size-flexibility ratio,
+// while the full recommendation's savings were still reported against it.
+//
+// Both directions are asserted: the mismatched pair must be gone, AND each
+// valid pair must still be produced. Asserting only the first passes against a
+// converter that returns nothing at all.
+func TestExtract_LegacySKUAndQuantityStayInMatchingUnits(t *testing.T) {
+	// Azure recommends 4 x Standard_D8s_v3, normalized to 16 x Standard_D2s_v3.
+	const (
+		actualSKU  = "Standard_D8s_v3"
+		normalized = "Standard_D2s_v3"
+		actualQty  = 4
+		normQty    = 16
+	)
+
+	tests := []struct {
+		name     string
+		opts     []mocks.LegacyOpt
+		wantType string
+		wantQty  int
+	}{
+		{
+			name: "actual SKU present: paired with the un-normalized count",
+			opts: []mocks.LegacyOpt{
+				mocks.WithSKU(actualSKU),
+				mocks.WithNormalizedSize(normalized),
+				mocks.WithQuantity(actualQty),
+				mocks.WithNormalizedQuantity(normQty),
+			},
+			wantType: actualSKU,
+			wantQty:  actualQty,
+		},
+		{
+			name: "only the normalized size: paired with the normalized count",
+			opts: []mocks.LegacyOpt{
+				mocks.WithNormalizedSize(normalized),
+				mocks.WithQuantity(actualQty),
+				mocks.WithNormalizedQuantity(normQty),
+			},
+			wantType: normalized,
+			wantQty:  normQty,
+		},
+		{
+			name: "no normalization: the single quantity pairs with the single SKU",
+			opts: []mocks.LegacyOpt{
+				mocks.WithSKU(actualSKU),
+				mocks.WithQuantity(actualQty),
+			},
+			wantType: actualSKU,
+			wantQty:  actualQty,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := Extract(mocks.BuildLegacyReservationRecommendation(tt.opts...))
+			require.NotNil(t, f)
+			assert.Equal(t, tt.wantType, f.ResourceType)
+			assert.Equal(t, tt.wantQty, f.Count)
+
+			// The invariant the pairing exists to hold: never the normalized
+			// SKU counted by the un-normalized quantity.
+			if f.ResourceType == normalized {
+				assert.NotEqual(t, actualQty, f.Count,
+					"normalized size %q must never carry the un-normalized count %d (issue #1540)",
+					normalized, actualQty)
+			}
+		})
+	}
+}
+
+// TestExtract_LegacyNormalizedSizeWithoutNormalizedQuantityLeavesCountUnset
+// pins the one state with no valid pairing. Borrowing RecommendedQuantity here
+// would reintroduce exactly the mismatch #1540 is about, so the count is left
+// at zero, which every service's `Count <= 0` guard refuses before purchasing.
+func TestExtract_LegacyNormalizedSizeWithoutNormalizedQuantityLeavesCountUnset(t *testing.T) {
+	rec := mocks.BuildLegacyReservationRecommendation(
+		mocks.WithNormalizedSize("Standard_D2s_v3"),
+		mocks.WithQuantity(4),
+		mocks.WithoutNormalizedQuantity(),
+	)
+	f := Extract(rec)
+	require.NotNil(t, f)
+	assert.Equal(t, "Standard_D2s_v3", f.ResourceType)
+	assert.Equal(t, 0, f.Count,
+		"an unpairable count must be left unset, not borrowed from RecommendedQuantity")
 }
 
 func TestExtract_MissingCostsReadAsZero(t *testing.T) {
@@ -228,24 +337,37 @@ func TestExtract_Modern_RegionFallsBackToInnerProperties(t *testing.T) {
 
 func TestExtract_Modern_ResourceTypePrefersSKUNameOverNormalizedSize(t *testing.T) {
 	// Both populated — Modern's top-level SKUName wins over NormalizedSize
-	// (matches the Modern field-preference documented in resolveModernResourceType).
+	// (matches the Modern field-preference documented in
+	// resolveModernSKUAndQuantity), and is counted by RecommendedQuantity.
 	rec := mocks.BuildModernReservationRecommendation(
 		mocks.WithModernSKUName("Standard_E4s_v5"),
 		mocks.WithModernNormalizedSize("Standard_D2"),
+		mocks.WithModernQuantity(4),
+		mocks.WithModernNormalizedQuantity(16),
 	)
 	f := Extract(rec)
 	require.NotNil(t, f)
 	assert.Equal(t, "Standard_E4s_v5", f.ResourceType)
+	assert.Equal(t, 4, f.Count,
+		"the actual SKU is counted by RecommendedQuantity; this is the rung real MCA payloads take")
 }
 
-func TestExtract_Modern_ResourceTypeFallsBackToNormalizedSize(t *testing.T) {
-	// No SKUName — should fall back to NormalizedSize (second preference).
+// TestExtract_Modern_NormalizedSizeRungIsCountedNormalized covers the one
+// Modern rung that had #1540's mismatch. Modern was not the reported instance
+// -- real MCA payloads carry SKUName and take the first rung, asserted above --
+// but with SKUName absent it paired NormalizedSize with RecommendedQuantity
+// just as Legacy did.
+func TestExtract_Modern_NormalizedSizeRungIsCountedNormalized(t *testing.T) {
 	rec := mocks.BuildModernReservationRecommendation(
 		mocks.WithModernNormalizedSize("Standard_D2"),
+		mocks.WithModernQuantity(4),
+		mocks.WithModernNormalizedQuantity(16),
 	)
 	f := Extract(rec)
 	require.NotNil(t, f)
 	assert.Equal(t, "Standard_D2", f.ResourceType)
+	assert.Equal(t, 16, f.Count,
+		"the normalized size must be counted by RecommendedQuantityNormalized")
 }
 
 func TestExtract_Modern_MissingCostAmountsReadAsZero(t *testing.T) {

--- a/providers/azure/mocks/recommendation_fixtures.go
+++ b/providers/azure/mocks/recommendation_fixtures.go
@@ -25,10 +25,13 @@ func BuildLegacyReservationRecommendation(opts ...LegacyOpt) *armconsumption.Leg
 	term := "P1Y"
 	qty := float64(1)
 
+	normQty := float32(qty)
+
 	props := &armconsumption.LegacyReservationRecommendationProperties{
-		Scope:               &scope,
-		Term:                &term,
-		RecommendedQuantity: &qty,
+		Scope:                         &scope,
+		Term:                          &term,
+		RecommendedQuantity:           &qty,
+		RecommendedQuantityNormalized: &normQty,
 	}
 	rec := &armconsumption.LegacyReservationRecommendation{
 		Location:   &location,
@@ -67,15 +70,45 @@ func WithTerm(term string) LegacyOpt {
 	}
 }
 
-// WithQuantity overrides RecommendedQuantity. Use float values (e.g. 0.5,
-// 2.7) to cover the float→int truncation contract.
+// WithQuantity overrides BOTH recommended quantities, modeling the common
+// case where the recommended SKU is already the family's base size so the
+// normalized and un-normalized counts agree. Use float values (e.g. 0.5, 2.7)
+// to cover the float→int truncation contract.
+//
+// Setting both matters because the converter pairs each resource-type source
+// with the quantity expressed in that source's units (issue #1540): a fixture
+// that set only RecommendedQuantity while naming a NormalizedSize would
+// describe a payload with no valid pairing. Use WithNormalizedQuantity to make
+// the two differ deliberately.
 func WithQuantity(qty float64) LegacyOpt {
 	return func(_ *armconsumption.LegacyReservationRecommendation, props *armconsumption.LegacyReservationRecommendationProperties) {
+		normQty := float32(qty)
 		props.RecommendedQuantity = &qty
+		props.RecommendedQuantityNormalized = &normQty
 	}
 }
 
-// WithNormalizedSize populates the preferred ResourceType source.
+// WithNormalizedQuantity overrides RecommendedQuantityNormalized alone, so a
+// test can express the real shape the normalization ratio produces: e.g.
+// 4 x Standard_D8s_v3 recommended, 16 x Standard_D2s_v3 normalized. Pass it
+// after WithQuantity, which sets both.
+func WithNormalizedQuantity(qty float32) LegacyOpt {
+	return func(_ *armconsumption.LegacyReservationRecommendation, props *armconsumption.LegacyReservationRecommendationProperties) {
+		props.RecommendedQuantityNormalized = &qty
+	}
+}
+
+// WithoutNormalizedQuantity clears RecommendedQuantityNormalized, modeling a
+// payload that names a NormalizedSize but gives no count in its units.
+func WithoutNormalizedQuantity() LegacyOpt {
+	return func(_ *armconsumption.LegacyReservationRecommendation, props *armconsumption.LegacyReservationRecommendationProperties) {
+		props.RecommendedQuantityNormalized = nil
+	}
+}
+
+// WithNormalizedSize populates NormalizedSize, the ResourceType source used
+// when no SKU property names the actual SKU. It is counted by
+// RecommendedQuantityNormalized, not RecommendedQuantity (issue #1540).
 func WithNormalizedSize(size string) LegacyOpt {
 	return func(_ *armconsumption.LegacyReservationRecommendation, props *armconsumption.LegacyReservationRecommendationProperties) {
 		props.NormalizedSize = &size
@@ -83,8 +116,8 @@ func WithNormalizedSize(size string) LegacyOpt {
 }
 
 // WithSKU is a convenience that seeds SKUProperties with a single
-// `{Name: "SKUName", Value: sku}` entry — the fallback path the converter
-// uses when NormalizedSize is unset.
+// `{Name: "SKUName", Value: sku}` entry — the actual SKU, which the converter
+// prefers over NormalizedSize because RecommendedQuantity counts it.
 func WithSKU(sku string) LegacyOpt {
 	return func(_ *armconsumption.LegacyReservationRecommendation, props *armconsumption.LegacyReservationRecommendationProperties) {
 		name := "SKUName"
@@ -144,10 +177,13 @@ func BuildModernReservationRecommendation(opts ...ModernOpt) *armconsumption.Mod
 	term := "P1Y"
 	qty := float64(1)
 
+	normQty := float32(qty)
+
 	props := &armconsumption.ModernReservationRecommendationProperties{
-		Scope:               &scope,
-		Term:                &term,
-		RecommendedQuantity: &qty,
+		Scope:                         &scope,
+		Term:                          &term,
+		RecommendedQuantity:           &qty,
+		RecommendedQuantityNormalized: &normQty,
 	}
 	rec := &armconsumption.ModernReservationRecommendation{
 		Location:   &location,
@@ -195,10 +231,23 @@ func WithModernTerm(term string) ModernOpt {
 	}
 }
 
-// WithModernQuantity overrides RecommendedQuantity.
+// WithModernQuantity overrides BOTH recommended quantities, for the same
+// reason as the Legacy WithQuantity: the converter pairs each resource-type
+// source with the quantity in that source's units (issue #1540).
 func WithModernQuantity(qty float64) ModernOpt {
 	return func(_ *armconsumption.ModernReservationRecommendation, props *armconsumption.ModernReservationRecommendationProperties) {
+		normQty := float32(qty)
 		props.RecommendedQuantity = &qty
+		props.RecommendedQuantityNormalized = &normQty
+	}
+}
+
+// WithModernNormalizedQuantity overrides RecommendedQuantityNormalized alone,
+// so a test can make the normalized and un-normalized counts differ. Pass it
+// after WithModernQuantity, which sets both.
+func WithModernNormalizedQuantity(qty float32) ModernOpt {
+	return func(_ *armconsumption.ModernReservationRecommendation, props *armconsumption.ModernReservationRecommendationProperties) {
+		props.RecommendedQuantityNormalized = &qty
 	}
 }
 
@@ -211,7 +260,8 @@ func WithModernSKUName(sku string) ModernOpt {
 }
 
 // WithModernNormalizedSize populates NormalizedSize (second-preference
-// source for ResourceType on Modern).
+// source for ResourceType on Modern). Counted by
+// RecommendedQuantityNormalized, not RecommendedQuantity (issue #1540).
 func WithModernNormalizedSize(size string) ModernOpt {
 	return func(_ *armconsumption.ModernReservationRecommendation, props *armconsumption.ModernReservationRecommendationProperties) {
 		props.NormalizedSize = &size

--- a/providers/azure/services/compute/client_test.go
+++ b/providers/azure/services/compute/client_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -1496,4 +1497,89 @@ func TestComputeClient_PurchaseCommitment_ZeroCountRejected(t *testing.T) {
 	assert.False(t, result.Success)
 	assert.Contains(t, err.Error(), "quantity must be greater than zero")
 	mockHTTP.AssertNotCalled(t, "Do", mock.Anything)
+}
+
+// TestPurchaseBody_SKUAndQuantityStayInMatchingUnits is the downstream half of
+// the issue #1540 regression. The pairing is fixed in the shared converter, but
+// the defect only mattered because it reached the wire: the same fields become
+// `sku.name` and `quantity` on the calculatePrice and purchase requests. A test
+// that only exercised the converter would look right while the bytes Azure
+// receives stayed wrong, which is exactly how the defect survived.
+//
+// Both directions are asserted per case: the SKU that must be sent AND the
+// quantity that must accompany it. Asserting only that the old mismatched pair
+// is gone would pass against a converter that produced nothing.
+func TestPurchaseBody_SKUAndQuantityStayInMatchingUnits(t *testing.T) {
+	// Azure recommends 4 x Standard_D8s_v3, normalized to 16 x Standard_D2s_v3.
+	const (
+		actualSKU  = "Standard_D8s_v3"
+		normalized = "Standard_D2s_v3"
+	)
+
+	tests := []struct {
+		name    string
+		opts    []mocks.LegacyOpt
+		wantSKU string
+		wantQty float64
+	}{
+		{
+			name: "actual SKU present: buys the recommended SKU at the recommended count",
+			opts: []mocks.LegacyOpt{
+				mocks.WithSKU(actualSKU),
+				mocks.WithNormalizedSize(normalized),
+				mocks.WithQuantity(4),
+				mocks.WithNormalizedQuantity(16),
+			},
+			wantSKU: actualSKU,
+			wantQty: 4,
+		},
+		{
+			name: "only the normalized size: buys the normalized SKU at the normalized count",
+			opts: []mocks.LegacyOpt{
+				mocks.WithNormalizedSize(normalized),
+				mocks.WithQuantity(4),
+				mocks.WithNormalizedQuantity(16),
+			},
+			wantSKU: normalized,
+			wantQty: 16,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiRec := mocks.BuildLegacyReservationRecommendation(append(tt.opts,
+				mocks.WithRegion("eastus"),
+				mocks.WithCosts(1000, 600, 400),
+			)...)
+
+			c := &ComputeClient{subscriptionID: "sub-1", region: "eastus"}
+			rec := c.convertAzureVMRecommendation(context.Background(), apiRec)
+			require.NotNil(t, rec)
+
+			body, err := c.buildReservationBody(*rec, armreservations.ReservationBillingPlanUpfront, "test", "tok")
+			require.NoError(t, err)
+
+			var payload struct {
+				SKU struct {
+					Name string `json:"name"`
+				} `json:"sku"`
+				Properties struct {
+					Quantity float64 `json:"quantity"`
+				} `json:"properties"`
+			}
+			require.NoError(t, json.Unmarshal(body, &payload))
+
+			assert.Equal(t, tt.wantSKU, payload.SKU.Name,
+				"sku.name is what Azure reserves")
+			assert.Equal(t, tt.wantQty, payload.Properties.Quantity,
+				"quantity must be expressed in units of sku.name, never the other size's count (issue #1540)")
+
+			// The specific mismatch #1540 shipped: the normalized (smaller) SKU
+			// carrying the un-normalized count, i.e. a quarter of the capacity.
+			if payload.SKU.Name == normalized {
+				assert.NotEqual(t, float64(4), payload.Properties.Quantity,
+					"normalized SKU %q must never be bought at the un-normalized count", normalized)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Closes #1540

## The defect

Azure's consumption API carries **two** quantities on a reservation recommendation and they are not interchangeable:

| field | counts |
|---|---|
| `RecommendedQuantity` | the **actual** SKU (`SKUProperties[SKUName]`) |
| `RecommendedQuantityNormalized` | `NormalizedSize` |

`ResourceType` and `Count` were resolved independently, so the Legacy/EA ladder took its SKU from `NormalizedSize` while the count came from `RecommendedQuantity`. Azure recommending **4 × `Standard_D8s_v3`**, normalized to **16 × `Standard_D2s_v3`**, became `Standard_D2s_v3` × **4** — a quarter of the recommended capacity.

`RecommendedQuantityNormalized` appeared **nowhere in the repo** before this change. The field was never read, so no path produced the correct pair.

## It reaches a purchase, not a display

Carried through the compute converter into `buildReservationBody`, these are the bytes sent to `calculatePrice` and `purchase`:

```json
{"sku":{"name":"Standard_D2s_v3"},
 "properties":{"quantity":4,"term":"P1Y","reservedResourceType":"VirtualMachines", ...}}
```

Azure has no reason to reject it: `Standard_D2s_v3` is a real SKU and `4` is a valid quantity. The purchase succeeds and the customer is committed for the term. The only quantity guard anywhere on the path is `rec.Count <= 0`; nothing validated that the SKU and the count were in the same units.

And the money figures ride along unchanged — same run:

```
common.Recommendation: ResourceType="Standard_D2s_v3" Count=4
                       OnDemandCost=1000 CommitmentCost=600 EstimatedSavings=400
```

`EstimatedSavings` is Azure's number for the **full** recommended quantity — the converter says so itself (`NetSavings is the savings from buying the full recommended quantity`). So $400/mo was reported against a purchase delivering roughly a quarter of it.

## Direction

**Under-buy — fails safe on commitment risk, unsafe on reported savings.**

Nobody is locked into capacity they cannot use; that is the worse direction and it does not happen here. But the savings figure shown to whoever approves the purchase is wrong. **A decision-quality defect rather than a spend defect** — which is why "wrong purchases" would overstate it and "display only" would understate it.

Strictly, the direction is decided by Azure's data rather than by the code: under-buy iff `NormalizedSize` ≤ the actual SKU. The `armconsumption@v1.1.0` doc comments are terse ("The recommended Quantity Normalized") and never state units, so that half rests on Azure's documented normalize-to-base-size behaviour. In-repo corroboration: all 34 Legacy fixture call sites treat `NormalizedSize` as the base size — `Standard_D2s_v3`, `GeneralPurpose_Gen5_2`, `100RU`, `DW500c`, `Premium_P1`.

## Scope — wider than the issue states

The issue cites one example consumer. It is **seven** services, all through the one shared `recommendations.Extract`:

`compute`, `cache`, `cosmosdb`, `database`, `managedredis`, `search`, `synapse`.

`Count` also feeds **provider-agnostic** logic in `cmd/helpers.go`, which the issue does not mention: `applySizing`/`ApplyCoverage` scale by `newCount / rec.Count`, `ApplyTargetCoverage` anchors on it, `--max-instances` clamps on it, and the duplicate checker compares `existingCount >= rec.Count` and subtracts. None of that is gated on provider, so the wrong count reached sizing math and duplicate suppression as well as the purchase body.

## The fix

`ResourceType` and `Count` are now resolved **together**, so no branch can emit a mixed pair.

- **The actual SKU is preferred**, matching the Modern ladder, so EA and MCA subscriptions with identical usage yield the same `ResourceType`. Its partner `RecommendedQuantity` is also the `*float64` field, avoiding a `*float32` rounding question on a purchase path.
- **When only `NormalizedSize` is available**, its normalized count is the only valid partner.
- **When that partner is absent**, the count is left unset rather than borrowed from `RecommendedQuantity` — an unpaired count is precisely the defect above. Zero is refused by the `Count <= 0` guard every service applies before purchasing, and a warning is logged. (Note there is no empty-`ResourceType` guard anywhere in `providers/azure`, so blanking the type instead would have put an empty `sku.name` on the wire.)
- **A payload with no resource type from either source keeps its previous behaviour** — there is no normalized size for the count to disagree with, so the pairing fix leaves that degenerate case alone.

### Behaviour change worth calling out explicitly

**This changes what gets purchased for EA customers.** The purchased SKU moves from the normalized size to the actual size for every Legacy recommendation carrying both fields — which is the common real-world payload shape. That is the point of the fix, but it is a real change and should not pass unnoticed.

### Modern was extended too — a correction to my own earlier assessment

I reported during investigation that Modern/MCA was unaffected. That is true of the rung real MCA payloads take (`SKUName` present), and this PR leaves that rung byte-identical — pinned by `TestExtract_Modern_ResourceTypePrefersSKUNameOverNormalizedSize`.

But while editing I found that with `SKUName` absent, Modern's `NormalizedSize` rung mixed the same two fields exactly as Legacy did. Fixing Legacy alone would have left one branch of the same function still able to emit mismatched units on a money path, so it is paired here rather than deferred. Flagging it as a deliberate, named extension rather than something slipped in.

## Tests — both directions, plus a downstream consumer

A test asserting only that the bad pairing is gone passes against a converter that produces nothing, so every case asserts the SKU **and** the quantity that must accompany it.

- `TestExtract_LegacySKUAndQuantityStayInMatchingUnits` — three payload shapes; each valid pair must still be produced.
- `TestExtract_LegacyNormalizedSizeWithoutNormalizedQuantityLeavesCountUnset` — the one state with no valid pairing.
- `TestExtract_Modern_NormalizedSizeRungIsCountedNormalized` and the `SKUName`-rung test above.
- `TestPurchaseBody_SKUAndQuantityStayInMatchingUnits` (`services/compute`) — the **downstream** half. The pairing is fixed in the shared converter, but the defect only mattered because it reached the wire; this parses the actual request body and asserts `sku.name` and `quantity` together. A converter-only test would have looked right while the bytes Azure receives stayed wrong, which is how the defect survived.

### Mutation-tested

Five mutations, each reverting one property of the fix. Every one is killed by a **named** test:

| mutation | killed by |
|---|---|
| M1 — original bug restored (`NormalizedSize` + un-normalized count) | 3 converter tests **and** both downstream cases |
| M2 — normalized rung counted by `RecommendedQuantity` | 2 converter tests |
| M3 — unpaired count borrowed from `RecommendedQuantity` | the unset-count test |
| M4 — Modern normalized rung counted by `RecommendedQuantity` | the Modern rung test |
| M5 — legacy pairing returns nothing at all | 3 converter tests |

M5 is the trap this design exists to avoid, and M1 shows the downstream test reporting the exact wrong wire values:

```
expected: "Standard_D8s_v3"   actual: "Standard_D2s_v3"   (sku.name is what Azure reserves)
expected: 16                  actual: 4                   (quantity must be expressed in units of sku.name)
```

## Fixtures

The Legacy and Modern builders now set **both** quantities, and `WithQuantity` / `WithModernQuantity` set both: a fixture naming a `NormalizedSize` while setting only `RecommendedQuantity` describes a payload with no valid pairing. `WithNormalizedQuantity` / `WithModernNormalizedQuantity` make them differ deliberately, and `WithoutNormalizedQuantity` models the unpairable payload. All 34 pre-existing Legacy fixture call sites are unchanged and still pass.

## Gates

| gate | result |
|---|---|
| `gofmt -l .` | clean (0 files) |
| `providers/azure`: `go build ./...` + `go vet ./...` + `go test -race -count=1 ./...` | exit 0 — 12 ok, 0 FAIL |
| `gocyclo -over 10 -ignore "_test\.go"` (root and `providers/azure`) | exit 0, empty |
| `golangci-lint` v2.10.1 on `providers/azure`, **`comm` set diff vs base** | **592 both sides; zero new, zero removed** |

The set diff earned itself: the first pass came back 592 → 597, and the diff named all five as mine — one `behaviour` misspell, two `modelling` misspells, and two `unnamedResult` from the new two-value returns. All fixed; the re-run is identical to base on both the untouched files (540 = 540, exact line-preserving `comm`) and the touched ones (by file+message, since my edits shift line numbers).

Both golangci runs initially exited **3 with zero findings** — `Error: parallel golangci-lint is running`. That reads exactly like a clean run and was retried rather than trusted.

**`main` is currently red** on `TestGrantCeiling_ConstraintContainment` (`internal/auth`), from #1737 and #1758 colliding — confirmed failing at this branch's base commit, unrelated to this diff and untouched by it. This PR's CI will inherit it until that fix lands.
