### PR TITLE
fix(ci): serialize AWS and GCP Terraform state writers on environment, not branch

### DIFF
--- a/.github/workflows/cleanup-staging.yml
+++ b/.github/workflows/cleanup-staging.yml
@@ -98,6 +98,13 @@ jobs:
     name: Destroy AWS Lambda (staging)
     runs-on: ubuntu-24.04-arm
     needs: guard
+    # Shares s3://<bucket>/github-staging/terraform.tfstate with
+    # deploy-aws-lambda.yml and rollback.yml, so it shares their concurrency
+    # group: one writer per state file, whatever workflow or ref it came from
+    # (#1806). The suffix is a literal because this job's state key is too.
+    concurrency:
+      group: aws-tfstate-staging
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read
@@ -175,6 +182,14 @@ jobs:
     name: Destroy AWS Fargate (staging)
     runs-on: ubuntu-24.04-arm
     needs: guard
+    # Shares s3://<bucket>/github-fargate-staging/terraform.tfstate with
+    # deploy-aws-fargate.yml, so it shares that workflow's concurrency group
+    # (#1806). This is a different state object from destroy-aws-lambda's
+    # above, so the two jobs are deliberately in different groups and may run
+    # concurrently. The suffix is a literal because this job's state key is too.
+    concurrency:
+      group: aws-fargate-tfstate-staging
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read
@@ -322,6 +337,13 @@ jobs:
     name: Destroy GCP (staging)
     runs-on: ubuntu-latest
     needs: guard
+    # Shares gs://<bucket>/github-staging/default.tfstate with deploy-gcp.yml
+    # and rollback.yml, so it shares their concurrency group (#1806). This job
+    # writes state twice: the `terraform state rm` calls below as well as the
+    # destroy. The suffix is a literal because this job's backend prefix is too.
+    concurrency:
+      group: gcp-tfstate-staging
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -50,6 +50,14 @@ on:
   release:
     types: [created]
 
+# None of the four `uses:` caller jobs below carries a `concurrency` group, and
+# that is deliberate (#1801, #1806). The Terraform state guard is the group on
+# each called workflow's own deploying job, which runs as a real job of THIS run
+# and is serialized there. Putting the same group on a caller job would deadlock:
+# the caller would hold the group while waiting on the inner job queued behind
+# it. GitHub documents the sibling hazard for `cancel-in-progress: true` (sharing
+# a group between caller and called cancels the already-running caller); at
+# `false` it stalls instead. The per-job note on `deploy-azure` spells this out.
 jobs:
   # Determine deployment strategy
   determine-deployment:

--- a/.github/workflows/deploy-aws-fargate.yml
+++ b/.github/workflows/deploy-aws-fargate.yml
@@ -25,10 +25,13 @@ permissions:
   id-token: write
   contents: read
 
-concurrency:
-  group: deploy-fargate-${{ github.ref }}
-  cancel-in-progress: false
-
+# No workflow-level `concurrency` on purpose. What needs protecting is the
+# Terraform state object, which is keyed on the environment, and only the
+# job-level key can see `needs.prepare.outputs.environment` -- this level is
+# limited to the `github`, `inputs` and `vars` contexts. Keying it on
+# `github.ref` put two runs on different refs that both resolve to the same
+# environment into different groups against one state file (#1806). The group
+# lives on `deploy` below.
 on:
   workflow_dispatch:
     inputs:
@@ -113,6 +116,21 @@ jobs:
     name: Deploy to Fargate
     runs-on: ubuntu-24.04-arm
     needs: prepare
+    # Every run that writes
+    # s3://<bucket>/github-fargate-<environment>/terraform.tfstate serializes
+    # here, whatever ref or workflow it came from (#1806). This is a DIFFERENT
+    # state object from the Lambda one (github-<environment>/), so it takes its
+    # own group rather than sharing `aws-tfstate-*`; sharing would serialize two
+    # independent state files against each other for no gain. The suffix is the
+    # exact value the backend key below is built from, and `prepare` fails the
+    # run on anything outside dev|staging|prod so it can never be empty.
+    #
+    # `cancel-in-progress: false` is stated rather than left to the default:
+    # cancelling mid-`terraform apply` is how you get a half-applied stack and a
+    # lock nobody releases.
+    concurrency:
+      group: aws-fargate-tfstate-${{ needs.prepare.outputs.environment }}
+      cancel-in-progress: false
     outputs:
       alb_url: ${{ steps.outputs.outputs.alb_url }}
       service_name: ${{ steps.outputs.outputs.service_name }}

--- a/.github/workflows/deploy-aws-lambda.yml
+++ b/.github/workflows/deploy-aws-lambda.yml
@@ -30,10 +30,13 @@ name: Deploy to AWS Lambda
 permissions:
   contents: read
 
-concurrency:
-  group: deploy-lambda-${{ github.ref }}
-  cancel-in-progress: false
-
+# No workflow-level `concurrency` on purpose. What needs protecting is the
+# Terraform state object, which is keyed on the environment, and only the
+# job-level key can see `needs.prepare.outputs.target_environment` -- this level
+# is limited to the `github`, `inputs` and `vars` contexts. Keying it on
+# `github.ref` put two runs on different refs that both resolve to the same
+# environment into different groups against one state file (#1806). The group
+# lives on `build-and-deploy` below.
 on:
   push:
     branches: [main]
@@ -206,6 +209,18 @@ jobs:
       # change none of this repo's Environments have any. See #1648.
       id-token: write
       contents: read
+    # Every run that writes s3://<bucket>/github-<environment>/terraform.tfstate
+    # serializes here, whatever ref or workflow it came from (#1806). The suffix
+    # is the exact value the backend key below is built from, so the group and
+    # the state object cannot drift apart, and `prepare` fails the run on
+    # anything outside dev|staging|prod so it can never be empty.
+    #
+    # `cancel-in-progress: false` is stated rather than left to the default:
+    # cancelling mid-`terraform apply` is how you get a half-applied stack and a
+    # lock nobody releases.
+    concurrency:
+      group: aws-tfstate-${{ needs.prepare.outputs.target_environment }}
+      cancel-in-progress: false
     # Bind to the named GitHub Environment matching the target so
     # secrets.* resolve to environment-scoped values when defined,
     # falling back to repo-scoped secrets otherwise. Without this,
@@ -280,18 +295,19 @@ jobs:
           cd terraform/environments/aws
           terraform apply -auto-approve tfplan
 
-      - name: Release state lock on failure
-        if: failure() || cancelled()
-        env:
-          TF_BACKEND: ${{ secrets.TF_BACKEND_AWS }}
-          ENVIRONMENT: ${{ needs.prepare.outputs.target_environment }}
-        run: |
-          BUCKET=$(grep -E '^\s*bucket\s*=' /tmp/backend.tfbackend 2>/dev/null | tr -d ' "' | cut -d= -f2)
-          if [ -n "$BUCKET" ]; then
-            LOCK_KEY="github-${ENVIRONMENT}/terraform.tfstate.tflock"
-            echo "Releasing S3 state lock: s3://${BUCKET}/${LOCK_KEY}"
-            aws s3 rm "s3://${BUCKET}/${LOCK_KEY}" 2>/dev/null || echo "No lock file found (already clean)"
-          fi
+      # No automatic state-lock release on failure. The step that used to live
+      # here ran on `failure() || cancelled()` with no age check and no check
+      # that the lock was this run's, so it deleted whatever lock object was
+      # there. The `cancelled()` half is the decisive one: GitHub runs those
+      # steps while `terraform apply` is still shutting down and may still be
+      # writing state, so it destroyed a lock out from under an active writer.
+      # A run that failed *because* it could not acquire the lock would also
+      # have deleted the lock held by the run still applying. Removed with
+      # #1806, matching the shape deploy-aws-fargate.yml already uses.
+      # Terraform releases its own lock on a clean apply error; a lock that
+      # survives a run means the run died abnormally, which needs operator
+      # confirmation that the owning run is dead. Recovery is
+      # `terraform force-unlock <ID>` -- see runbooks/terraform-stuck-lock.md.
 
       - name: Get Terraform outputs
         id: outputs

--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -24,10 +24,13 @@ permissions:
   id-token: write
   contents: read
 
-concurrency:
-  group: deploy-gcp-${{ github.ref }}
-  cancel-in-progress: false
-
+# No workflow-level `concurrency` on purpose. What needs protecting is the
+# Terraform state object, which is keyed on the environment, and only the
+# job-level key can see `needs.prepare.outputs.environment` -- this level is
+# limited to the `github`, `inputs` and `vars` contexts. Keying it on
+# `github.ref` put two runs on different refs that both resolve to `dev` into
+# different groups against one state file (#1806). The group lives on
+# `build-and-deploy` below.
 on:
   push:
     branches: [main]
@@ -115,6 +118,18 @@ jobs:
     name: Build & Deploy
     runs-on: ubuntu-latest
     needs: prepare
+    # Every run that writes gs://<bucket>/github-<environment>/default.tfstate
+    # serializes here, whatever ref or workflow it came from (#1806). The suffix
+    # is the exact value the backend prefix below is built from, so the group and
+    # the state object cannot drift apart, and `prepare` fails the run on
+    # anything outside dev|staging|prod so it can never be empty.
+    #
+    # `cancel-in-progress: false` is stated rather than left to the default:
+    # cancelling mid-`terraform apply` is how you get a half-applied stack and a
+    # lock nobody releases.
+    concurrency:
+      group: gcp-tfstate-${{ needs.prepare.outputs.environment }}
+      cancel-in-progress: false
     outputs:
       service_url: ${{ steps.deploy.outputs.service_url }}
 
@@ -136,18 +151,20 @@ jobs:
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
+      # This step used to `gsutil rm` the state lock object before every init,
+      # unconditionally and with no check that the lock was stale or anyone
+      # else's, so it deleted a live lock held by a concurrent writer. Removed
+      # with #1806; the job-level `concurrency` group above is what keeps
+      # writers apart now, and a loud "Error acquiring the state lock" is the
+      # correct outcome if one ever slips through. Recovery from a genuinely
+      # stranded lock is `terraform force-unlock <ID>` -- see
+      # runbooks/terraform-stuck-lock.md.
       - name: Terraform Init
         env:
           TF_BACKEND: ${{ secrets.TF_BACKEND_GCP }}
           ENVIRONMENT: ${{ needs.prepare.outputs.environment }}
         run: |
           printf '%s\nprefix = "github-%s"\n' "$TF_BACKEND" "$ENVIRONMENT" > /tmp/backend.tfbackend
-          # Break any stale state lock from a previous failed run
-          BUCKET=$(grep -E '^\s*bucket\s*=' /tmp/backend.tfbackend 2>/dev/null | tr -d ' "' | cut -d= -f2)
-          if [ -n "$BUCKET" ]; then
-            LOCK_FILE="gs://${BUCKET}/github-${ENVIRONMENT}/default.tflock"
-            gsutil rm "${LOCK_FILE}" 2>/dev/null || true
-          fi
           cd terraform/environments/gcp
           terraform init -backend-config=/tmp/backend.tfbackend
 
@@ -173,17 +190,16 @@ jobs:
           SERVICE_URL=$(terraform output -raw cloud_run_service_url 2>/dev/null | grep -v '::' || echo "")
           echo "service_url=$SERVICE_URL" >> $GITHUB_OUTPUT
 
-      - name: Release state lock on failure
-        if: failure() || cancelled()
-        env:
-          ENVIRONMENT: ${{ needs.prepare.outputs.environment }}
-        run: |
-          BUCKET=$(grep -E '^\s*bucket\s*=' /tmp/backend.tfbackend 2>/dev/null | tr -d ' "' | cut -d= -f2)
-          if [ -n "$BUCKET" ]; then
-            LOCK_FILE="gs://${BUCKET}/github-${ENVIRONMENT}/default.tflock"
-            echo "Releasing GCS state lock: ${LOCK_FILE}"
-            gsutil rm "${LOCK_FILE}" 2>/dev/null || echo "No lock file found (already clean)"
-          fi
+      # No automatic state-lock release on failure. The step that used to live
+      # here ran on `failure() || cancelled()` with no age check and no check
+      # that the lock was this run's, so it deleted whatever lock object was
+      # there. The `cancelled()` half is the decisive one: GitHub runs those
+      # steps while `terraform apply` is still shutting down and may still be
+      # writing state, so it destroyed a lock out from under an active writer.
+      # Terraform releases its own lock on a clean apply error; a lock that
+      # survives a run means the run died abnormally, which needs operator
+      # confirmation that the owning run is dead. Recovery is
+      # `terraform force-unlock <ID>` -- see runbooks/terraform-stuck-lock.md.
 
       - name: Save deployment info
         run: |

--- a/.github/workflows/destroy-fargate-dev.yml
+++ b/.github/workflows/destroy-fargate-dev.yml
@@ -75,6 +75,15 @@ jobs:
     name: Terraform Destroy (Fargate dev)
     runs-on: ubuntu-24.04-arm
     needs: guard
+    # Destroys s3://<bucket>/github-fargate-dev/terraform.tfstate, the same
+    # state object deploy-aws-fargate.yml and cleanup-staging.yml write, so it
+    # takes the same concurrency group: one writer per state file, whatever
+    # workflow or ref it came from (#1806). The suffix is a literal because this
+    # job's state key is too. `cancel-in-progress: false` because cancelling
+    # mid-`terraform destroy` leaves a half-destroyed stack and a stuck lock.
+    concurrency:
+      group: aws-fargate-tfstate-dev
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read
@@ -103,15 +112,19 @@ jobs:
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
+      # This step used to `aws s3 rm` the state lock object before every init,
+      # unconditionally and with no check that the lock was stale or anyone
+      # else's, so it deleted a live lock held by a concurrent writer. Removed
+      # with #1806; the job-level `concurrency` group above is what keeps
+      # writers apart now, and a loud "Error acquiring the state lock" is the
+      # correct outcome if one ever slips through. Recovery from a genuinely
+      # stranded lock is `terraform force-unlock <ID>` -- see
+      # runbooks/terraform-stuck-lock.md.
       - name: Terraform Init
         env:
           TF_BACKEND: ${{ secrets.TF_BACKEND_AWS }}
         run: |
           printf '%s\nkey = "github-fargate-dev/terraform.tfstate"\n' "$TF_BACKEND" > /tmp/backend.tfbackend
-          BUCKET=$(grep -E '^\s*bucket\s*=' /tmp/backend.tfbackend 2>/dev/null | tr -d ' "' | cut -d= -f2)
-          if [ -n "$BUCKET" ]; then
-            aws s3 rm "s3://${BUCKET}/github-fargate-dev/terraform.tfstate.tflock" 2>/dev/null || true
-          fi
           cd terraform/environments/aws
           terraform init -backend-config=/tmp/backend.tfbackend
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -175,6 +175,16 @@ jobs:
     timeout-minutes: 30
     needs: validate
     if: inputs.cloud == 'aws-lambda'
+    # `terraform apply` against s3://<bucket>/github-<environment>/terraform.tfstate,
+    # the same object deploy-aws-lambda.yml and cleanup-staging.yml write, so it
+    # takes the same concurrency group (#1806). `inputs.environment` is a
+    # required `choice` constrained to dev|staging|prod, so the suffix is never
+    # empty; it is the same value this job interpolates into the state key below.
+    # The eviction and approval-gate caveats documented on `rollback-azure` apply
+    # here identically.
+    concurrency:
+      group: aws-tfstate-${{ inputs.environment }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read
@@ -263,6 +273,20 @@ jobs:
     timeout-minutes: 30
     needs: validate
     if: inputs.cloud == 'aws-fargate'
+    # NOTE the group is `aws-tfstate-*`, NOT `aws-fargate-tfstate-*`. Despite
+    # the job name, the state key this job builds below is
+    # `github-<environment>/terraform.tfstate` -- the LAMBDA namespace -- not
+    # `github-fargate-<environment>/` as deploy-aws-fargate.yml uses. The group
+    # must name the object this job actually locks, or it would serialize
+    # against a state file it never touches while writing one unguarded, which
+    # is #1806 reproduced in a new place. That namespace mismatch is a real
+    # pre-existing defect (a Fargate rollback applies into the Lambda state),
+    # tracked in #1811 rather than changed here, because moving the key changes
+    # which infrastructure a rollback rewrites. When #1811 lands, this group
+    # moves to `aws-fargate-tfstate-*` in the same commit as the key.
+    concurrency:
+      group: aws-tfstate-${{ inputs.environment }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read
@@ -335,6 +359,14 @@ jobs:
     timeout-minutes: 30
     needs: validate
     if: inputs.cloud == 'gcp'
+    # `terraform apply` against gs://<bucket>/github-<environment>/default.tfstate,
+    # the same object deploy-gcp.yml and cleanup-staging.yml write, so it takes
+    # the same concurrency group (#1806). `inputs.environment` is a required
+    # `choice` constrained to dev|staging|prod, so the suffix is never empty; it
+    # is the same value this job interpolates into the backend prefix below.
+    concurrency:
+      group: gcp-tfstate-${{ inputs.environment }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Closes #1806

Both halves of #1801 were fixed for Azure only in #1803. This lands the equivalent for AWS and GCP. It is not a copy-paste of #1803: the environment is derived differently per workflow, Fargate uses a separate state namespace and needs its own group, and one lock-removal step is deliberately kept.

## Enumeration, not sampling

`.github/workflows/` holds **16 `.yml` files** (a 17th entry is `README.md`). All 16 were classified by grepping for backend config, state keys, bucket names and state-mutating `terraform` subcommands, not by filename.

| file | verdict | evidence |
|---|---|---|
| `aws_sanity.yml` | not a writer | `rg -l -i 'terraform\|tfstate\|aws s3\|gsutil'` -> no match |
| `azure_sanity.yml` | not a writer | same, no match |
| `frontend-build.yml` | not a writer | same, no match |
| `frontend-build-sentinel.yml` | not a writer | same, no match |
| `frontend-e2e.yml` | not a writer | same, no match |
| `ci.yml` | not a writer | 30 `terraform` mentions, all `terraform init -backend=false` + `validate` at `:386`. No backend, no lock |
| `pre-commit.yml` | not a writer | 17 mentions, all prose in comments about the `terraform_validate` hook |
| `database-migration.yml` | not a writer | `terraform init` at `:258`, `:355`, `:432` then `terraform output` only. `output` takes no lock. (Those are bare `init` with no `-backend-config` against a partial backend block, flagged in #1803 and still unfixed; either way nothing is written) |
| `deploy-all.yml` | not a direct writer | one `terraform` mention, in a comment. Reaches state only via `uses:` |
| `deploy-azure.yml` | Azure only | already fixed in #1803, out of scope |
| **`deploy-aws-lambda.yml`** | **writer** | `terraform apply` `:281`; key `github-<env>/terraform.tfstate` |
| **`deploy-aws-fargate.yml`** | **writer** | `terraform apply` `:179`; key `github-fargate-<env>/terraform.tfstate` |
| **`deploy-gcp.yml`** | **writer** | `terraform apply` `:170`; prefix `github-<env>` (GCS) |
| **`destroy-fargate-dev.yml`** | **writer** | `terraform destroy` `:143`; key `github-fargate-dev/terraform.tfstate` |
| **`cleanup-staging.yml`** | **writer x4** | `terraform destroy` `:169`, `:246`, `:316`, `:412` plus four `terraform state rm` at `:395-400` |
| **`rollback.yml`** | **writer x4** | `terraform apply` `:238`, `:326`, `:389`, `:481` |

Line numbers above are `origin/main` at `17a568f42`.

**This differs from the issue.** The issue names three workflows for half 1 and two steps for half 2. The real candidate set is larger in two places and smaller in one:

- **`destroy-fargate-dev.yml` is a state writer the issue does not mention**, and it carried *both* defects: no concurrency group at all, and an unconditional `aws s3 rm` of the `.tflock` before every `terraform init` (`:111-114`).
- **`deploy-gcp.yml` had *two* lock deletions, not one.** The issue cites the `failure() || cancelled()` step. There was also an unconditional `gsutil rm` inside `Terraform Init` (`:145-150`) that deleted the lock on **every single run**, before init, with no condition whatsoever. That is strictly worse than the one the issue names.
- **`deploy-aws-fargate.yml` no longer has half 2.** The issue lists it under half 1 only, which is right, but for completeness: its lock-removal step (`:138-152`) is already gated on `inputs.clear_stale_lock == true`, a `workflow_dispatch`-only boolean defaulting false, and its failure-path release step was already deleted with a comment explaining why. That step is **retained** (justified below).

Enumerated mechanically rather than by eye: a script parses every workflow, selects jobs whose `run:` blocks contain a state-mutating `terraform` subcommand, and prints the group next to the state key.

```
origin/main:  jobs mutating terraform state: 13   without a group: 10
this PR:      jobs mutating terraform state: 13   without a group: 0
              with cancel-in-progress true: 0
```

## Half 1: group on the job that writes state, keyed on the value that builds the state key

Workflow-level `concurrency` cannot see `needs` (constraint proven below), so each group lives on the deploying job. Three distinct state objects across AWS and GCP, therefore three group prefixes:

| group | state object |
|---|---|
| `aws-tfstate-<env>` | `s3://<bucket>/github-<env>/terraform.tfstate` |
| `aws-fargate-tfstate-<env>` | `s3://<bucket>/github-fargate-<env>/terraform.tfstate` |
| `gcp-tfstate-<env>` | `gs://<bucket>/github-<env>/default.tfstate` |

Fargate gets its **own** prefix rather than sharing `aws-tfstate-*`. Sharing would serialize two independent state files against each other, buying nothing and costing queue evictions.

Every group and the state key it guards, side by side, at post-merge line numbers:

| file | job | group | state key expression | same value? |
|---|---|---|---|---|
| `deploy-aws-lambda.yml` | `build-and-deploy` | `:222` `aws-tfstate-${{ needs.prepare.outputs.target_environment }}` | `:255` `ENVIRONMENT: needs.prepare.outputs.target_environment` -> `:257` `key = "github-%s/terraform.tfstate"` | yes |
| `deploy-aws-fargate.yml` | `deploy` | `:132` `aws-fargate-tfstate-${{ needs.prepare.outputs.environment }}` | `:175` `ENVIRONMENT: needs.prepare.outputs.environment` -> `:177` `key = "github-fargate-%s/terraform.tfstate"` | yes |
| `deploy-gcp.yml` | `build-and-deploy` | `:131` `gcp-tfstate-${{ needs.prepare.outputs.environment }}` | `:165` `ENVIRONMENT: needs.prepare.outputs.environment` -> `:167` `prefix = "github-%s"` | yes |
| `destroy-fargate-dev.yml` | `destroy` | `:85` literal `aws-fargate-tfstate-dev` | `:127` literal `github-fargate-dev/terraform.tfstate` | yes |
| `cleanup-staging.yml` | `destroy-aws-lambda` | `:106` literal `aws-tfstate-staging` | `:137` literal `github-staging/terraform.tfstate` | yes |
| `cleanup-staging.yml` | `destroy-aws-fargate` | `:191` literal `aws-fargate-tfstate-staging` | `:222` literal `github-fargate-staging/terraform.tfstate` | yes |
| `cleanup-staging.yml` | `destroy-gcp` | `:345` literal `gcp-tfstate-staging` | `:379` literal `prefix = "github-staging"` | yes |
| `rollback.yml` | `rollback-aws-lambda` | `:186` `aws-tfstate-${{ inputs.environment }}` | `:240` `ENVIRONMENT: inputs.environment` -> `:244` `key = "github-%s/terraform.tfstate"` | yes |
| `rollback.yml` | `rollback-aws-fargate` | `:288` `aws-tfstate-${{ inputs.environment }}` | `:342` `ENVIRONMENT: inputs.environment` -> `:346` `key = "github-%s/terraform.tfstate"` | yes, see below |
| `rollback.yml` | `rollback-gcp` | `:368` `gcp-tfstate-${{ inputs.environment }}` | `:412` `ENVIRONMENT: inputs.environment` -> `:417` `prefix = "github-%s"` | yes |

That is **10 AWS/GCP state-mutating jobs**, every one of them previously ungrouped.

### `rollback-aws-fargate` takes the Lambda group on purpose

Despite its name, that job's backend key is `github-<env>/terraform.tfstate`, the **Lambda** namespace, not `github-fargate-<env>/`. Giving it `aws-fargate-tfstate-*` would have serialized it against a state file it never touches while leaving the one it does write unguarded, which is exactly this bug reproduced in a new place. So the group names the object the job actually locks.

The underlying namespace mismatch is a real pre-existing defect (a Fargate rollback applies `compute_platform=fargate` into the Lambda state). It is filed as **#1811** rather than changed here, because moving the key changes which infrastructure a rollback rewrites and may strand resources already written to the wrong file. A comment at the job says the group moves when #1811 lands.

### Workflow-level `concurrency` removed from all three deploy workflows

`deploy-lambda-${{ github.ref }}`, `deploy-fargate-${{ github.ref }}` and `deploy-gcp-${{ github.ref }}` are deleted, replaced by a comment saying why the level had to change. Keeping them would imply a state guard they never provided, and they group runs the job-level key deliberately does not (a `prod` dispatch and a `main` push write different state files and have no reason to queue behind each other). Same call as #1803 made for Azure. The image build is unaffected: tags derive from the git commit, so distinct refs produce distinct tags and same-ref runs were never racing on a tag.

### `deploy-all.yml` gets no group, only a comment

It reaches AWS and GCP state exclusively through `uses:`, and the called workflow's deploying job runs as a real job of that run and is serialized there. A group on the caller job would deadlock: the caller holds the group while waiting on the inner job queued behind it. #1803 documented this for `deploy-azure`; the note is generalized to all four callers.

## Half 2: four lock deletions removed, one retained

| file | step | disposition |
|---|---|---|
| `deploy-gcp.yml` | unconditional `gsutil rm` of `.tflock` inside `Terraform Init` | **deleted** |
| `deploy-gcp.yml` | `Release state lock on failure`, `if: failure() \|\| cancelled()` | **deleted** |
| `deploy-aws-lambda.yml` | `Release state lock on failure`, `if: failure() \|\| cancelled()` | **deleted** |
| `destroy-fargate-dev.yml` | unconditional `aws s3 rm` of `.tflock` inside `Terraform Init` | **deleted** |
| `deploy-aws-fargate.yml` | `Clear stale state lock (operator-triggered only)`, `if: inputs.clear_stale_lock == true` | **retained** |

Deleted rather than made conditional, per #1803's decisive argument: `cancelled()` steps run while `terraform apply` is still gracefully shutting down and may still be writing state, so the step destroys a lock the dying run is still using. The `failure()` half is no better: a run that failed *because* it could not acquire the lock deletes the lock held by the run that is still applying. Neither step checked age, and neither checked the lock was this run's. A loud `Error acquiring the state lock` is the correct outcome of a real collision.

The two unconditional pre-`init` deletions were worse than either: they fired on **every** run regardless of outcome, so any second writer wiped the first's live lock before even trying to acquire one.

**The retained step is justified**: `clear_stale_lock` is a `workflow_dispatch`-only boolean defaulting to `false`, undeclared on the `workflow_call` path (so it renders null and the `== true` guard is false). It only fires when an operator explicitly asks for it, having confirmed the owning run is dead. That is the operator-confirmed recovery shape this issue asks for, not the blanket delete it asks to remove. It also gives the four deleted steps somewhere to point: every replacement comment names `terraform force-unlock <ID>` and `runbooks/terraform-stuck-lock.md`.

Trade accepted, stated plainly: a Terraform crash that strands a lock now wedges the pipeline until someone runs `force-unlock`, instead of the next run silently clearing it. That is the point.

## Verification

| check | exit | result |
|---|---|---|
| `actionlint` on all 7 touched files, this branch | 1 | 352 lines, 88 findings |
| `actionlint` on the same 7 files at `origin/main` | 1 | 352 lines, 88 findings |
| `diff` of the two, normalized to strip `file:line:col` prefixes and source gutters | 0 | **byte-identical. Zero new findings.** Every finding is a pre-existing shellcheck `SC2086`/`SC2129` info/style note on steps this PR does not touch |
| negative control: the job-level expression moved to **workflow-level** `concurrency` in a scratch copy of `deploy-gcp.yml` | 1 | `context "needs" is not allowed here. available contexts are "github", "inputs", "vars"` |
| `pre-commit run --files <7 files>` | 0 | all applicable hooks pass |

actionlint is not wired into CI or pre-commit, so it gates nothing either way.

The negative control is what makes the clean run evidence rather than silence: it proves actionlint actually enforces context availability for `concurrency`, so a clean result on the job-level form means the expression resolves, not that nothing was checked.

### The group suffix can never be empty, established by execution

An empty suffix would collapse every run into one group, a new bug. A script extracts each `prepare` job's `set-env` script **verbatim from the committed YAML** and executes it under 12 input combinations, 36 executions across the three deploy workflows:

```
deploy-aws-lambda.yml -> group aws-tfstate-<suffix>
  event=push              input=''        -> group=aws-tfstate-dev
  event=workflow_dispatch input='dev'     -> group=aws-tfstate-dev
  event=workflow_dispatch input='staging' -> group=aws-tfstate-staging
  event=workflow_dispatch input='prod'    -> group=aws-tfstate-prod
  event=release           input=''        -> group=aws-tfstate-prod
  event=release           input='staging' -> group=aws-tfstate-staging
  event=pull_request      input=''        -> prepare EXITS 1 -> job skipped, group never claimed
  event=schedule          input=''        -> prepare EXITS 1 -> job skipped, group never claimed
  event=workflow_dispatch input=''        -> prepare EXITS 1 -> job skipped, group never claimed
  event=push              input='bogus'   -> prepare EXITS 1 -> job skipped, group never claimed
  event=push              input=' '       -> prepare EXITS 1 -> job skipped, group never claimed
  event=push              input='DEV'     -> prepare EXITS 1 -> job skipped, group never claimed

empty-suffix occurrences: 0   (across all three workflows, 36 executions)
```

`deploy-aws-fargate.yml` is stricter still: it has no `push` or `release` trigger, so every empty-input row exits 1.

What guarantees this is the `dev|staging|prod` allowlist under `set -euo pipefail`, not the default arms. Empty string does not match, falls to `*)`, and exits 1. Each deploying job then declares `needs: prepare` with **no `if:`** (verified programmatically across all 13 state-mutating jobs, printed alongside the group), and a job whose `needs` failed is skipped, so it never dispatches and never occupies a group. Job-level `concurrency` is evaluated at dispatch, after `needs` resolves, so there is no ordering in which an empty value claims a group.

The three `rollback.yml` jobs and the four literal-suffix jobs cannot be empty by construction: `inputs.environment` is a required `choice` of `dev|staging|prod` on `rollback.yml`'s only trigger (`workflow_dispatch`, no `workflow_call`), and the rest are literals.

### One vocabulary across writers

Groups only serialize against each other if the same environment produces the identical string. All ten AWS/GCP suffixes resolve to exactly `dev`, `staging` or `prod`: from `prepare`'s runtime allowlist (deploy workflows, needed because `workflow_call` inputs are free-form strings), from a `type: choice` (`rollback.yml`), or from a literal (`cleanup-staging.yml`, `destroy-fargate-dev.yml`). No `development`/`dev` divergence is reachable.

## What remains unproven

- **The concurrency behaviour itself is not empirically demonstrated, and this is the single largest gap.** Two overlapping live runs were not staged; group semantics are only observable on GitHub's runners. The evidence is that the expressions are valid, in scope, evaluate to the intended string on every path, and name the object each job actually locks. That is not evidence GitHub queued anything. Since the failure mode is silent, a fix that merely makes collisions rarer would not be a fix, so this gap matters.
- **Nothing exercises most of these groups until someone dispatches the workflow.** A push to `main` exercises `aws-tfstate-dev` and `gcp-tfstate-dev`. `deploy-aws-fargate.yml`, `destroy-fargate-dev.yml`, `cleanup-staging.yml` and `rollback.yml` are all dispatch-only and will not be touched by CI on this PR. The first real cross-workflow collision after merge is the actual test.
- **A queued rollback or destroy can be evicted.** GitHub keeps one pending entry per group; `cancel-in-progress: false` protects the *running* job, not the *pending* one. A `rollback-aws-lambda` queued behind an in-flight prod deploy is cancelled if another deploy queues into the same group. `rollback.yml`'s summary job exits 1 on any non-success, so that surfaces; `cleanup-staging.yml` and `destroy-fargate-dev.yml` have no aggregator, so an evicted destroy shows only as a cancelled job. Inherent to sharing one group across workflows, and still better than concurrent writers.
- **Interaction with `environment:` bindings is untested.** Nine of the ten grouped jobs are bound to deployment environments (all but `deploy-gcp.yml`'s `build-and-deploy`). If required-reviewer rules are ever configured (per #1660, none exist today), it is unclear whether a job parked awaiting approval holds its group. If it does, an unapproved rollback blocks deploys to that environment for the approval window. Same unknown #1803 recorded; not resolvable from the docs and not tested.
- **Nothing enforces the group prefixes staying in sync.** The `aws-tfstate-*`, `aws-fargate-tfstate-*` and `gcp-tfstate-*` literals are matched by convention. A future writer added without the group would silently not serialize, the same class of silent failure as the original bug. #1807 already tracks this for Azure; it now covers three more prefixes.
- **`terraform plan` also takes a state lock**, so plan-only paths could in principle contend. None exist here: every workflow that plans also applies, in the same job, inside the same group. Noted rather than assumed away.
- **I did not verify the backend buckets or the live state objects.** The mapping from backend config to object path is read from the `printf` templates, not from the buckets. `TF_BACKEND_*` are secrets and were not resolved.

## Follow-up filed

- **#1811** (p1) `rollback-aws-fargate` builds its backend key from the Lambda namespace, so a Fargate rollback applies into the Lambda state. Pre-existing; this PR keys its group on the object it actually locks and leaves the key alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Deployment, cleanup, and rollback operations now coordinate more reliably when targeting the same environment.
  * Independent environments can continue deploying in parallel without unnecessary cancellation.
  * In-progress operations are preserved instead of being automatically canceled.

* **Operational Changes**
  * Automatic removal of infrastructure locks has been disabled to prevent potential state corruption.
  * If a stale lock occurs, recovery now requires explicit operator intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->