### PR TITLE
fix(ci/azure): serialize Terraform state writers on environment, not branch

### DIFF
--- a/.github/workflows/cleanup-staging.yml
+++ b/.github/workflows/cleanup-staging.yml
@@ -252,6 +252,13 @@ jobs:
     name: Destroy Azure (staging)
     runs-on: ubuntu-latest
     needs: guard
+    # Shares the Azure Terraform state blob github-staging.terraform.tfstate
+    # with deploy-azure.yml and rollback.yml, so it shares their concurrency
+    # group: one writer per state file, whatever workflow or ref it came from
+    # (#1801). The suffix is a literal because this job's state key is too.
+    concurrency:
+      group: azure-tfstate-staging
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read
@@ -284,28 +291,16 @@ jobs:
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
-      - name: Break stale Azure state lock
+      # This step used to also break the blob lease on the state file, with no
+      # age check and no --lease-break-period, so it broke a live lease held by
+      # a concurrent writer. Removed with #1801; the job-level `concurrency`
+      # group above is what keeps writers apart now, and a loud "Error acquiring
+      # the state lock" is the correct outcome if one ever slips through.
+      - name: Write Terraform backend config (staging state)
         env:
           TF_BACKEND: ${{ secrets.TF_BACKEND_AZURE }}
         run: |
           printf '%s\nkey = "github-staging.terraform.tfstate"\n' "$TF_BACKEND" > /tmp/backend.tfbackend
-          STORAGE_ACCOUNT=$(grep -E '^\s*storage_account_name\s*=' /tmp/backend.tfbackend 2>/dev/null | tr -d ' "' | cut -d= -f2)
-          CONTAINER=$(grep -E '^\s*container_name\s*=' /tmp/backend.tfbackend 2>/dev/null | tr -d ' "' | cut -d= -f2)
-          RESOURCE_GROUP=$(grep -E '^\s*resource_group_name\s*=' /tmp/backend.tfbackend 2>/dev/null | tr -d ' "' | cut -d= -f2)
-          STATE_KEY="github-staging.terraform.tfstate"
-          if [ -n "$STORAGE_ACCOUNT" ] && [ -n "$CONTAINER" ]; then
-            ACCOUNT_KEY=$(az storage account keys list \
-              --account-name "${STORAGE_ACCOUNT}" \
-              ${RESOURCE_GROUP:+--resource-group "${RESOURCE_GROUP}"} \
-              --query '[0].value' -o tsv 2>/dev/null || echo "")
-            if [ -n "$ACCOUNT_KEY" ]; then
-              az storage blob lease break \
-                --account-name "${STORAGE_ACCOUNT}" \
-                --container-name "${CONTAINER}" \
-                --blob-name "${STATE_KEY}" \
-                --account-key "${ACCOUNT_KEY}" 2>/dev/null || echo "No lease to break (clean)"
-            fi
-          fi
 
       - name: Terraform Init (staging state)
         run: |

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -162,6 +162,12 @@ jobs:
       TF_BACKEND_GCP: ${{ secrets.TF_BACKEND_GCP }}
 
   # Deploy to Azure Container Apps
+  #
+  # Deliberately carries no `concurrency` (#1801). The Terraform state guard is
+  # the `azure-tfstate-<environment>` group on the called workflow's own
+  # build-and-deploy job, which runs as a real job of this run and is serialized
+  # there. Putting that same group on this caller job would deadlock: this job
+  # would hold the group while waiting on the inner job queued behind it.
   deploy-azure:
     name: Deploy Azure Container Apps
     needs: determine-deployment

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -171,8 +171,9 @@ jobs:
   #
   # Putting that same group on this caller job would deadlock: this job would
   # hold the group while waiting on the inner job queued behind it. GitHub
-  # documents the sibling hazard for `cancel-in-progress: true` (caller and
-  # called sharing a group cancel each other); at `false` it stalls instead.
+  # documents the sibling hazard for `cancel-in-progress: true`: sharing a group
+  # between caller and called cancels the already-running caller. At `false` it
+  # stalls instead.
   deploy-azure:
     name: Deploy Azure Container Apps
     needs: determine-deployment

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -164,10 +164,15 @@ jobs:
   # Deploy to Azure Container Apps
   #
   # Deliberately carries no `concurrency` (#1801). The Terraform state guard is
-  # the `azure-tfstate-<environment>` group on the called workflow's own
-  # build-and-deploy job, which runs as a real job of this run and is serialized
-  # there. Putting that same group on this caller job would deadlock: this job
-  # would hold the group while waiting on the inner job queued behind it.
+  # the group on the called workflow's own build-and-deploy job, which runs as a
+  # real job of this run and is serialized there. That group is derived from the
+  # called workflow's own `prepare` output, which is not necessarily the
+  # `environment` computed above, so do not assume the two agree.
+  #
+  # Putting that same group on this caller job would deadlock: this job would
+  # hold the group while waiting on the inner job queued behind it. GitHub
+  # documents the sibling hazard for `cancel-in-progress: true` (caller and
+  # called sharing a group cancel each other); at `false` it stalls instead.
   deploy-azure:
     name: Deploy Azure Container Apps
     needs: determine-deployment

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -26,9 +26,13 @@ permissions:
   id-token: write
   contents: read
 
-concurrency:
-  group: deploy-azure-${{ github.ref }}
-  cancel-in-progress: false
+# No workflow-level `concurrency` on purpose. What needs protecting is the
+# Terraform state blob, which is keyed on the environment, and only the
+# job-level key can see `needs.prepare.outputs.environment` -- this level is
+# limited to the `github`, `inputs` and `vars` contexts. Keying it on
+# `github.ref` here was issue #1801: two refs resolving to the same environment
+# landed in different groups and applied against one state file. See
+# `build-and-deploy` below.
 
 on:
   push:
@@ -104,6 +108,21 @@ jobs:
     name: Build & Deploy
     runs-on: ubuntu-latest
     needs: prepare
+    # Every run that writes github-<environment>.terraform.tfstate serializes
+    # here, whatever its ref and whatever workflow it came from. The group name
+    # is a 1:1 function of the state key, and the same literal prefix is used by
+    # cleanup-staging.yml and rollback.yml, which write the same blob.
+    #
+    # `prepare` rejects anything outside dev|staging|prod and fails the run, so
+    # this expression cannot evaluate to an empty suffix while this job runs --
+    # that would collapse every environment into one group.
+    #
+    # cancel-in-progress stays false, stated explicitly rather than left to the
+    # default: cancelling mid-`terraform apply` is how you get a half-applied
+    # stack and a lease nobody releases.
+    concurrency:
+      group: azure-tfstate-${{ needs.prepare.outputs.environment }}
+      cancel-in-progress: false
     outputs:
       app_url: ${{ steps.deploy.outputs.app_url }}
       app_name: ${{ steps.deploy.outputs.app_name }}
@@ -129,30 +148,19 @@ jobs:
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
-      - name: Break stale state lock (if any)
+      # This step used to also run `az storage blob lease break` on the state
+      # blob, with no lease-age check and no --lease-break-period, so it broke a
+      # *live* lease immediately. Removed with #1801: the lease is the last line
+      # of defence against two writers, and a loud "Error acquiring the state
+      # lock" is the correct outcome of a real collision. A genuinely stranded
+      # lease (runner killed mid-apply) is recovered with `terraform
+      # force-unlock <ID>`, using the lock ID Terraform prints in that error.
+      - name: Write Terraform backend config
         env:
           TF_BACKEND: ${{ secrets.TF_BACKEND_AZURE }}
           ENVIRONMENT: ${{ needs.prepare.outputs.environment }}
         run: |
           printf '%s\nkey = "github-%s.terraform.tfstate"\n' "$TF_BACKEND" "$ENVIRONMENT" > /tmp/backend.tfbackend
-          STORAGE_ACCOUNT=$(grep -E '^\s*storage_account_name\s*=' /tmp/backend.tfbackend 2>/dev/null | tr -d ' "' | cut -d= -f2)
-          CONTAINER=$(grep -E '^\s*container_name\s*=' /tmp/backend.tfbackend 2>/dev/null | tr -d ' "' | cut -d= -f2)
-          RESOURCE_GROUP=$(grep -E '^\s*resource_group_name\s*=' /tmp/backend.tfbackend 2>/dev/null | tr -d ' "' | cut -d= -f2)
-          if [ -n "$STORAGE_ACCOUNT" ] && [ -n "$CONTAINER" ]; then
-            STATE_KEY="github-${ENVIRONMENT}.terraform.tfstate"
-            ACCOUNT_KEY=$(az storage account keys list \
-              --account-name "${STORAGE_ACCOUNT}" \
-              ${RESOURCE_GROUP:+--resource-group "${RESOURCE_GROUP}"} \
-              --query '[0].value' -o tsv 2>/dev/null || echo "")
-            if [ -n "$ACCOUNT_KEY" ]; then
-              echo "Breaking any stale blob lease on ${STATE_KEY}..."
-              az storage blob lease break \
-                --account-name "${STORAGE_ACCOUNT}" \
-                --container-name "${CONTAINER}" \
-                --blob-name "${STATE_KEY}" \
-                --account-key "${ACCOUNT_KEY}" 2>/dev/null || echo "No lease to break (clean)"
-            fi
-          fi
 
       - name: Terraform Init
         run: |
@@ -293,31 +301,14 @@ jobs:
                the bootstrap builds the name from its own var.name_suffix.
           EOT
 
-      - name: Release state lock on failure
-        if: failure() || cancelled()
-        env:
-          ENVIRONMENT: ${{ needs.prepare.outputs.environment }}
-        run: |
-          STORAGE_ACCOUNT=$(grep -E '^\s*storage_account_name\s*=' /tmp/backend.tfbackend 2>/dev/null | tr -d ' "' | cut -d= -f2)
-          CONTAINER=$(grep -E '^\s*container_name\s*=' /tmp/backend.tfbackend 2>/dev/null | tr -d ' "' | cut -d= -f2)
-          RESOURCE_GROUP=$(grep -E '^\s*resource_group_name\s*=' /tmp/backend.tfbackend 2>/dev/null | tr -d ' "' | cut -d= -f2)
-          if [ -n "$STORAGE_ACCOUNT" ] && [ -n "$CONTAINER" ]; then
-            STATE_KEY="github-${ENVIRONMENT}.terraform.tfstate"
-            ACCOUNT_KEY=$(az storage account keys list \
-              --account-name "${STORAGE_ACCOUNT}" \
-              ${RESOURCE_GROUP:+--resource-group "${RESOURCE_GROUP}"} \
-              --query '[0].value' -o tsv 2>/dev/null || echo "")
-            if [ -n "$ACCOUNT_KEY" ]; then
-              echo "Breaking Azure Blob lease on ${STATE_KEY}"
-              az storage blob lease break \
-                --account-name "${STORAGE_ACCOUNT}" \
-                --container-name "${CONTAINER}" \
-                --blob-name "${STATE_KEY}" \
-                --account-key "${ACCOUNT_KEY}" 2>/dev/null || echo "No lease to break (already clean)"
-            else
-              echo "WARNING: Could not get storage account key — lease may remain held"
-            fi
-          fi
+      # A "Release state lock on failure" step used to break the lease here on
+      # `failure() || cancelled()`. Removed with #1801: on an ordinary failure
+      # Terraform unlocks on its way out, so the step did nothing; on cancelled()
+      # a SIGINT'd apply is still shutting down and may still be writing state,
+      # so it broke the lease out from under it; and if the runner dies hard no
+      # step runs at all. That leaves only a Terraform crash, where a stranded
+      # lease should surface loudly and be cleared with `terraform force-unlock`,
+      # not swept up by a step that also breaks live leases.
 
       - name: Save deployment info
         run: |

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -302,13 +302,20 @@ jobs:
           EOT
 
       # A "Release state lock on failure" step used to break the lease here on
-      # `failure() || cancelled()`. Removed with #1801: on an ordinary failure
-      # Terraform unlocks on its way out, so the step did nothing; on cancelled()
-      # a SIGINT'd apply is still shutting down and may still be writing state,
-      # so it broke the lease out from under it; and if the runner dies hard no
-      # step runs at all. That leaves only a Terraform crash, where a stranded
-      # lease should surface loudly and be cleared with `terraform force-unlock`,
-      # not swept up by a step that also breaks live leases.
+      # `failure() || cancelled()`. Removed with #1801. On failure Terraform
+      # ordinarily unlocks on its way out, so the step usually did nothing; on
+      # cancelled() a SIGINT'd apply is still shutting down and may still be
+      # writing state, so it broke the lease out from under it. That is the
+      # decisive half: a live lease must never be broken.
+      #
+      # The residue is real and is accepted, not denied. A lease IS stranded
+      # when the unlock call itself fails ("Error releasing the state lock",
+      # e.g. OIDC expiry mid-apply), when Terraform crashes, or when Actions
+      # SIGKILLs after the cancellation grace period. The azurerm backend takes
+      # an INFINITE lease, so none of those self-expire. Recovery is deliberate
+      # and manual: `terraform force-unlock <ID>` with the ID Terraform prints.
+      # A step that clears those cases can only do so by also breaking live
+      # leases, which is the bug this issue is about.
 
       - name: Save deployment info
         run: |

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -403,6 +403,16 @@ jobs:
     # concurrency group (#1801). `inputs.environment` is a required `choice`
     # constrained to dev|staging|prod, so the suffix is never empty; it is the
     # same value this job interpolates into the state key below.
+    #
+    # Two consequences of sharing the group across workflows, both accepted as
+    # better than concurrent writers:
+    #   - GitHub keeps one pending entry per group, so a queued rollback can be
+    #     evicted by a later arrival. That surfaces: the summary job below exits
+    #     1 on any non-success result, so an evicted rollback reddens the run.
+    #   - if the `environment:` binding below is ever given required reviewers
+    #     (see the header note; none are configured today), it is undocumented
+    #     whether a job parked awaiting approval holds its group. If it does, an
+    #     unapproved rollback blocks deploys to that environment meanwhile.
     concurrency:
       group: azure-tfstate-${{ inputs.environment }}
       cancel-in-progress: false

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -409,10 +409,11 @@ jobs:
     #   - GitHub keeps one pending entry per group, so a queued rollback can be
     #     evicted by a later arrival. That surfaces: the summary job below exits
     #     1 on any non-success result, so an evicted rollback reddens the run.
-    #   - if the `environment:` binding below is ever given required reviewers
-    #     (see the header note; none are configured today), it is undocumented
-    #     whether a job parked awaiting approval holds its group. If it does, an
-    #     unapproved rollback blocks deploys to that environment meanwhile.
+    #   - if the `environment:` binding below carries required reviewers (see
+    #     #1660 for the live state, deliberately not restated here), it is
+    #     undocumented whether a job parked awaiting approval holds its group.
+    #     If it does, an unapproved rollback blocks deploys to that environment
+    #     for the whole approval window.
     concurrency:
       group: azure-tfstate-${{ inputs.environment }}
       cancel-in-progress: false

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -398,6 +398,14 @@ jobs:
     timeout-minutes: 30
     needs: validate
     if: inputs.cloud == 'azure'
+    # `terraform apply` against github-<environment>.terraform.tfstate, the same
+    # blob deploy-azure.yml and cleanup-staging.yml write, so it takes the same
+    # concurrency group (#1801). `inputs.environment` is a required `choice`
+    # constrained to dev|staging|prod, so the suffix is never empty; it is the
+    # same value this job interpolates into the state key below.
+    concurrency:
+      group: azure-tfstate-${{ inputs.environment }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Closes #1801

## What was broken

The Azure Terraform state blob is keyed on **environment** (`github-<env>.terraform.tfstate`), but `deploy-azure.yml` serialized on **branch** (`concurrency.group: deploy-azure-${{ github.ref }}`). `prepare` maps every non-dispatch event to `dev`, so two runs on different refs landed in different concurrency groups, ran simultaneously, and applied against one state file.

On its own that collision would have been loud: the Azure blob lease makes the second writer fail with `Error acquiring the state lock`. Three `az storage blob lease break` invocations removed that safety net. None of them checked that a lease was held, none checked its age, and none passed `--lease-break-period`, so the default broke an **active** lease immediately. The step named "Break stale state lock" never established staleness. That is what turned a noisy collision into a silent one: the second run broke the first's live lease, both wrote, and the later writer's stale read dropped the earlier one's entries.

## The fix

**1. Serialize on the value that identifies the state file.**

The trap here is that workflow-level `concurrency` cannot see `needs`; it is limited to `github`, `inputs` and `vars`. Rather than re-deriving the environment at that level (which would duplicate `prepare`'s mapping and, on the `workflow_call` path from `deploy-all.yml`, risk not applying at all), the group moves to the **job** level, where `needs` *is* in scope:

```yaml
# deploy-azure.yml, job build-and-deploy
concurrency:
  group: azure-tfstate-${{ needs.prepare.outputs.environment }}
  cancel-in-progress: false
```

This is the exact value the next step interpolates into the state key, so the group and the state file cannot drift apart. Workflow-level `concurrency` is removed; it was fully subsumed (same ref implies same environment implies same group) and keeping it would have implied a state guard it never provided.

The same group is applied to the other two writers of that blob, so serialization holds **across workflows**, not just within one:

| file | job | state key | group |
|---|---|---|---|
| `deploy-azure.yml` | `build-and-deploy` | `github-<env>.terraform.tfstate` | `azure-tfstate-<env>` |
| `cleanup-staging.yml` | `destroy-azure` | `github-staging.terraform.tfstate` | `azure-tfstate-staging` |
| `rollback.yml` | `rollback-azure` | `github-<env>.terraform.tfstate` | `azure-tfstate-<env>` |

`deploy-all.yml` is the fourth workflow named in the issue and gets **no group**, only a comment saying so. It reaches the state exclusively through `uses: ./.github/workflows/deploy-azure.yml`, whose `build-and-deploy` job runs as a real job of that run and is serialized there. Putting the same group on the caller job would deadlock: the caller would hold the group while waiting on the inner job queued behind it.

`cancel-in-progress: false` is stated explicitly on all three rather than left to the default. Cancelling mid-`terraform apply` is how you get a half-applied stack and a lease nobody releases.

**2. Delete the lease breaks, all three.**

The two pre-emptive ones (`deploy-azure.yml`, `cleanup-staging.yml`) are the defect itself. Each step also generated `/tmp/backend.tfbackend`, which `terraform init` consumes, so the step survives as a renamed backend-config writer with the lease break removed.

The third, `Release state lock on failure` (`if: failure() || cancelled()`), is deleted rather than made conditional. The decisive argument is the `cancelled()` half: GitHub SIGINTs the step and then runs the `if: cancelled()` steps while `terraform apply` is still gracefully shutting down and may still be writing state, so the step broke a live lease out from under an active writer. That is a corruption vector, not a cleanup.

An earlier draft of this section claimed the `failure()` half was simply a no-op because Terraform always unlocks on its way out. Adversarial review showed that overstates it, and the code comment has been corrected. A lease **is** genuinely stranded when:

- the unlock call itself fails (`Error releasing the state lock`, e.g. OIDC token expiry mid-apply, a 403 on the storage account), and those conditions correlate with whatever failed the apply, so this is not exotic;
- Terraform crashes;
- Actions SIGKILLs after the cancellation grace period rather than letting the graceful shutdown finish.

The azurerm backend takes an **infinite** blob lease, so none of these self-expire. That residue is accepted rather than denied: recovery is `terraform force-unlock <ID>` with the ID Terraform prints. The reason to delete anyway is that a step which clears those cases can only do so by *also* breaking live leases, which is the defect this issue is about. A loud `Error acquiring the state lock` is the correct outcome of a real collision and is now allowed to happen.

## How this would have prevented the June 9 incident

Per #1801, at the creation instant of `cost_management_reader` (2026-06-09T15:42:51Z):

| run | branch | window | old group | new group |
|---|---|---|---|---|
| 27217251153 | `feat/multicloud-web-frontend` | 15:32:24 -> 15:58:15 | `deploy-azure-refs/heads/feat/multicloud-web-frontend` | `azure-tfstate-dev` |
| 27217600951 | `main` | 15:38:01 -> 16:03:01 | `deploy-azure-refs/heads/main` | `azure-tfstate-dev` |

Both runs are non-dispatch events, so `prepare` returned `dev` for both and both wrote `github-dev.terraform.tfstate`. Under the old group they were in **different** groups and both ran. Under the new group they are in the **same** group: run 27217600951's `build-and-deploy` would have sat pending at 15:38:01 until 27217251153 finished at 15:58:15, and would then have `terraform init`'d against the state that run had just written. There is no window in which both hold the blob, so no read-modify-write of a stale state, and no dropped role assignments.

Both runs were verified as `event: push` via `gh run view`, so both took `prepare`'s `*)` branch. Note the feature-branch run was possible because `deploy-azure.yml` reached pushes beyond `main` at the time; today's `on.push.branches: [main]` narrows that particular path. It does not close the hole: a `workflow_dispatch` can still be launched from any ref, and `deploy-all.yml`, `rollback.yml` and `cleanup-staging.yml` all reach the same blob independently of the push trigger. The trigger list is not the guard; the concurrency group is.

Belt and braces: even if the groups were somehow bypassed, deleting the lease breaks restores the blob lease as a real barrier, so the second writer fails loudly instead of proceeding.

## Verification

| command | exit | result |
|---|---|---|
| `actionlint deploy-azure.yml deploy-all.yml cleanup-staging.yml rollback.yml` | 1 | 268 lines of output, **byte-identical to the same command on `origin/main`** after normalizing file:line prefixes. Every finding is a pre-existing shellcheck `SC2086`/`SC2129` info/style note on steps this PR does not touch. Zero new findings. actionlint is not wired into CI or pre-commit, so this is not a gate either way. |
| negative control: `needs.…` added to a **workflow-level** `concurrency` in a scratch copy | 1 | `context "needs" is not allowed here. available contexts are "github", "inputs", "vars"` |
| the same expression at **job** level (this PR) | n/a | no such error |

The negative control matters: it proves actionlint actually enforces context availability for `concurrency`, so the clean run on the job-level form is evidence the expression resolves, not evidence that nothing was checked. It also confirms the docs' scoping rule first-hand rather than on trust.

`prepare`'s environment derivation was re-executed standalone for every trigger path to confirm the group can never be partially empty:

```
event=push              input=''        -> key=github-dev.terraform.tfstate      group=azure-tfstate-dev
event=push (other ref)  input=''        -> key=github-dev.terraform.tfstate      group=azure-tfstate-dev
event=workflow_dispatch input='dev'     -> key=github-dev.terraform.tfstate      group=azure-tfstate-dev
event=workflow_dispatch input='staging' -> key=github-staging.terraform.tfstate  group=azure-tfstate-staging
event=workflow_dispatch input='prod'    -> key=github-prod.terraform.tfstate     group=azure-tfstate-prod
event=workflow_call     input='staging' -> key=github-staging.terraform.tfstate  group=azure-tfstate-staging
event=workflow_call     input=''        -> prepare FAILS, build-and-deploy skipped, group never evaluated
event=workflow_call     input='bogus'   -> prepare FAILS, build-and-deploy skipped, group never evaluated
```

The rows are labelled by the `EVENT_NAME` value fed to `prepare`, since that is what its script branches on. Note per #1805 that a real `workflow_call` never presents `workflow_call` as `github.event_name`; that does not change the empty-suffix conclusion, because every arm of the first case statement is still filtered by the allowlist below.

### The load-bearing property: can the group ever be `azure-tfstate-` with an empty suffix?

No, and importantly **the `*) ENVIRONMENT=dev ;;` catch-all is not what guarantees it**. That arm only covers non-dispatch events. The `workflow_dispatch|workflow_call` arm assigns `ENVIRONMENT="$INPUT_ENVIRONMENT"`, which `prepare` explicitly defaults to the empty string (`INPUT_ENVIRONMENT="${INPUT_ENVIRONMENT:-}"`) and which is typed as a free-form string on the `workflow_call` path. So an empty value *is* reachable inside the step.

What makes it safe is the **second** case statement, the allowlist:

```yaml
case "$ENVIRONMENT" in
  dev|staging|prod) ;;
  *) echo "::error::Refusing unknown environment: $ENVIRONMENT"; exit 1 ;;
esac
```

Empty string does not match `dev|staging|prod`, so it falls to `*)` and exits 1 under `set -euo pipefail`. `prepare` then fails, and `build-and-deploy` declares `needs: prepare` with **no `if:`** (verified by reading the job's direct children: `name`, `runs-on`, `needs`, `concurrency`, `outputs`, `env`, `steps`, and no `if`). A job whose `needs` failed or was skipped is skipped, so it never dispatches and never occupies a group. Job-level `concurrency` is evaluated at dispatch, after `needs` resolves, so there is no ordering in which an empty value claims a group.

Verified empirically, not inferred: the `workflow_call input=''` and `input='bogus'` rows in the table above are actual executions of `prepare`'s script, and both exit non-zero.

### The other load-bearing property: do the three writers share one vocabulary?

They only serialize against each other if they produce the **identical string** for the same environment. A `development` here against a `dev` there would put a rollback and a deploy in different groups against one blob, which is the original bug on the worst possible path.

| writer | source of the value | possible values |
|---|---|---|
| `deploy-azure.yml` `build-and-deploy` | `needs.prepare.outputs.environment` | `dev`, `staging`, `prod` only, enforced by `prepare`'s runtime allowlist (it needs one, because `workflow_call` inputs are free-form strings) |
| `rollback.yml` `rollback-azure` | `inputs.environment` | `dev`, `staging`, `prod` only, enforced by `type: choice, options: [dev, staging, prod]` at `rollback.yml:34-38`. `rollback.yml` has **only** a `workflow_dispatch` trigger (no `workflow_call`, no `release`), so there is no free-form path into it |
| `cleanup-staging.yml` `destroy-azure` | literal | `staging` |

Same three lowercase tokens, no divergence reachable. (GitHub also documents concurrency group names as case insensitive, so a future case slip would not split a group either.)

And each group is keyed on the **same value its own state key is built from**, which is what stops this fix reproducing the original defect somewhere new:

| file | group | state key | same value? |
|---|---|---|---|
| `deploy-azure.yml` | `:124` `needs.prepare.outputs.environment` | `:161` `ENVIRONMENT: needs.prepare.outputs.environment` -> `:163` `github-%s.terraform.tfstate` | yes |
| `rollback.yml` | `:418` `inputs.environment` | `:473` `ENVIRONMENT: inputs.environment` -> `:477` `github-%s.terraform.tfstate` | yes |
| `cleanup-staging.yml` | `:260` literal `staging` | `:303` literal `github-staging.terraform.tfstate` | yes |

All three resolve to the same blob name shape `github-<env>.terraform.tfstate`. (`rollback.yml:234` and `:322` use `github-%s/terraform.tfstate` with a slash, but those are the AWS jobs on a different backend, correctly outside this group.)

Repo-wide check for other writers: `rg` across `.github/workflows/`, `scripts/` and `Makefile` finds no other CI path that runs `terraform apply`/`destroy` against `terraform/environments/azure`. `database-migration.yml`'s `migrate-azure` job runs only `terraform output`, which takes no lock, so it needs no group.

## What remains unproven

- **The concurrency behaviour itself is not empirically demonstrated.** Two overlapping live runs were not staged, and the group semantics can only be observed on GitHub's runners. The evidence here is that the expression is valid, in scope, and evaluates to the intended string on every path, plus that the vocabularies align. It is not evidence that GitHub queued anything. This is the single largest gap.
- **A queued rollback or destroy can be evicted.** GitHub keeps one pending entry per group; `cancel-in-progress: false` protects the *running* job, not the *pending* one. A `rollback-azure` queued behind an in-flight prod deploy is cancelled if another deploy queues into the same group. A rollback evaporating mid-incident is a real cost of sharing one group across three workflows, and it is inherent to that sharing. It is not silent: `rollback.yml`'s summary job exits 1 on any non-success result, so an evicted rollback reddens the run. `cleanup-staging.yml` has no such aggregator, so an evicted `destroy-azure` shows only as a cancelled job. Documented in the job comments.
- **The `environment:` bindings are a hazard, not just an unknown.** Beyond the open question of whether an approval-parked job holds its group, if it does, the mitigation with the right shape is the one already used for `deploy-all.yml`: keep the group off the approval-gated job and put it on an inner job past the gate. Not done here because no environment currently carries protection rules (#1660) and the restructure is larger than this fix warrants.
- **The first real cross-workflow collision after this merges is the actual test.** The first push to `main` will exercise the deploy path; nothing will exercise the `cleanup-staging.yml` / `rollback.yml` groups until one of those workflows is dispatched.
- **Nothing enforces the group prefix staying in sync.** The three `azure-tfstate-` literals are matched by convention. A future writer of that blob added without the group, or a typo in the prefix, would silently not serialize, the same class of silent failure as the original bug. Filed as a follow-up so it does not evaporate.
- **Interaction with the `environment:` bindings is untested.** `rollback-azure` and `destroy-azure` are bound to deployment environments. If required-reviewer rules are ever configured on those (per #1660 none exist today), it is unclear to me whether a job parked awaiting approval holds its concurrency group. If it does, an unapproved rollback would block deploys to that environment until someone acts on it. I could not settle this from the docs and did not test it. Blocking is still the safer failure than concurrent writers, so it does not change the design, but it is a real unknown.
- **The lease-break deletion trades a self-healing path for a loud one.** A Terraform crash that strands a lease now wedges the pipeline until someone runs `force-unlock`. That is the intended trade per the issue, but it is a real operational change, not a free win.

## Other providers: BOTH halves of this bug are live on AWS and GCP

An earlier draft of this section claimed the silent-loss half did not transfer to AWS because S3 uses a lock file rather than a blob lease. **That was wrong**, and adversarial review caught it. Corrected:

Half 1, branch-keyed groups against environment-keyed state:

- `deploy-aws-lambda.yml:33-35` -> `deploy-lambda-${{ github.ref }}`
- `deploy-aws-fargate.yml:28-30` -> `deploy-fargate-${{ github.ref }}`
- `deploy-gcp.yml:27-29` -> `deploy-gcp-${{ github.ref }}`

Half 2, unconditional destruction of another writer's live lock, `if: failure() || cancelled()`, no age check, no held-lock check:

- `deploy-gcp.yml:156-167` -> `gsutil rm "gs://${BUCKET}/github-${ENVIRONMENT}/default.tflock"`
- `deploy-aws-lambda.yml:269-280` -> `aws s3 rm "s3://${BUCKET}/github-${ENVIRONMENT}/terraform.tfstate.tflock"`

Deleting another run's live lock object is exactly as destructive as breaking its lease. The lock mechanism differs; the failure mode does not. So the same silent state loss is reachable on GCP and AWS Lambda today.

Per the scope given for this change, that is **flagged, not fixed**. Widening it is a separate decision, and the AWS/GCP fix is not a copy-paste of this one (different backends, different lock semantics, `deploy-aws-lambda.yml` derives its environment differently). Filed as #1806.

## Follow-ups filed

- **#1806** (p1) BOTH halves of #1801 live on GCP and AWS, per the section above.
- **#1807** (p2) nothing enforces the shared `azure-tfstate-*` group across the three writers; a fourth writer added without it silently does not serialize.
- **#1805** (p2) inside a reusable workflow `github.event_name` is the caller's event, so `deploy-azure.yml`'s `workflow_call` case arm is dead code and a release-triggered `deploy-all.yml` silently deploys to dev while reporting prod. Affects `deploy-azure.yml`, `deploy-gcp.yml` and `deploy-aws-fargate.yml`; `deploy-aws-lambda.yml:110-118` already handles it and is the reference implementation. Does **not** affect this PR: the group and the state key both read the same `needs.prepare.outputs.environment`, so whatever `prepare` decides, the group names the blob that actually gets written. It is a wrong-environment bug, not a serialization bug.

Two pre-existing defects also surfaced during review and are **not** filed, since they are adjacent and unverified by me end to end: `rollback.yml:49` pins `TF_VERSION: 1.6.0` against a stack requiring `>= 1.10.0` (so `rollback-azure` may not init at all today), and `database-migration.yml:431` runs a bare `terraform init` with no `-backend-config` against a partial backend block. Flagging rather than filing so someone with more context decides.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved Azure deployment, staging cleanup, and rollback coordination to prevent conflicting operations.
  * Preserved queued workflow runs instead of cancelling them when another operation is in progress.
  * Updated Terraform state handling to rely on standard locking and explicit recovery procedures.
* **Documentation**
  * Added workflow guidance explaining deployment concurrency behavior and Terraform state protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->