### PR TITLE
fix(test): stop using a carved-out verb as a generic ceiling fixture

### DIFF
--- a/internal/auth/group_ceiling_permissions_test.go
+++ b/internal/auth/group_ceiling_permissions_test.go
@@ -216,14 +216,29 @@ func TestGrantCeiling_InCeilingUpdateSucceeds(t *testing.T) {
 
 // TestGrantCeiling_ConstraintContainment: a constrained holder may hand out a
 // narrower grant but not a broader one.
+//
+// The fixture verb is deliberately NOT one of adminCarvedOuts: this test
+// exercises the general containment logic in grantCeilingAllows, which
+// checkGrantCeiling only reaches for a pair the carve-out check lets through.
+// A carved-out verb refuses unconditionally before containment is ever
+// evaluated (see TestGrantCeiling_CarvedOutNotGrantable), which is exactly
+// what happened here when this test used execute:ri-exchange as its fixture:
+// PR #1758 carved that pair out and every subtest below started failing for
+// the wrong reason. The assertion below fails loudly, at the fixture, if a
+// future carve-out addition collides with this verb again.
 func TestGrantCeiling_ConstraintContainment(t *testing.T) {
 	ctx := context.Background()
+
+	const fixtureAction, fixtureResource = ActionView, ResourcePlans
+	require.False(t, adminCarvedOuts[[2]string{fixtureAction, fixtureResource}],
+		"fixture verb %s:%s must not be carved out, or the carve-out check "+
+			"refuses before this test's containment logic ever runs", fixtureAction, fixtureResource)
 
 	held := []Permission{
 		{Action: ActionUpdate, Resource: ResourceGroups},
 		{
-			Action:   ActionExecute,
-			Resource: ResourceRIExchange,
+			Action:   fixtureAction,
+			Resource: fixtureResource,
 			Constraints: &PermissionConstraints{
 				Providers:         []string{"aws"},
 				MaxPurchaseAmount: 100,
@@ -242,8 +257,8 @@ func TestGrantCeiling_ConstraintContainment(t *testing.T) {
 
 		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
 			updateReqWith(APIPermission{
-				Action:   ActionExecute,
-				Resource: ResourceRIExchange,
+				Action:   fixtureAction,
+				Resource: fixtureResource,
 				Constraints: &APIPermissionConstraint{
 					Providers: []string{"aws"},
 					MaxAmount: 50,
@@ -261,7 +276,7 @@ func TestGrantCeiling_ConstraintContainment(t *testing.T) {
 		stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
 
 		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
-			updateReqWith(APIPermission{Action: ActionExecute, Resource: ResourceRIExchange}))
+			updateReqWith(APIPermission{Action: fixtureAction, Resource: fixtureResource}))
 
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrPermissionCeiling)
@@ -278,8 +293,8 @@ func TestGrantCeiling_ConstraintContainment(t *testing.T) {
 
 		_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID,
 			updateReqWith(APIPermission{
-				Action:   ActionExecute,
-				Resource: ResourceRIExchange,
+				Action:   fixtureAction,
+				Resource: fixtureResource,
 				Constraints: &APIPermissionConstraint{
 					Providers: []string{"aws", "azure"},
 					MaxAmount: 50,


### PR DESCRIPTION
## Summary

`main` is red: `TestGrantCeiling_ConstraintContainment` in `internal/auth/group_ceiling_permissions_test.go` fails (3 subtests + parent), blocking CI on every open PR.

**Root cause: an emergent conflict between two independently-green PRs, not a logic bug.**

- The test uses `execute:ri-exchange` as its fixture verb to exercise *general* grant-ceiling constraint containment (narrower grant allowed / cap-drop refused / unheld-provider-add refused), against a target group with an **empty** existing-permissions list.
- #1758 then added `{ActionExecute, ResourceRIExchange}` to `adminCarvedOuts`.
- `checkGrantCeiling` (`internal/auth/group_ceiling.go:73-96`) checks `adminCarvedOuts` **before** the containment logic in `grantCeilingAllows`. Once the fixture's verb became carved out, and the target group didn't already hold it, every subtest hit the unconditional carve-out refusal (`ErrPermissionNotGrantable`) before the containment logic it exists to test ever ran.

Both #1737 (grant ceiling) and #1758 (RI-exchange carve-out) are correct in isolation. Neither is at fault; the merge sequencing created a stale fixture.

## Fix

Test-only. Swapped the fixture verb from `execute:ri-exchange` to `view:plans` (already used elsewhere in the same file, not a carved-out pair) and hoisted it to named constants with an assertion that the verb is not in `adminCarvedOuts`, so the next carve-out addition that collides with a generic fixture fails loudly *at the fixture* instead of three subtests dying somewhere that looks unrelated.

`checkGrantCeiling`'s carve-out-before-containment ordering is **untouched** -- verified `git diff 7c4e8405c origin/main -- internal/auth/group_ceiling.go` is empty, so the squash-merge did not alter it. That ordering is correct and deliberate (issue #923 separation of duties): a carved-out verb must refuse unconditionally regardless of what containment logic would otherwise allow.

## Sweep for latent occurrences of the same defect

`adminCarvedOuts` currently holds four pairs: `{execute,purchases}`, `{approve-any,purchases}`, `{retry-any,purchases}`, `{execute,ri-exchange}`. Searched every construction of a `Permission`/`APIPermission` value across `internal/auth` and the rest of the repo for a carved-out pair used as a **generic** fixture (as opposed to a test that is deliberately *about* carve-out behavior).

**Fixed:** `TestGrantCeiling_ConstraintContainment` (this PR).

**Inspected and deliberately left alone** (each uses a carved-out pair on purpose, to test the carve-out itself):
- `internal/auth/group_ceiling_permissions_test.go`: `TestGrantCeiling_CarvedOutNotGrantable`, `TestGrantCeiling_CarvedOutNotGrantableByPurchaserAdmin`, `TestGrantCeiling_CarvedOutMayBeKeptNotWidened` -- the #1550 attack scenarios.
- `internal/auth/group_system_managed_test.go`: `TestSystemManagedGroup_Immutable`.
- `internal/auth/self_escalation_carveout_test.go`: all `TestSelfCarvedOutGrant_*` tests.
- `internal/auth/service_group_only_authz_test.go`: `TestGroupOnlyAuthz_AdminEquivalence`, `TestGroupOnlyAuthz_NonAdminDenied` -- admin-wildcard-vs-carve-out coverage.
- `internal/auth/service_group_test.go`: `TestHasPermission_RegionConstraintDeniesUnpermittedTargetRegion` -- RI-exchange region-matching, calls `HasPermission` directly, not the ceiling.
- `internal/auth/types_test.go`: `adminCarvedOuts` / `HasPermission` coverage.
- `internal/api/grantadmin_carveout_test.go`, `internal/api/ri_exchange_carveout_test.go`: handler-level carve-out enforcement tests.
- `internal/database/postgres/migrations/000096_seed_ri_exchanger_group_test.go`: the seeded-group migration test.

None of these are affected, today or on a future carve-out addition, because their subject *is* carve-out behavior.

`internal/auth/group_ceiling_validation_test.go` was also checked -- it only uses `ActionView`/blank fields, no carved-out pairs.

## Verification

- `go test ./internal/auth/...` -- 735 passed (was 4 failing, now 0).
- `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` -- clean.
- `go vet -tags=e2e ./...` in `tests/e2e` -- clean.
- `go test -race -short ./...` in `.`, `pkg`, `providers/aws`, `providers/azure`, `providers/gcp` -- all green.
- `gocyclo -over 10 -ignore "_test\.go" .` -- 0 findings.
- `golangci-lint run` at CI-pinned **v2.10.1** -- exit 0 and a genuine `0 issues.` line (not just exit 0, per the known v2 false-clean modes on a removed flag / concurrent-run lock).

## Test plan

- [x] `internal/auth` full package green
- [x] Six-module build/vet/test gate green
- [x] gocyclo clean
- [x] golangci-lint v2.10.1 clean (genuine `0 issues.`)
