### PR TITLE
docs(azure): correct two retry comments that #1767 made false

### DIFF
--- a/providers/azure/services/internal/reservations/purchase.go
+++ b/providers/azure/services/internal/reservations/purchase.go
@@ -261,10 +261,17 @@ const (
 // DoPurchaseTwoStep executes the calculatePrice->purchase two-step flow.
 //
 // It POSTs bodyBytes to calculateURL to mint an Azure-assigned reservationOrderId,
-// then POSTs the same body to the derived purchaseURL. On a "Session timed out"
-// 400 from the purchase endpoint (Azure has retired the session) it re-runs
-// calculatePrice from scratch (up to purchaseMaxAttempts total attempts).
-// Other 4xx/5xx errors are returned immediately without retry.
+// then POSTs the same body to the derived purchaseURL. It re-runs calculatePrice
+// from scratch (up to purchaseMaxAttempts total attempts) in exactly two cases:
+//
+//  1. a "Session timed out" 400 from the purchase endpoint, meaning Azure has
+//     retired the session; and
+//  2. a 400 whose response body did not read completely, where case 1 cannot be
+//     ruled out because the fragment it matches on may be in the part that never
+//     arrived (see errRetryabilityUnknown).
+//
+// Every other response, including a cleanly read 4xx or any 5xx, is returned
+// immediately without retry.
 //
 // Returns the Azure-minted reservationOrderId on success, which the caller
 // should store as the CommitmentID.

--- a/providers/azure/services/internal/reservations/purchase_test.go
+++ b/providers/azure/services/internal/reservations/purchase_test.go
@@ -833,17 +833,23 @@ func (b *truncatingBody) Close() error { return nil }
 // TestDoPurchase_UnreadableBodyDoesNotSilentlyLookPermanent is the regression
 // test for the retry-classification defect.
 //
-// doPurchase's error text is the ONLY input to IsSessionTimeout, and
-// DoPurchaseTwoStep retries only when that predicate matches. When the read
-// error was discarded, a 400 whose body was truncated before the
-// "Session timed out" fragment produced a bare `status 400: <partial>` error.
-// IsSessionTimeout then returned false and the purchase was abandoned on its
-// first attempt — the precise condition purchaseMaxAttempts exists to survive —
-// with no indication that anything had gone wrong reading the response.
+// Current rule: DoPurchaseTwoStep retries when IsSessionTimeout matches the
+// error text, OR when the error carries errRetryabilityUnknown — which
+// doPurchase attaches to a 400 whose body did not read completely, and to
+// nothing else. Retryability is no longer inferred solely from text.
 //
-// The fix must not classify retryability from a body that was never fully
-// received. Pre-fix this test fails: the error carries neither the read failure
-// nor the session-timeout fragment, so both assertions below are false.
+// Why the test exists (pre-fix behavior): the error text was once the only
+// input to IsSessionTimeout, and that predicate the only retry trigger. With
+// the read error discarded, a 400 truncated before the "Session timed out"
+// fragment produced a bare `status 400: <partial>`; IsSessionTimeout returned
+// false and the purchase was abandoned on its first attempt — the precise
+// condition purchaseMaxAttempts exists to survive — with no indication that
+// anything had gone wrong reading the response.
+//
+// This test pins the surfacing and the out-of-band tag. The retry decision
+// itself is pinned by TestDoPurchaseTwoStep_TruncatedSessionTimeoutStillRetries,
+// which counts attempts, because a message assertion cannot tell a changed
+// message from changed behavior.
 func TestDoPurchase_UnreadableBodyDoesNotSilentlyLookPermanent(t *testing.T) {
 	ctx := context.Background()
 	full := `{"error":{"code":"BadRequest","message":"Session timed out - Call CalculatePrice again"}}`


### PR DESCRIPTION
Comment-only follow-up to #1767, which merged (`d6e60f637`) before these two fixes landed. No behavior change; the lint set diff is byte-identical to `main`.

## What was wrong

Both comments make **exhaustiveness claims** that stopped being true when #1767 added a second retry trigger.

**1. `purchase_test.go` — flagged by CodeRabbit on #1767, unfixed at merge time:**

```go
// doPurchase's error text is the ONLY input to IsSessionTimeout, and
// DoPurchaseTwoStep retries only when that predicate matches.
```

Neither half holds. The loop also retries on `errors.Is(err, errRetryabilityUnknown)`.

**2. `DoPurchaseTwoStep`'s own doc — nobody flagged this one:**

```go
// On a "Session timed out" 400 from the purchase endpoint (Azure has retired
// the session) it re-runs calculatePrice from scratch (up to
// purchaseMaxAttempts total attempts).
// Other 4xx/5xx errors are returned immediately without retry.
```

That omits the second trigger entirely, in the production doc a caller reads to decide whether a failure will be retried. Found by sweeping the whole #1767 diff for the same class rather than fixing only the reported line.

## What they say now

Each leads with the **current** rule and keeps the pre-fix explanation marked as the reason the test exists, rather than past-tensing the old text into history. A reader who stops after the first paragraph should come away with something true.

`DoPurchaseTwoStep` now enumerates both retry cases and states plainly that everything else — including a cleanly read 4xx and any 5xx — returns without retry.

## Why this is worth its own PR

Exhaustiveness claims are what readers rely on to decide they do not need to check, so a stale one is worse than no comment. In this repo that class has already cost real defects: **#1757**, a live CSRF hole, survived behind a parity claim that was not true, and **#1764**'s `getAccountScope` godoc described the inverse of its behavior after a change.

#1767 spent two review rounds removing an assertion that read as a guarantee it did not provide. Leaving comments that read as guarantees they no longer provide is the same defect in prose.

## Gates

`providers/azure`: gofmt clean, build, vet, `go test -race -count=1 ./...` green. Root: build, vet, `gocyclo -over 10 -ignore "_test\.go" .` exit 0 empty, `golangci-lint` v2.10.1 **exit 0 with a genuine `0 issues.` line** (both asserted).

`providers/azure` lint set diff vs `main`: **589 vs 589, zero only-in-HEAD, zero only-in-BASE** — byte-identical, as a comment-only change should be.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of purchase requests when a 400 response body cannot be read, allowing eligible requests to be retried.
  * Preserved non-retryable behavior for clearly readable 4xx responses and all 5xx responses.
  * Improved retry decisions by relying on response context rather than error message text alone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->