### PR TITLE
fix(ci): resolve deploy environment from inputs, not github.event_name

### DIFF
--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -15,6 +15,15 @@
 
 name: Deploy to All Clouds
 
+# Adding a trigger here, or a second caller of the deploy-* workflows, means
+# revisiting the `prepare` comments in deploy-azure.yml, deploy-gcp.yml and
+# deploy-aws-lambda.yml. Since #1805 those three resolve their environment from
+# `inputs.environment` and fall back on `github.event_name`, which inside a
+# reusable workflow is whatever event started THIS run. They are correct today
+# only because this workflow is their only caller, has no `push` trigger, and
+# allowlists the environment it passes. A `push:` trigger here would make
+# Azure and GCP silently resolve dev for a caller that asked for something
+# else, which is #1805 restored.
 on:
   workflow_dispatch:
     inputs:
@@ -56,12 +65,35 @@ jobs:
     steps:
       - name: Set environment
         id: set-env
+        env:
+          # This workflow is always the entry point of its own run, never a
+          # reusable one, so `github.event_name` here really is the trigger that
+          # started it. The called workflows cannot rely on that and read
+          # `inputs.environment` instead (issue #1805).
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_ENVIRONMENT: ${{ inputs.environment }}
         run: |
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "environment=prod" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          INPUT_ENVIRONMENT="${INPUT_ENVIRONMENT:-}"
+
+          if [ "$EVENT_NAME" = release ]; then
+            ENVIRONMENT=prod
           else
-            echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT
+            ENVIRONMENT="$INPUT_ENVIRONMENT"
           fi
+
+          # Every called workflow takes this value verbatim, so an empty or
+          # unknown value has to stop the fan-out here rather than reach four
+          # deployments.
+          case "$ENVIRONMENT" in
+            dev|staging|prod) ;;
+            *)
+              echo "::error::Refusing unknown environment: '$ENVIRONMENT'"
+              exit 1
+              ;;
+          esac
+
+          echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
       - name: Set cloud providers
         id: set-clouds
@@ -166,8 +198,9 @@ jobs:
   # Deliberately carries no `concurrency` (#1801). The Terraform state guard is
   # the group on the called workflow's own build-and-deploy job, which runs as a
   # real job of this run and is serialized there. That group is derived from the
-  # called workflow's own `prepare` output, which is not necessarily the
-  # `environment` computed above, so do not assume the two agree.
+  # called workflow's own `prepare` output, which since #1805 is the
+  # `environment` computed above verbatim: `prepare` takes the non-empty input
+  # it is passed and fails the run rather than substituting a default.
   #
   # Putting that same group on this caller job would deadlock: this job would
   # hold the group while waiting on the inner job queued behind it. GitHub
@@ -263,7 +296,22 @@ jobs:
         run: |
           FAILED=false
 
-          if [[ "${{ needs.deploy-aws-lambda.result }}" == "failure" ]] || \
+          # determine-deployment is checked for anything other than success, not
+          # just "failure". When it stops the run the four deploy jobs are
+          # SKIPPED rather than failed, so testing only those would report "all
+          # deployments completed successfully" for a run that deployed nothing.
+          #
+          # The four deploy jobs are deliberately still tested for "failure"
+          # only. A CANCELLED run leaves them `cancelled` and reaches the
+          # success line, which is the same false report. That predates this
+          # change, so it is tracked in #1810 rather than fixed here.
+          #
+          # Note this step is the only success-by-default check in the repo. All
+          # four per-cloud `summary` jobs allowlist on `== "success"` instead,
+          # so an unenumerated result falls to their failure branch and errs
+          # safe. This denylist is the outlier, not the pattern.
+          if [[ "${{ needs.determine-deployment.result }}" != "success" ]] || \
+             [[ "${{ needs.deploy-aws-lambda.result }}" == "failure" ]] || \
              [[ "${{ needs.deploy-aws-fargate.result }}" == "failure" ]] || \
              [[ "${{ needs.deploy-gcp.result }}" == "failure" ]] || \
              [[ "${{ needs.deploy-azure.result }}" == "failure" ]]; then
@@ -272,7 +320,7 @@ jobs:
 
           if [ "$FAILED" = true ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "❌ **One or more deployments failed. Check individual job logs.**" >> $GITHUB_STEP_SUMMARY
+            echo "❌ **Deployment did not complete successfully. Check individual job logs.**" >> $GITHUB_STEP_SUMMARY
             exit 1
           else
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-aws-fargate.yml
+++ b/.github/workflows/deploy-aws-fargate.yml
@@ -74,16 +74,21 @@ jobs:
       - name: Determine environment
         id: set-env
         env:
-          EVENT_NAME: ${{ github.event_name }}
           INPUT_ENVIRONMENT: ${{ inputs.environment }}
         run: |
           set -euo pipefail
           INPUT_ENVIRONMENT="${INPUT_ENVIRONMENT:-}"
 
-          case "$EVENT_NAME" in
-            workflow_dispatch|workflow_call) ENVIRONMENT="$INPUT_ENVIRONMENT" ;;
-            *)                               ENVIRONMENT=dev ;;
-          esac
+          # workflow_dispatch and workflow_call are this workflow's only
+          # triggers and both declare `environment` as `required: true`, so the
+          # input is the single source of truth and there is nothing to fall
+          # back to. Branching on `github.event_name` here was issue #1805:
+          # inside a reusable workflow it reports the CALLER's event and is
+          # never "workflow_call", so a release-triggered caller passing
+          # environment=prod would have mis-resolved to a `dev` default arm.
+          # deploy-all.yml hardcodes this workflow off, so the case was latent
+          # here and live only for Azure and GCP.
+          ENVIRONMENT="$INPUT_ENVIRONMENT"
 
           # workflow_dispatch constrains this to the declared `choice` options,
           # but the workflow_call input is typed as a free-form string, so the
@@ -91,7 +96,7 @@ jobs:
           case "$ENVIRONMENT" in
             dev|staging|prod) ;;
             *)
-              echo "::error::Refusing unknown environment: $ENVIRONMENT"
+              echo "::error::Refusing unknown environment: '$ENVIRONMENT'"
               exit 1
               ;;
           esac

--- a/.github/workflows/deploy-aws-lambda.yml
+++ b/.github/workflows/deploy-aws-lambda.yml
@@ -107,17 +107,31 @@ jobs:
           set -euo pipefail
           INPUT_ENVIRONMENT="${INPUT_ENVIRONMENT:-}"
 
-          # Inside a reusable workflow `github.event_name` is the CALLER's
-          # event, so it is never "workflow_call" — a caller's free-form
-          # `inputs.environment` arrives through the workflow_dispatch arm.
-          # Caveat: the `*` arm forces dev, so a push-triggered caller would
-          # have its requested environment silently ignored. deploy-all.yml
-          # triggers only on workflow_dispatch and release today.
-          case "$EVENT_NAME" in
-            release)           TARGET_ENVIRONMENT=prod ;;
-            workflow_dispatch) TARGET_ENVIRONMENT="$INPUT_ENVIRONMENT" ;;
-            *)                 TARGET_ENVIRONMENT=dev ;;
-          esac
+          # Branch on whether an environment was REQUESTED, not on the event
+          # name. Inside a reusable workflow `github.event_name` is the CALLER's
+          # event and is never "workflow_call", so no event name can identify a
+          # workflow_call invocation (issue #1805). A non-empty input is always
+          # an explicit request and wins.
+          #
+          # An empty input means none was supplied, which this workflow's own
+          # `release` and `push` triggers are the legitimate causes of; every
+          # other event stops the run. Note that `release` is inherited by a
+          # workflow_call from a release-triggered caller, so a caller passing
+          # an EMPTY environment would resolve to prod here rather than
+          # failing. deploy-all.yml is the only caller and allowlists the value
+          # it passes, so that cannot happen. Telling the two apart would need
+          # `github.job_workflow_ref`, which is not worth the machinery for an
+          # unreachable path.
+          if [ -n "$INPUT_ENVIRONMENT" ]; then
+            TARGET_ENVIRONMENT="$INPUT_ENVIRONMENT"
+          elif [ "$EVENT_NAME" = release ]; then
+            TARGET_ENVIRONMENT=prod
+          elif [ "$EVENT_NAME" = push ]; then
+            TARGET_ENVIRONMENT=dev
+          else
+            echo "::error::No environment supplied on a '$EVENT_NAME'-triggered run; refusing to guess a deployment target."
+            exit 1
+          fi
 
           # workflow_dispatch constrains this to the declared `choice` options,
           # but the workflow_call input is typed as a free-form string, so the
@@ -125,7 +139,7 @@ jobs:
           case "$TARGET_ENVIRONMENT" in
             dev|staging|prod) ;;
             *)
-              echo "::error::Refusing unknown environment: $TARGET_ENVIRONMENT"
+              echo "::error::Refusing unknown environment: '$TARGET_ENVIRONMENT'"
               exit 1
               ;;
           esac

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -85,10 +85,30 @@ jobs:
           set -euo pipefail
           INPUT_ENVIRONMENT="${INPUT_ENVIRONMENT:-}"
 
-          case "$EVENT_NAME" in
-            workflow_dispatch|workflow_call) ENVIRONMENT="$INPUT_ENVIRONMENT" ;;
-            *)                               ENVIRONMENT=dev ;;
-          esac
+          # Branch on whether an environment was REQUESTED, not on the event
+          # name. Inside a reusable workflow `github.event_name` is the CALLER's
+          # event and is never "workflow_call", so no event name can identify a
+          # workflow_call invocation: a release-triggered deploy-all.yml passing
+          # environment=prod would have landed on a `dev` default arm and
+          # resolved to dev while the summary said prod (issue #1805).
+          #
+          # `inputs` is populated on workflow_dispatch and workflow_call, the
+          # only two triggers that carry an environment, so a non-empty input is
+          # always an explicit request and wins. An empty input means none was
+          # supplied: under `push` that is this workflow's own main-branch
+          # deploy and means dev, and every other event stops the run rather
+          # than guessing. A workflow_call from a push-triggered caller would
+          # read as `push` here too, since `github.event_name` is inherited, but
+          # deploy-all.yml is the only caller, has no push trigger, and
+          # allowlists the value it passes.
+          if [ -n "$INPUT_ENVIRONMENT" ]; then
+            ENVIRONMENT="$INPUT_ENVIRONMENT"
+          elif [ "$EVENT_NAME" = push ]; then
+            ENVIRONMENT=dev
+          else
+            echo "::error::No environment supplied on a '$EVENT_NAME'-triggered run; refusing to guess a deployment target."
+            exit 1
+          fi
 
           # workflow_dispatch constrains this to the declared `choice` options,
           # but the workflow_call input is typed as a free-form string, so the
@@ -96,7 +116,7 @@ jobs:
           case "$ENVIRONMENT" in
             dev|staging|prod) ;;
             *)
-              echo "::error::Refusing unknown environment: $ENVIRONMENT"
+              echo "::error::Refusing unknown environment: '$ENVIRONMENT'"
               exit 1
               ;;
           esac

--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -72,10 +72,30 @@ jobs:
           set -euo pipefail
           INPUT_ENVIRONMENT="${INPUT_ENVIRONMENT:-}"
 
-          case "$EVENT_NAME" in
-            workflow_dispatch|workflow_call) ENVIRONMENT="$INPUT_ENVIRONMENT" ;;
-            *)                               ENVIRONMENT=dev ;;
-          esac
+          # Branch on whether an environment was REQUESTED, not on the event
+          # name. Inside a reusable workflow `github.event_name` is the CALLER's
+          # event and is never "workflow_call", so no event name can identify a
+          # workflow_call invocation: a release-triggered deploy-all.yml passing
+          # environment=prod would have landed on a `dev` default arm and
+          # resolved to dev while the summary said prod (issue #1805).
+          #
+          # `inputs` is populated on workflow_dispatch and workflow_call, the
+          # only two triggers that carry an environment, so a non-empty input is
+          # always an explicit request and wins. An empty input means none was
+          # supplied: under `push` that is this workflow's own main-branch
+          # deploy and means dev, and every other event stops the run rather
+          # than guessing. A workflow_call from a push-triggered caller would
+          # read as `push` here too, since `github.event_name` is inherited, but
+          # deploy-all.yml is the only caller, has no push trigger, and
+          # allowlists the value it passes.
+          if [ -n "$INPUT_ENVIRONMENT" ]; then
+            ENVIRONMENT="$INPUT_ENVIRONMENT"
+          elif [ "$EVENT_NAME" = push ]; then
+            ENVIRONMENT=dev
+          else
+            echo "::error::No environment supplied on a '$EVENT_NAME'-triggered run; refusing to guess a deployment target."
+            exit 1
+          fi
 
           # workflow_dispatch constrains this to the declared `choice` options,
           # but the workflow_call input is typed as a free-form string, so the
@@ -83,7 +103,7 @@ jobs:
           case "$ENVIRONMENT" in
             dev|staging|prod) ;;
             *)
-              echo "::error::Refusing unknown environment: $ENVIRONMENT"
+              echo "::error::Refusing unknown environment: '$ENVIRONMENT'"
               exit 1
               ;;
           esac


### PR DESCRIPTION
Closes #1805

## The defect

Inside a reusable workflow `github.event_name` is the **caller's** event, never the literal string `workflow_call`. Four deploy workflows branched on it:

```bash
case "$EVENT_NAME" in
  workflow_dispatch|workflow_call) ENVIRONMENT="$INPUT_ENVIRONMENT" ;;
  *)                               ENVIRONMENT=dev ;;
esac
```

`deploy-all.yml` triggers on `release: types: [created]`, computes `environment=prod`, and passes it to every callee. On that path the callee sees `event_name=release`, matches neither arm of the first case, discards the `prod` it was handed, and returns `dev`. The `workflow_dispatch` path worked only by coincidence: there the caller's event genuinely is `workflow_dispatch`, which the arm happens to match. That is why the bug is invisible on the path anyone would test with.

## The signal, and why this is not "add `release` to the case arm"

Adding `release` treats the symptom and stays fragile: the next trigger added to `deploy-all.yml` reintroduces it silently. `github.event_name` is the wrong signal entirely, because it always describes the triggering event of the whole run and can never answer "was I called by another workflow".

The fix branches on **whether an environment was requested** - `inputs.environment` - which answers exactly that question:

- `inputs` is populated on precisely the two triggers that carry an environment (`workflow_dispatch`, `workflow_call`) and is empty on every other trigger, whatever the caller's event was.
- `environment` is already `required: true` on both of those triggers in all four workflows, so an empty value means none was requested.
- Where an empty value has no defensible default, the step now **fails** rather than guessing. A deploy that cannot determine its target environment must stop, not pick one.

In-repo precedent: `database-migration.yml` already resolves its environment straight from `inputs.environment`, and its comment at `:107-110` documents that an input absent on a given path "renders empty".

## Which workflows shared the pattern

| Workflow | Status before | Change |
|---|---|---|
| `deploy-azure.yml` | **broken** - release path returned `dev` | branch on input; `dev` only for its own `push` trigger; everything else fails |
| `deploy-gcp.yml` | **broken** - release path returned `dev` | same |
| `deploy-aws-fargate.yml` | **broken** - release path returned `dev` | declares no trigger but `workflow_dispatch`/`workflow_call`, so the input is the only source of truth and the fallback is removed outright |
| `deploy-aws-lambda.yml` | correct result, wrong reasoning | had an explicit `release) prod` arm, so it hardcoded the answer instead of honouring the input. The input now wins; the arm serves only its own direct `release` trigger |
| `deploy-all.yml` | caller, not callee | `github.event_name` is sound here (this workflow is always the entry point of its own run) and stays. Gains the `dev\|staging\|prod` allowlist the callees already had |
| `database-migration.yml` | already correct | none - reads `inputs.environment` directly |

`deploy-all.yml` gaining the allowlist is what closes the last way to reach a wrong environment through a `workflow_call`: it is the only caller of these workflows, and an empty or unknown environment now stops the fan-out instead of reaching four deployments. It also stops interpolating `${{ inputs.environment }}` directly into a shell command.

That allowlist makes `determine-deployment` the first job in this workflow that can deliberately fail, which surfaced a second, related defect. `notify` runs `if: always()` and its `Check for failures` step only tested the four deploy jobs for `== "failure"`. When `determine-deployment` stops the run those jobs are **skipped**, not failed, so the step summary would print "✅ **All deployments completed successfully!**" for a run that deployed nothing. That is the same shape as #1805 itself, a summary asserting something the deployment did not do, and this PR made it reachable, so it is fixed here: the step now treats any non-success of `determine-deployment` as a failure.

A sibling of that gap - a **cancelled** run also reaching the success line - was deliberately **not** fixed here and is split out to **#1810**. It is unchanged from `origin/main`, so this PR did not cause it, and it is a class issue across all four deploy workflows' summary jobs; fixing one instance here would leave three live. `Check for failures` carries a comment pointing at #1810 rather than staying silent about it. The full analysis, including the documented proof that the obvious fix is safe, is on that issue.

## Blast radius correction

Issue #1805 originally said a release-triggered run "silently targets dev on three clouds". It is two: `deploy-all.yml:105` hardcodes `deploy-aws-fargate=false`, so a release fans out to Lambda, GCP and Azure only, and Lambda was already resolving to `prod`. The consequence would be **Azure and GCP applying Terraform against `dev` while the run summary reported `prod`**. Fargate was latently broken and is fixed here too.

Tense matters here: **nothing has actually been mis-deployed**. `gh run list --workflow deploy-all.yml` returns `[]` - the workflow has never executed, so the release path has never fired. The bug is real by inspection and would fire on the first release; it has no history. The impact claim on #1805 has since been retracted by its author on the strength of this, and the correction is posted there.

## The comment this PR makes false, and CodeRabbit's stale learning

The `deploy-azure:` job in `deploy-all.yml` documented that the called workflow's `prepare` output "is not necessarily the `environment` computed above, so do not assume the two agree". That was **correct, and correct precisely because of this bug**. CodeRabbit challenged it on #1803, the challenge was declined with the trace, and CodeRabbit agreed the finding was invalid and stored a learning to that effect.

This PR inverts that. `prepare` now takes the passed input verbatim or fails the run, so the two do agree, and the comment is updated in the same commit. **CodeRabbit therefore holds a now-stale learning from #1803 about this exact line.** Reviewers should not treat it as authoritative here.

## Does #1803's concurrency reasoning still hold

Yes, and it was re-checked rather than assumed. `deploy-azure.yml`'s job-level group `azure-tfstate-${{ needs.prepare.outputs.environment }}` and the state key `github-${ENVIRONMENT}.terraform.tfstate` both derive from the same `prepare` output, so they stay in lockstep whatever `prepare` decides. This change alters only what that output evaluates to, never the fact that both sides read it. The comment at `deploy-azure.yml:130-132` ("`prepare` rejects anything outside dev|staging|prod and fails the run, so this expression cannot evaluate to an empty suffix") remains true and is now reinforced, since an empty input fails earlier as well.

## Verification

**What was proved.** The `Determine environment` / `Set environment` step body was extracted from the YAML for both `origin/main` and this branch (parsed, not retyped), the `${{ }}` expressions substituted with the values each scenario would present, and executed under `bash` with a scratch `$GITHUB_OUTPUT`.

Release path, `event_name=release` + `inputs.environment=prod`:

| Workflow | before | after |
|---|---|---|
| `deploy-azure.yml` | `environment=dev` | `environment=prod` |
| `deploy-gcp.yml` | `environment=dev` | `environment=prod` |
| `deploy-aws-fargate.yml` | `environment=dev` | `environment=prod` |
| `deploy-aws-lambda.yml` | `target_environment=prod` | `target_environment=prod` |

The negative, a `workflow_call` that passes no environment (`event_name=release` + `inputs.environment=''`):

| Workflow | before | after |
|---|---|---|
| `deploy-azure.yml` | `environment=dev` | **fails**, `::error::No environment supplied on a 'release'-triggered run; refusing to guess a deployment target.` |
| `deploy-gcp.yml` | `environment=dev` | **fails**, same |
| `deploy-aws-fargate.yml` | `environment=dev` | **fails**, `::error::Refusing unknown environment: ''` |

Unchanged where it should be: direct `push` to main still resolves `dev` on Azure, GCP and Lambda; direct `release` on Lambda still resolves `prod`; `workflow_dispatch` still honours its choice on all four.

**What was NOT proved.** No release was created and no run was executed. `gh run list --workflow deploy-all.yml` is empty, so the release path has never run at all. This is a standalone simulation of the resolution logic, not an end-to-end deploy: it does not prove that the resolved `prod` reaches `terraform apply` against the prod state file, only that `prepare` now emits `prod` where it previously emitted `dev`. Everything downstream already reads `needs.prepare.outputs.*` and is unchanged by this PR.

Two residuals, stated rather than hidden. Note that `required: true` on a `workflow_call` input requires the *key* to be present, not the *value* to be non-empty, so a caller can deliver an empty input:

- A future caller triggered by `push` passing an empty environment would resolve `dev` on Azure/GCP, because `github.event_name` is inherited and reads as `push` there too.
- A future caller triggered by `release` passing an empty environment would resolve `prod` on Lambda, because Lambda's own `release` trigger legitimately means prod and is indistinguishable from an inherited one.

Neither is reachable: `deploy-all.yml` is the only caller, it has neither a `push` trigger nor a path to an empty environment now that it allowlists the value it passes. Telling a direct trigger from an inherited one would need `github.job_workflow_ref`, which is not worth the machinery for an unreachable path. Both residuals are documented in the comments at the relevant branch rather than papered over.

**`actionlint`** (v1.7.12) is not wired into CI, so the same command was run against `origin/main` for comparison:

```
actionlint .github/workflows/deploy-all.yml .github/workflows/deploy-azure.yml \
           .github/workflows/deploy-gcp.yml .github/workflows/deploy-aws-fargate.yml \
           .github/workflows/deploy-aws-lambda.yml
```

Exit `1` on both `origin/main` and this branch - entirely pre-existing shellcheck `SC2086`/`SC2129` debt in untouched steps. Findings go **113 -> 111**: no new findings, none on any line this PR touches, and the two that disappear are pre-existing unquoted `$GITHUB_OUTPUT` uses in the `deploy-all.yml` step that was rewritten.

## A note on counts, for whoever picks up #1810

Worth recording, because #1810's actionable content *is* a count and this PR is the cautionary tale.

Four count errors occurred in this one changeset, in a PR whose entire subject is code asserting something the codebase does not do:

1. The original #1810 filing said the cancelled-run bug was **"a class across four workflows"**. It is **one** instance.
2. The correction to that said **"three siblings allowlist on success"**. It is **four** - `deploy-gcp.yml:307` was missing.
3. An independent verification reproduced error 2, because it re-derived each listed entry's *polarity* correctly but inherited the *membership* of the set from the list it was given.
4. The sweep backing "the only denylist in the repo" was described as covering **"all 17 workflows"**. There are **16** `.yml` files; the 17th directory entry is `README.md`.

Every one came from counting the shape that was salient - files containing `if: always()`, files someone happened to enumerate, entries in a directory listing - rather than enumerating the candidate set and then measuring the defining property on each member. Note that error 3 survived a review that was correct on every substantive point, which is the dangerous part: re-deriving one side of a comparison while accepting the other side as given is not verification.

The generalisable rule: **a count in a code comment or a filed issue is a claim about the whole repository, and the only thing that makes it true is enumerating every candidate and reading what each one does.** Never carry a count forward from a previous message, a previous revision, or someone else's list, including a reviewer's.

The substantive claims survived all four corrections unchanged: `deploy-all.yml` is the only success-by-default check in the repo, and the cancelled-run gap is a single site. Only the numbers were ever wrong, which is precisely why they were easy to miss.

## Two smaller things

All five allowlist errors now quote the rejected value (`'$ENVIRONMENT'`). Unquoted, an empty or whitespace value renders as `Refusing unknown environment: ` with nothing after it. This matches the existing style in `database-migration.yml:127`.

`deploy-aws-lambda.yml`'s `Set image tag` step still branches on `github.event_name` and was deliberately left alone. It is not the same bug class: the environment is a deployment *intent* the caller communicates out-of-band through `inputs`, and the caller's event is a bad proxy for it, whereas the image tag is a property of the *code being deployed*, which a called workflow genuinely inherits along with the ref it checks out. On a release-triggered caller, `github.event.release.tag_name` is the release actually being deployed, which is the correct answer. All six trigger combinations were enumerated and it is right in each; its empty-tag path already fails loudly.
