### PR TITLE
sec(api): enforce CSRF on the RI-exchange session-authed approve path

### DIFF
--- a/internal/api/handler_ri_exchange.go
+++ b/internal/api/handler_ri_exchange.go
@@ -2057,7 +2057,15 @@ func (h *Handler) approveRIExchange(ctx context.Context, req *events.LambdaFunct
 			}
 			// Record-level RBAC denied (e.g. approve-own user is not the creator).
 			// If a token is present, preserve legacy token flow; otherwise surface the error.
-			if token == "" || !isPermissionDenied(sessErr) {
+			//
+			// A CSRF rejection must NOT fall through, even with a token present.
+			// isPermissionDenied is a bare 403 test, so without this it cannot tell a
+			// forged cross-site request from a legitimate approve-own denial, and the
+			// request would proceed on the token alone: the exchange executes, but as
+			// an unattributed system approval (transitioned_by NULL, no approved_by
+			// stamp) on a money path. Checked first so the sentinel is never reached
+			// by the 403 test below.
+			if errors.Is(sessErr, errCSRFRejected) || token == "" || !isPermissionDenied(sessErr) {
 				return nil, sessErr
 			}
 		case isPermissionDenied(err):
@@ -2110,7 +2118,7 @@ func (h *Handler) approveRIExchangeViaSession(ctx context.Context, req *events.L
 	// #1757 -- this call was previously reachable with no CSRF token at
 	// all, despite a comment claiming parity with the purchases path).
 	if err := h.validateCSRF(ctx, req); err != nil {
-		return nil, NewClientError(403, "CSRF validation failed")
+		return nil, errCSRFRejected
 	}
 
 	var err error

--- a/internal/api/handler_ri_exchange.go
+++ b/internal/api/handler_ri_exchange.go
@@ -2103,6 +2103,16 @@ func (h *Handler) approveRIExchangeViaToken(ctx context.Context, id, token strin
 // The session parameter may be non-nil (already validated by the caller) or nil
 // (requireSession will validate it and return 401 if absent).
 func (h *Handler) approveRIExchangeViaSession(ctx context.Context, req *events.LambdaFunctionURLRequest, id string, session *Session) (any, error) {
+	// This endpoint is AuthPublic so the outer middleware skips CSRF.
+	// Enforce it here for the session-authed sub-path, mirroring
+	// approvePurchaseViaSession / cancelPurchaseViaSession: the session
+	// bearer token is cookie-equivalent and must be CSRF-protected (issue
+	// #1757 -- this call was previously reachable with no CSRF token at
+	// all, despite a comment claiming parity with the purchases path).
+	if err := h.validateCSRF(ctx, req); err != nil {
+		return nil, NewClientError(403, "CSRF validation failed")
+	}
+
 	var err error
 	if session == nil {
 		session, err = h.requireSession(ctx, req)

--- a/internal/api/handler_ri_exchange_test.go
+++ b/internal/api/handler_ri_exchange_test.go
@@ -370,6 +370,10 @@ func TestApproveRIExchange_SessionAdmin(t *testing.T) {
 	adminSession := &Session{UserID: "admin-uuid", Email: "admin@example.com"}
 	mockAuth.On("ValidateSession", ctx, "admin-bearer").Return(adminSession, nil)
 	mockAuth.grantAdminPurchaser()
+	// approveRIExchangeViaSession validates CSRF before anything else (issue
+	// #1757); a valid token must be supplied for this session-authed path
+	// to reach the record fetch at all.
+	mockAuth.On("ValidateCSRFToken", ctx, "admin-bearer", "csrf-abc").Return(nil)
 
 	// authorizeSessionApproveRIExchange: admin role short-circuits (no HasPermissionAPI call)
 
@@ -398,7 +402,10 @@ func TestApproveRIExchange_SessionAdmin(t *testing.T) {
 	mockStore.On("StampRIExchangeApprovedBy", ctx, id, adminSession.Email).Return(nil)
 
 	req := &events.LambdaFunctionURLRequest{
-		Headers: map[string]string{"authorization": "Bearer admin-bearer"},
+		Headers: map[string]string{
+			"authorization": "Bearer admin-bearer",
+			"x-csrf-token":  "csrf-abc",
+		},
 	}
 	_, err := h.approveRIExchange(ctx, req, id, "")
 	require.NoError(t, err)
@@ -427,6 +434,8 @@ func TestApproveRIExchange_SessionApproveOwn(t *testing.T) {
 		mockAuth.On("ValidateSession", ctx, "owner-bearer").Return(ownerSession, nil)
 		mockAuth.On("HasPermissionAPI", ctx, ownerID, auth.ActionApproveAny, auth.ResourcePurchases).Return(false, nil)
 		mockAuth.On("HasPermissionAPI", ctx, ownerID, auth.ActionApproveOwn, auth.ResourcePurchases).Return(true, nil)
+		// Issue #1757: CSRF must be validated before the record fetch.
+		mockAuth.On("ValidateCSRFToken", ctx, "owner-bearer", "csrf-abc").Return(nil)
 
 		// authorizeSessionApproveRIExchange fetches record for ownership check
 		mockStore.On("GetRIExchangeRecord", ctx, id).Return(&config.RIExchangeRecord{
@@ -449,7 +458,10 @@ func TestApproveRIExchange_SessionApproveOwn(t *testing.T) {
 		mockStore.On("StampRIExchangeApprovedBy", ctx, id, ownerSession.Email).Return(nil)
 
 		req := &events.LambdaFunctionURLRequest{
-			Headers: map[string]string{"authorization": "Bearer owner-bearer"},
+			Headers: map[string]string{
+				"authorization": "Bearer owner-bearer",
+				"x-csrf-token":  "csrf-abc",
+			},
 		}
 		_, err := h.approveRIExchange(ctx, req, id, "")
 		require.NoError(t, err)
@@ -465,6 +477,9 @@ func TestApproveRIExchange_SessionApproveOwn(t *testing.T) {
 		mockAuth.On("ValidateSession", ctx, "owner-bearer").Return(ownerSession, nil)
 		mockAuth.On("HasPermissionAPI", ctx, ownerID, auth.ActionApproveAny, auth.ResourcePurchases).Return(false, nil)
 		mockAuth.On("HasPermissionAPI", ctx, ownerID, auth.ActionApproveOwn, auth.ResourcePurchases).Return(true, nil)
+		// Issue #1757: CSRF must be validated before the record fetch, so this
+		// test needs a valid token to reach the ownership check it targets.
+		mockAuth.On("ValidateCSRFToken", ctx, "owner-bearer", "csrf-abc").Return(nil)
 
 		// authorizeSessionApproveRIExchange fetches record — creator does not match
 		mockStore.On("GetRIExchangeRecord", ctx, id).Return(&config.RIExchangeRecord{
@@ -475,7 +490,10 @@ func TestApproveRIExchange_SessionApproveOwn(t *testing.T) {
 		}, nil)
 
 		req := &events.LambdaFunctionURLRequest{
-			Headers: map[string]string{"authorization": "Bearer owner-bearer"},
+			Headers: map[string]string{
+				"authorization": "Bearer owner-bearer",
+				"x-csrf-token":  "csrf-abc",
+			},
 		}
 		_, err := h.approveRIExchange(ctx, req, id, "")
 		require.Error(t, err)
@@ -1758,6 +1776,8 @@ func TestApproveRIExchange_SessionActorStamped(t *testing.T) {
 	adminSession := &Session{UserID: actorID, Email: "admin@example.com"}
 	mockAuth.On("ValidateSession", ctx, "admin-bearer").Return(adminSession, nil)
 	mockAuth.grantAdminPurchaser()
+	// Issue #1757: CSRF must be validated before the record fetch.
+	mockAuth.On("ValidateCSRFToken", ctx, "admin-bearer", "csrf-abc").Return(nil)
 
 	mockStore.On("GetRIExchangeRecord", ctx, id).Return(&config.RIExchangeRecord{
 		ID: id, Status: "pending", ApprovalToken: "tok", SourceRIIDs: []string{"ri-1"}, PaymentDue: "10.00",
@@ -1774,7 +1794,10 @@ func TestApproveRIExchange_SessionActorStamped(t *testing.T) {
 	mockStore.On("StampRIExchangeApprovedBy", ctx, id, adminSession.Email).Return(nil)
 
 	req := &events.LambdaFunctionURLRequest{
-		Headers: map[string]string{"authorization": "Bearer admin-bearer"},
+		Headers: map[string]string{
+			"authorization": "Bearer admin-bearer",
+			"x-csrf-token":  "csrf-abc",
+		},
 	}
 	_, err := (&Handler{config: mockStore, auth: mockAuth}).approveRIExchange(ctx, req, id, "")
 	require.NoError(t, err)

--- a/internal/api/handler_router.go
+++ b/internal/api/handler_router.go
@@ -18,6 +18,14 @@ func (h *Handler) routeRequest(ctx context.Context, method, path string, req *ev
 // errNotFound is a sentinel error for 404 responses.
 var errNotFound = &notFoundError{}
 
+// errCSRFRejected marks a CSRF validation failure so it stays distinguishable
+// from an authorization denial. Both surface as 403, and isPermissionDenied
+// tests the code alone, so a dispatch that falls back to a token flow on 403
+// cannot otherwise tell a forged cross-site request from a legitimate
+// approve-own denial. Compare with errors.Is before any 403 test that decides
+// whether to continue rather than return (issue #1757).
+var errCSRFRejected = NewClientError(403, "CSRF validation failed")
+
 type notFoundError struct{}
 
 func (e *notFoundError) Error() string {

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -287,6 +287,14 @@ func (h *Handler) requiresCSRFValidation(method, path string, req *events.Lambda
 	//
 	// Similarly, /api/ri-exchange/approve/ and /api/ri-exchange/reject/ are
 	// AuthPublic and therefore exempted by isPublicEndpoint(), not here.
+	// approve/ has a session-authed sub-path (approveRIExchangeViaSession)
+	// and, like the purchases functions above, enforces CSRF directly
+	// inside that function -- NOT here, and not automatically just because
+	// it is "similar" to purchases (issue #1757: this exemption used to
+	// exist in prose only, with no actual validateCSRF call backing it).
+	// reject/ has no session-authed path at all -- it is unconditionally
+	// gated on a constant-time comparison against the record's stored
+	// approval token, so CSRF does not apply to it.
 	//
 	// All exemptions use exact-match to prevent a path like
 	// /api/register-malicious from bypassing CSRF via accidental prefix overlap.

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeanerCloud/CUDly/internal/config"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -421,6 +422,98 @@ func TestCancelViaSession_RequiresCSRF(t *testing.T) {
 	assert.Contains(t, ce.Error(), "CSRF validation failed")
 }
 
+// TestApproveRIExchangeViaSession_RequiresCSRF is the RI-exchange analog of
+// TestApproveViaSession_RequiresCSRF (issue #1757). Before this fix,
+// approveRIExchangeViaSession had no CSRF check at all -- the endpoint is
+// AuthPublic, so the outer middleware skips CSRF (same as purchases), but
+// unlike purchases nothing enforced it inside the handler. A comment at
+// middleware.go claimed parity with the purchases path; it didn't hold.
+//
+// Asserts on the call to TransitionRIExchangeStatus directly, not just on
+// the returned error: an error alone doesn't prove the state transition was
+// prevented, only that something failed somewhere.
+func TestApproveRIExchangeViaSession_RequiresCSRF(t *testing.T) {
+	ctx := context.Background()
+	id := "550e8400-e29b-41d4-a716-446655440020"
+
+	mockStore := new(MockConfigStore)
+	mockAuth := new(MockAuthService)
+	adminSession := &Session{UserID: "admin-uuid", Email: "admin@example.com"}
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(adminSession, nil)
+	mockAuth.grantAdmin()
+	// CSRF token is empty → ValidateCSRFToken must return an error so the
+	// request is rejected before ever fetching the exchange record.
+	mockAuth.On("ValidateCSRFToken", ctx, "sess-tok", "").Return(errors.New("csrf mismatch"))
+	t.Cleanup(func() { mockAuth.AssertExpectations(t) })
+
+	h := &Handler{config: mockStore, auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer sess-tok"},
+	}
+	_, err := h.approveRIExchange(ctx, req, id, "")
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a ClientError, got: %v", err)
+	assert.Equal(t, 403, ce.code)
+	assert.Contains(t, ce.Error(), "CSRF validation failed")
+
+	// The state-changing assertion: CSRF must be checked before the record
+	// is even fetched, let alone transitioned. Both must be untouched.
+	mockStore.AssertNotCalled(t, "GetRIExchangeRecord", mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "TransitionRIExchangeStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestApproveRIExchangeViaSession_PassesCSRF confirms the CSRF guard does
+// not block the legitimate dashboard flow: a valid CSRF token still reaches
+// TransitionRIExchangeStatus. Without this, "add the CSRF check" could ship
+// a fix that also breaks the happy path.
+func TestApproveRIExchangeViaSession_PassesCSRF(t *testing.T) {
+	ctx := context.Background()
+	id := "550e8400-e29b-41d4-a716-446655440021"
+	creatorID := "creator-uuid"
+
+	mockStore := new(MockConfigStore)
+	mockAuth := new(MockAuthService)
+	adminSession := &Session{UserID: "admin-uuid", Email: "admin@example.com"}
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(adminSession, nil)
+	// approve-any:purchases is carved out of admin:* (#923); grantAdminPurchaser
+	// grants it explicitly so this test reaches TransitionRIExchangeStatus
+	// without also depending on the ownership comparison, matching the sibling
+	// TestApproveRIExchange_SessionAdmin fixture.
+	mockAuth.grantAdminPurchaser()
+	mockAuth.On("ValidateCSRFToken", ctx, "sess-tok", "csrf-abc").Return(nil)
+	t.Cleanup(func() { mockAuth.AssertExpectations(t) })
+
+	mockStore.On("GetRIExchangeRecord", ctx, id).Return(&config.RIExchangeRecord{
+		ID:              id,
+		Status:          "pending",
+		ApprovalToken:   "tok",
+		SourceRIIDs:     []string{"ri-123"},
+		PaymentDue:      "100.00",
+		CreatedByUserID: &creatorID,
+	}, nil).Once()
+	mockStore.On("TransitionRIExchangeStatus", ctx, id, "pending", "processing", mock.Anything).
+		Return(&config.RIExchangeRecord{ID: id, Status: "processing", SourceRIIDs: []string{"ri-123"}, PaymentDue: "100.00"}, nil)
+	mockStore.On("GetRIExchangeDailySpend", mock.Anything, mock.Anything).Return("0", nil)
+	mockStore.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{
+		RIExchangeMaxDailyUSD:       1000,
+		RIExchangeMaxPerExchangeUSD: 500,
+	}, nil)
+	mockStore.On("FailRIExchange", ctx, id, mock.AnythingOfType("string")).Return(nil)
+	mockStore.On("StampRIExchangeApprovedBy", ctx, id, adminSession.Email).Return(nil)
+
+	h := &Handler{config: mockStore, auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{
+			"authorization": "Bearer sess-tok",
+			"x-csrf-token":  "csrf-abc",
+		},
+	}
+	_, err := h.approveRIExchange(ctx, req, id, "")
+	require.NoError(t, err)
+	mockStore.AssertCalled(t, "TransitionRIExchangeStatus", ctx, id, "pending", "processing", mock.Anything)
+}
+
 // TestTokenOnlyApprove_BypassesCSRF asserts that the email-link token path
 // does NOT invoke approvePurchaseViaSession, so CSRF is not checked on that
 // code path. The token path uses authorizeApprovalAction which validates the
@@ -480,10 +573,29 @@ func TestTokenOnlyApprove_BypassesCSRF(t *testing.T) {
 	assert.Equal(t, "completed", result.(map[string]string)["status"])
 }
 
-// Regression test for #404: approve/cancel/reject paths must require CSRF
-// when the request carries a session bearer token. Previously they were
-// unconditionally exempt, meaning a logged-in user could be CSRF-attacked
-// into approving a purchase via a malicious page.
+// Regression test for #404: pins requiresCSRFValidation's own per-path
+// decision for the approve/cancel/reject paths.
+//
+// IMPORTANT SCOPE LIMIT (issue #1757): this calls requiresCSRFValidation
+// directly, bypassing validateSecurityContext's isPublicEndpoint gate. Every
+// path in tokenPaths below is registered AuthPublic in router.go, so in the
+// real request path isPublicEndpoint short-circuits BEFORE
+// requiresCSRFValidation is ever reached -- this function's return value for
+// these four paths is never actually consulted by the live dispatch. A
+// passing assertion here is NOT proof that CSRF is enforced end-to-end; it
+// was misread as exactly that for approveRIExchangeViaSession, which had no
+// validateCSRF call of its own until this issue. The end-to-end guarantee
+// for a given AuthPublic route comes only from that route's handler calling
+// h.validateCSRF directly (see TestApproveViaSession_RequiresCSRF /
+// TestCancelViaSession_RequiresCSRF / TestApproveRIExchangeViaSession_
+// RequiresCSRF, which drive the real handler.approvePurchase /
+// cancelPurchase / approveRIExchange entry points instead).
+//
+// Kept rather than deleted: requiresCSRFValidation's per-path table is real
+// logic that would matter again if any of these routes ever stopped being
+// AuthPublic, and this is the only test that pins it. Deleting it would
+// trade a mislabeled test for no coverage at all; the comment above is the
+// fix for the mislabeling.
 func TestRequiresCSRFValidation_TokenBasedPathsWithSession(t *testing.T) {
 	h := &Handler{}
 

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -435,32 +435,69 @@ func TestCancelViaSession_RequiresCSRF(t *testing.T) {
 func TestApproveRIExchangeViaSession_RequiresCSRF(t *testing.T) {
 	ctx := context.Background()
 	id := "550e8400-e29b-41d4-a716-446655440020"
+	creatorID := "creator-uuid"
 
 	mockStore := new(MockConfigStore)
 	mockAuth := new(MockAuthService)
 	adminSession := &Session{UserID: "admin-uuid", Email: "admin@example.com"}
 	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(adminSession, nil)
-	mockAuth.grantAdmin()
+	mockAuth.grantAdminPurchaser()
 	// CSRF token is empty → ValidateCSRFToken must return an error so the
 	// request is rejected before ever fetching the exchange record.
 	mockAuth.On("ValidateCSRFToken", ctx, "sess-tok", "").Return(errors.New("csrf mismatch"))
 	t.Cleanup(func() { mockAuth.AssertExpectations(t) })
+
+	// Full happy-path fixture, registered but never meant to be consumed
+	// (.Maybe()): if the CSRF guard were ever removed or reordered, this lets
+	// execution run all the way to TransitionRIExchangeStatus instead of
+	// panicking on an earlier unmocked call. The assertion below on
+	// TransitionRIExchangeStatus is what must actually fail under that
+	// mutation -- an early panic on GetRIExchangeRecord would prove only
+	// that record wasn't reached, not that the state transition (the
+	// money-moving call) was prevented. Verified: reverting the CSRF guard
+	// with this fixture present makes the TransitionRIExchangeStatus
+	// AssertNotCalled fail cleanly rather than crashing on an earlier call.
+	mockStore.On("GetRIExchangeRecord", ctx, id).Return(&config.RIExchangeRecord{
+		ID:              id,
+		Status:          "pending",
+		ApprovalToken:   "tok",
+		SourceRIIDs:     []string{"ri-123"},
+		PaymentDue:      "100.00",
+		CreatedByUserID: &creatorID,
+	}, nil).Maybe()
+	mockStore.On("TransitionRIExchangeStatus", ctx, id, "pending", "processing", mock.Anything).
+		Return(&config.RIExchangeRecord{ID: id, Status: "processing", SourceRIIDs: []string{"ri-123"}, PaymentDue: "100.00"}, nil).Maybe()
+	mockStore.On("GetRIExchangeDailySpend", mock.Anything, mock.Anything).Return("0", nil).Maybe()
+	mockStore.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{
+		RIExchangeMaxDailyUSD:       1000,
+		RIExchangeMaxPerExchangeUSD: 500,
+	}, nil).Maybe()
+	mockStore.On("FailRIExchange", ctx, id, mock.AnythingOfType("string")).Return(nil).Maybe()
+	mockStore.On("StampRIExchangeApprovedBy", ctx, id, adminSession.Email).Return(nil).Maybe()
 
 	h := &Handler{config: mockStore, auth: mockAuth}
 	req := &events.LambdaFunctionURLRequest{
 		Headers: map[string]string{"authorization": "Bearer sess-tok"},
 	}
 	_, err := h.approveRIExchange(ctx, req, id, "")
+
+	// The state-changing assertion comes FIRST and is the primary check:
+	// the money-moving call must never be reached, full stop. Checked ahead
+	// of (and independent of) the error-shape assertions below, using
+	// assert (not require) so it always runs and reports on its own even if
+	// the error-shape checks would also fail. This is the assertion the
+	// mutation verification (see fixture comment above) proved fails
+	// cleanly -- "An error is expected but got nil" plus a call-count
+	// mismatch on TransitionRIExchangeStatus -- when the CSRF guard is
+	// removed, rather than a panic on an earlier unmocked call.
+	mockStore.AssertNotCalled(t, "TransitionRIExchangeStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "GetRIExchangeRecord", mock.Anything, mock.Anything)
+
 	require.Error(t, err)
 	ce, ok := IsClientError(err)
 	require.True(t, ok, "expected a ClientError, got: %v", err)
 	assert.Equal(t, 403, ce.code)
 	assert.Contains(t, ce.Error(), "CSRF validation failed")
-
-	// The state-changing assertion: CSRF must be checked before the record
-	// is even fetched, let alone transitioned. Both must be untouched.
-	mockStore.AssertNotCalled(t, "GetRIExchangeRecord", mock.Anything, mock.Anything)
-	mockStore.AssertNotCalled(t, "TransitionRIExchangeStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestApproveRIExchangeViaSession_PassesCSRF confirms the CSRF guard does

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -500,6 +500,74 @@ func TestApproveRIExchangeViaSession_RequiresCSRF(t *testing.T) {
 	assert.Contains(t, ce.Error(), "CSRF validation failed")
 }
 
+// TestApproveRIExchange_CSRFFailureDoesNotFallThroughToToken covers the case
+// the empty-token test above cannot reach: a session-authed approve that fails
+// CSRF while carrying a VALID ?token=.
+//
+// approveRIExchange's dispatch falls back to the token flow on a 403 from the
+// session path, so email-link holders can still approve. isPermissionDenied
+// tests the status code alone, so without a distinguishable CSRF error a forged
+// cross-site request is indistinguishable from a legitimate approve-own denial
+// and proceeds on the token: the exchange executes, but as an unattributed
+// system approval (transitioned_by NULL, no approved_by stamp) on a money path.
+//
+// Verified by mutation: replacing errCSRFRejected with a plain
+// NewClientError(403, ...) makes the TransitionRIExchangeStatus assertion below
+// fail, because control reaches approveRIExchangeViaToken.
+func TestApproveRIExchange_CSRFFailureDoesNotFallThroughToToken(t *testing.T) {
+	ctx := context.Background()
+	id := "550e8400-e29b-41d4-a716-446655440021"
+	creatorID := "creator-uuid"
+
+	mockStore := new(MockConfigStore)
+	mockAuth := new(MockAuthService)
+	adminSession := &Session{UserID: "admin-uuid", Email: "admin@example.com"}
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(adminSession, nil)
+	mockAuth.grantAdminPurchaser()
+	mockAuth.On("ValidateCSRFToken", ctx, "sess-tok", "").Return(errors.New("csrf mismatch"))
+	t.Cleanup(func() { mockAuth.AssertExpectations(t) })
+
+	// Same full happy-path fixture as the empty-token test, and for the same
+	// reason: registered .Maybe() so a broken guard runs on to the state
+	// transition and fails the assertion, rather than panicking earlier and
+	// proving only that some intermediate call was not reached. ApprovalToken
+	// matches the token passed below, so the token path would genuinely succeed
+	// if the CSRF failure were swallowed.
+	mockStore.On("GetRIExchangeRecord", ctx, id).Return(&config.RIExchangeRecord{
+		ID:              id,
+		Status:          "pending",
+		ApprovalToken:   "tok",
+		SourceRIIDs:     []string{"ri-123"},
+		PaymentDue:      "100.00",
+		CreatedByUserID: &creatorID,
+	}, nil).Maybe()
+	mockStore.On("TransitionRIExchangeStatus", ctx, id, "pending", "processing", mock.Anything).
+		Return(&config.RIExchangeRecord{ID: id, Status: "processing", SourceRIIDs: []string{"ri-123"}, PaymentDue: "100.00"}, nil).Maybe()
+	mockStore.On("GetRIExchangeDailySpend", mock.Anything, mock.Anything).Return("0", nil).Maybe()
+	mockStore.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{
+		RIExchangeMaxDailyUSD:       1000,
+		RIExchangeMaxPerExchangeUSD: 500,
+	}, nil).Maybe()
+	mockStore.On("FailRIExchange", ctx, id, mock.AnythingOfType("string")).Return(nil).Maybe()
+	mockStore.On("StampRIExchangeApprovedBy", ctx, id, adminSession.Email).Return(nil).Maybe()
+
+	h := &Handler{config: mockStore, auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer sess-tok"},
+	}
+	// Valid token, so the fallback path would succeed if CSRF were swallowed.
+	_, err := h.approveRIExchange(ctx, req, id, "tok")
+
+	// Primary assertion: the money-moving call is never reached.
+	mockStore.AssertNotCalled(t, "TransitionRIExchangeStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a ClientError, got: %v", err)
+	assert.Equal(t, 403, ce.code)
+	assert.Contains(t, ce.Error(), "CSRF validation failed")
+}
+
 // TestApproveRIExchangeViaSession_PassesCSRF confirms the CSRF guard does
 // not block the legitimate dashboard flow: a valid CSRF token still reaches
 // TransitionRIExchangeStatus. Without this, "add the CSRF check" could ship


### PR DESCRIPTION
Closes #1757 (`p0`/`severity/critical`).

**Recovered work.** These two commits were written a day ago, committed to a worktree, and never pushed because the authoring agent hit a quota limit mid-task. Rebased onto current `main` (13 commits behind), zero conflicts, and re-verified after the rebase rather than carrying the earlier gate results forward.

## The vulnerability

The session-authed RI-exchange approve path had **no CSRF enforcement at all**. Confirmed by execution with a purchases control in the same probe run:

```
CONTROL (purchases approve, valid session, no CSRF headers):
    err = "CSRF validation failed"          <- correctly refused

RI-EXCHANGE approve (same shape):
    err = <nil>
    TransitionRIExchangeStatus called: true  <- state transitioned
```

A logged-in user visiting an attacker-controlled page that fires a cross-site POST to `/api/ri-exchange/approve/<id>` had their exchange approved and executed. This is exactly the threat model #404 fixed for purchases; it was never applied here.

## Why it survived

Two compounding reasons, both worth recording.

**A comment asserted the protection existed.** `middleware.go:288-289` stated that `/api/ri-exchange/approve/` and `/api/ri-exchange/reject/` are `AuthPublic` and "therefore exempted by isPublicEndpoint(), not here" — the same sentence structure used two lines above for purchases approve/cancel, where "not here" means enforced inside the handler instead. For purchases that is true (`approvePurchaseViaSession` calls `h.validateCSRF` directly). For RI-exchange it was not: `h.validateCSRF` appeared **nowhere** in `handler_ri_exchange.go`.

**A test asserted it was required, and passed.** `TestRequiresCSRFValidation_TokenBasedPathsWithSession` asserts `requiresCSRFValidation(...)` returns `true` for this exact path — but calls the predicate **directly**, bypassing the `isPublicEndpoint` gate that stops the real dispatch from ever consulting it. The test name and its passing assertion both read as "CSRF is required and enforced here"; neither touches the enforced path.

The repos own test suite had zero real CSRF assertions for this handler: the only CSRF-related line was a stub `ValidateCSRFToken` returning `nil` unconditionally, never exercised to prove rejection.

## The fix

`h.validateCSRF(ctx, req)` at the top of `approveRIExchangeViaSession`, mirroring `approvePurchaseViaSession`, with the explanatory comment about `AuthPublic` routes skipping the outer middleware so the next reader sees why it is in-handler.

`rejectRIExchange` needs nothing: it has no session-authed branch, being unconditionally token-gated with a `subtle.ConstantTimeCompare` against the stored approval token.

## The regression test asserts the money-moving call

The second commit exists because asserting on the error alone would not prove the state transition was prevented. The test asserts `TransitionRIExchangeStatus` is **not reached**, which is the property that matters. Both directions: no CSRF token is refused before the transition, and a valid token still succeeds — a fix that refused every session-authed approve would pass a rejection-only test while breaking the feature.

## Post-rebase verification

`validateCSRF` present in `handler_ri_exchange.go` (was 0 occurrences, now 1), `go build ./...` exit 0, and `go test ./internal/api/ -run CSRF|RIExchange` passes. Full gates run by CI.

## Related, filed separately from this investigation

- **#1753** — `approvePurchase`/`cancelPurchase` discard an authorization denial and fall through. Verified **latent, not live**: safe today on two independent facts (inner and outer call the same `authorizeSessionApprove`, and this `AuthPublic` route family never caches a context principal), either of which could change alone.
- **#1749** — `approvePurchaseViaSession` returns a 409 carrying `status=` before authorization, letting a caller probe existence and status of an execution whose UUID it knows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added CSRF protection to session-authenticated RI exchange approvals.
  - Requests without valid CSRF validation are rejected before approval processing begins, even when an approval token is present.
  - Valid CSRF-authenticated approval requests continue normally.

- **Tests**
  - Added regression coverage for missing or invalid CSRF tokens and successful requests with valid tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->