### PR TITLE
fix(ci/azure): name the missing bootstrap stack when the role lookup fails

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -243,14 +243,19 @@ jobs:
       - name: Explain a missing bootstrap role
         if: failure()
         run: |
-          # Both logs: the data source is read at plan time as well as apply, so a
-          # missing role can surface in either step depending on state freshness.
+          # Both logs are checked. Today the role lookup is deferred to apply --
+          # the plan reports "will be read during apply (config refers to values
+          # not yet known)" -- because of the module-level depends_on at
+          # terraform/environments/azure/compute.tf:75. That is contingent, not
+          # structural: if that stops forcing deferral the read moves to plan, and
+          # the diagnostic should not have to move with it.
           #
-          # Each file is grepped separately rather than passing both to one grep.
-          # With multiple operands where one does not exist, grep's exit status is
-          # implementation-defined: GNU returns 0 when -q matched an earlier file,
-          # BSD returns 2. Either log may legitimately be absent when an earlier
-          # step failed first, so the combined form would go silent on some hosts.
+          # Each file is checked separately so that "this log does not exist" is an
+          # explicit, expected case at the point of reading -- either log is absent
+          # when an earlier step failed first. Passing both to one grep would also
+          # work (POSIX: -q exits 0 if a line is selected, and the only combinations
+          # returning 2 are those with no match anywhere, where silence is wanted),
+          # but it leaves that reasoning implicit.
           found=0
           for log in "${RUNNER_TEMP}/tf-plan.log" "${RUNNER_TEMP}/tf-apply.log"; do
             [ -f "$log" ] || continue

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -164,11 +164,15 @@ jobs:
           TF_VAR_admin_email: ${{ secrets.ADMIN_EMAIL }}
           TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         run: |
+          # pipefail for the same reason as the apply step below: the default
+          # shell is `bash -e`, where a pipeline takes tee's exit status and a
+          # failed plan would be reported as success.
+          set -o pipefail
           cd terraform/environments/azure
           terraform plan \
             -var-file="github-${{ needs.prepare.outputs.environment }}.tfvars" \
             -var="location=${{ env.AZURE_LOCATION }}" \
-            -out=tfplan
+            -out=tfplan 2>&1 | tee "${RUNNER_TEMP}/tf-plan.log"
 
 
       - name: Wait for resource group deletion to complete
@@ -239,9 +243,23 @@ jobs:
       - name: Explain a missing bootstrap role
         if: failure()
         run: |
-          if ! grep -qiE 'could not find role|Role Definition .* was not found' "${RUNNER_TEMP}/tf-apply.log" 2>/dev/null; then
-            exit 0
-          fi
+          # Both logs: the data source is read at plan time as well as apply, so a
+          # missing role can surface in either step depending on state freshness.
+          #
+          # Each file is grepped separately rather than passing both to one grep.
+          # With multiple operands where one does not exist, grep's exit status is
+          # implementation-defined: GNU returns 0 when -q matched an earlier file,
+          # BSD returns 2. Either log may legitimately be absent when an earlier
+          # step failed first, so the combined form would go silent on some hosts.
+          found=0
+          for log in "${RUNNER_TEMP}/tf-plan.log" "${RUNNER_TEMP}/tf-apply.log"; do
+            [ -f "$log" ] || continue
+            if grep -qiE 'could not find role|Role Definition .* was not found' "$log"; then
+              found=1
+              break
+            fi
+          done
+          [ "$found" -eq 1 ] || exit 0
           cat >&2 <<'EOT'
           ::error title=Missing bootstrap role::The custom reservation-purchaser role does not exist in this subscription.
 

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -217,8 +217,11 @@ jobs:
           TF_VAR_admin_email: ${{ secrets.ADMIN_EMAIL }}
           TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         run: |
+          # pipefail is required: the default shell is `bash -e`, where a pipeline
+          # takes tee's exit status and a failed apply would be reported as success.
+          set -o pipefail
           cd terraform/environments/azure
-          terraform apply -auto-approve tfplan
+          terraform apply -auto-approve tfplan 2>&1 | tee "${RUNNER_TEMP}/tf-apply.log"
 
           # Get app URL
           APP_URL=$(terraform output -raw container_app_url 2>/dev/null | grep -v '::' || echo "")
@@ -227,6 +230,37 @@ jobs:
           # Get app name
           APP_NAME=$(terraform output -raw container_app_name 2>/dev/null | grep -v '::' || echo "")
           echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
+
+      # The provider fails the data read outright when the custom role is absent,
+      # so a Terraform precondition can never run for this case. Issue #1794: the
+      # Azure deploy failed on every main run for three weeks because the raw
+      # provider error names neither the missing prerequisite nor the stack that
+      # creates it, and the explanation lived only in a source comment.
+      - name: Explain a missing bootstrap role
+        if: failure()
+        run: |
+          if ! grep -qiE 'could not find role|Role Definition .* was not found' "${RUNNER_TEMP}/tf-apply.log" 2>/dev/null; then
+            exit 0
+          fi
+          cat >&2 <<'EOT'
+          ::error title=Missing bootstrap role::The custom reservation-purchaser role does not exist in this subscription.
+
+          Apply the bootstrap stack that creates it:
+              terraform/environments/azure/ci-cd-permissions
+
+          Do NOT grant Microsoft.Authorization/roleDefinitions/write to the deploy
+          service principal to work around this. The split is deliberate: this
+          pipeline holds roleAssignments/write only.
+
+          If the bootstrap HAS been applied, check in this order:
+            1. the deploy SP has Microsoft.Authorization/roleDefinitions/read.
+               Without it the lookup returns empty, which is indistinguishable
+               from the role being absent.
+            2. the role was not renamed or deleted out of band.
+            3. the name suffix still matches. The runtime module looks up
+               "CUDly Reservation Purchaser (custom) - <subscription-id>";
+               the bootstrap builds the name from its own var.name_suffix.
+          EOT
 
       - name: Release state lock on failure
         if: failure() || cancelled()

--- a/terraform/modules/compute/azure/container-apps/main.tf
+++ b/terraform/modules/compute/azure/container-apps/main.tf
@@ -278,8 +278,24 @@ resource "azurerm_role_assignment" "subscription_reader" {
 # (re-)applied, this data source fails loudly with "Role Definition ... was not
 # found" -- the signal to re-run the ci-cd-permissions bootstrap, NOT to grant
 # roleDefinitions/write to the deploy SP.
+locals {
+  # Reconstruction of local.role_definition_name from
+  # terraform/modules/iam/azure/cudly-reservation-role. That module's
+  # role_definition_name output cannot be referenced here: it is instantiated in
+  # the ci-cd-permissions stack, which has separate state, and this repo does not
+  # use terraform_remote_state. Keeping the format string in one place per module
+  # is the most the split allows; changing it requires changing both.
+  cudly_reservation_purchaser_role_name = "CUDly Reservation Purchaser (custom) - ${data.azurerm_subscription.current.subscription_id}"
+}
+
+# A lifecycle postcondition deliberately is NOT used here. The azurerm provider
+# fails the data read itself when the role is absent ("loading Role Definition
+# List: could not find role ..."), so Terraform aborts before any postcondition
+# evaluates -- the check would never fire for the failure it was meant to explain.
+# The remediation is surfaced from the workflow's failure path instead; see the
+# "Explain a missing bootstrap role" step in .github/workflows/deploy-azure.yml.
 data "azurerm_role_definition" "cudly_reservation_purchaser" {
-  name  = "CUDly Reservation Purchaser (custom) - ${data.azurerm_subscription.current.subscription_id}"
+  name  = local.cudly_reservation_purchaser_role_name
   scope = data.azurerm_subscription.current.id
 }
 


### PR DESCRIPTION
Refs #1794. **This does not fix the deploy** — the bootstrap stack still has to be applied. It makes the next occurrence self-explaining instead of silent.

## Why three weeks of identical failures produced no action

The Azure deploy has failed on **every** `main` run since 2026-07-19 (0 successes in 100 runs), at Terraform Apply:

```
Error: loading Role Definition List: could not find role
       CUDly Reservation Purchaser (custom) - ***
```

That error names neither the missing prerequisite nor the stack that creates it. The role is created by `terraform/environments/azure/ci-cd-permissions` and consumed by the deploy stack through `data.azurerm_role_definition`. The split is deliberate: creating a role definition needs `Microsoft.Authorization/roleDefinitions/write`, which the deploy service principal intentionally lacks.

The remediation *was* documented — at `container-apps/main.tf:275-280`, in a source comment. That is the right place for someone reading the module and the wrong place for someone reading a failed CI log. Nobody was reading the module.

It also went unnoticed because `CI - Build & Test` is green and has been throughout. Every gate anyone looks at is green; the deploy is a separate workflow that nothing surfaces. Same shape as #1751, where `./...` covered one workspace module of six.

## A Terraform precondition cannot solve this, and I tried it first

My first version added a `lifecycle { postcondition }` to the data source. **It would never have fired.** The provider fails the data *read* when the role is absent, so Terraform aborts before any postcondition evaluates — a guard that cannot fire for the failure it exists to explain.

Caught before pushing, and worth recording since it is the exact defect class this repo has spent #1740/#1750/#1758 removing.

So the remediation is emitted from the workflows failure path, gated on the providers error text.

## The second unfireable guard, also caught

The new step greps `${RUNNER_TEMP}/tf-apply.log` — and nothing was writing that file, so the grep would always miss and the message would never print.

`Terraform Apply` now tees to it. **`set -o pipefail` is required**: the default shell is `bash -e`, where a pipeline takes `tee`s exit status, so a failed apply would have been reported as **success**. Verified both directions:

```
with pipefail:     exit=1   (failure preserved)
without pipefail:  exit=0   (the bug avoided)
```

And the grep verified in both directions too — it matches the real error text, and stays silent on an unrelated Terraform failure.

## What the step prints

The stack to apply, plus an explicit warning **not** to grant `roleDefinitions/write` to the deploy SP as a workaround, and three ordered checks if the bootstrap has already been applied. The first matters most: a deploy SP lacking `Microsoft.Authorization/roleDefinitions/read` sees an **empty list**, not an authorization error — indistinguishable from the role being absent.

## The name duplication, reduced but not removed

The lookup name is hoisted into a named local with the reason recorded. The bootstrap module exports `role_definition_name` for exactly this, but its output cannot be referenced across a stack boundary without `terraform_remote_state`, which this repo does not use anywhere. Introducing it (or a parameter store) would relocate the dependency rather than remove it, and add a second mechanism where the repo has 16 `data` blocks and one pattern.

The dependency itself is structural and cannot be removed: the role needs a privileged stack to create it, while the identity it is assigned to does not exist until the deploy stack runs.

## Verification

- `terraform validate`: **Success**, `terraform fmt` clean
- workflow YAML parses; the new step sits between `Terraform Apply` and `Release state lock on failure`, with `if: failure()`
- no untrusted input in the step (static heredoc, no `github.event.*` interpolation)

Still open on #1794: whether `azurerm_container_app.main` applies before the failure, which decides if three weeks of merged Azure changes are live or not. The cheap way to settle it is comparing the running image tag against `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment failures now retain their correct failure status while producing plan and apply logs for review.
  - Added targeted diagnostics for missing Azure custom-role errors, including guidance on permissions, role setup, bootstrap deployment, and naming issues.
  - Improved role-name handling to provide more reliable infrastructure deployments across split-state environments.

- **Documentation**
  - Clarified role-name handling and troubleshooting guidance for split infrastructure state scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->