### PR TITLE
ci: add per-database concurrency groups to database-migration migrate jobs

### DIFF
--- a/.github/workflows/database-migration.yml
+++ b/.github/workflows/database-migration.yml
@@ -225,6 +225,39 @@ jobs:
     if: |
       needs.validate.outputs.is_safe == 'true' &&
       (inputs.cloud == 'aws' || inputs.cloud == 'all')
+    # Serializes migrations against one database: two dispatches for the same
+    # cloud and environment must not run `migrate` concurrently against the same
+    # schema_migrations table (#1593). Deliberately NOT the `aws-tfstate-*` group
+    # deploy-aws-lambda.yml and rollback.yml use: this job only runs `terraform
+    # init` + `terraform output -raw` to read the DB endpoint, takes no state
+    # lock, and the resource needing protection is the database, not the state
+    # file. Different clouds, and the same cloud in different environments, are
+    # different databases and stay concurrent.
+    #
+    # `inputs.environment` is a required `choice` on `workflow_dispatch`, so that
+    # path is constrained to dev|staging|prod server-side. On the `workflow_call`
+    # path it is a plain `type: string`; `required: true` makes the caller pass
+    # the key but GitHub does not enforce that the value is non-empty, and an
+    # empty suffix would collapse every environment into one group. The fallback
+    # below keeps such a call in its own group instead. `validate` rejects an
+    # environment outside the allowlist before this job runs, so the sentinel
+    # should be unreachable in practice; it is here so the group can never be
+    # silently ambiguous if that ordering ever changes.
+    #
+    # `cancel-in-progress: false` because cancelling mid-`migrate` leaves
+    # schema_migrations dirty, which then needs the CUDLY_FORCE_MIGRATION_VERSION
+    # recovery path in internal/database/postgres/migrations/migrate.go. Two
+    # consequences, both accepted as better than concurrent writers to one
+    # database:
+    #   - GitHub keeps one pending entry per group, so a queued migration can be
+    #     evicted by a later dispatch. Unlike rollback.yml, the `summary` job
+    #     below does not exit 1 on a non-success result, so an evicted migration
+    #     leaves the run green; read the per-cloud results it prints.
+    #   - if the `environment:` binding below carries required reviewers, it is
+    #     undocumented whether a job parked awaiting approval holds its group.
+    concurrency:
+      group: db-migrate-aws-${{ inputs.environment || 'unset' }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read
@@ -319,6 +352,14 @@ jobs:
     if: |
       needs.validate.outputs.is_safe == 'true' &&
       (inputs.cloud == 'gcp' || inputs.cloud == 'all')
+    # Serializes migrations against the GCP database for one environment
+    # (#1593). A different database from `migrate-aws`'s, so a different group:
+    # `cloud=all` still migrates the three clouds concurrently. The group-key,
+    # empty-suffix and `cancel-in-progress: false` reasoning documented on
+    # `migrate-aws` applies here identically.
+    concurrency:
+      group: db-migrate-gcp-${{ inputs.environment || 'unset' }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read
@@ -398,6 +439,14 @@ jobs:
     if: |
       needs.validate.outputs.is_safe == 'true' &&
       (inputs.cloud == 'azure' || inputs.cloud == 'all')
+    # Serializes migrations against the Azure database for one environment
+    # (#1593). A different database from `migrate-aws`'s and `migrate-gcp`'s, so
+    # a different group: `cloud=all` still migrates the three clouds
+    # concurrently. The group-key, empty-suffix and `cancel-in-progress: false`
+    # reasoning documented on `migrate-aws` applies here identically.
+    concurrency:
+      group: db-migrate-azure-${{ inputs.environment || 'unset' }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Closes #1593

## Why the diff is smaller than the issue title

#1593 names four workflows. Three of them are already covered on `main`:
`rollback.yml` and `cleanup-staging.yml` by #1806/#1801, and
`destroy-fargate-dev.yml` by #1806. Enumerating every job on `origin/main`
(23ad4e4be) confirms it, and shows `database-migration.yml` as the only one
with no group at the workflow level or on any of its five jobs:

| workflow | top-level | jobs with a group |
| --- | --- | --- |
| `rollback.yml` | none | 4/6 (`rollback-*`; `validate`/`summary` exempt) |
| `cleanup-staging.yml` | none | 4/5 (`destroy-*`; `guard` exempt) |
| `destroy-fargate-dev.yml` | none | 1/2 (`destroy`; `guard` exempt) |
| `database-migration.yml` | none | **0/5** |

So this PR only touches the fourth.

## The change

Job-level `concurrency` on `migrate-aws`, `migrate-gcp` and `migrate-azure`.

**Why not the `*-tfstate-*` groups.** These jobs are not Terraform state
writers. They run `terraform init` plus `terraform output -raw` to read a
database endpoint, which takes no state lock. Reusing
`aws-tfstate-*`/`gcp-tfstate-*`/`azure-tfstate-*` would serialize migrations
against unrelated deploys and still not identify the database. The group keys
on the resource that actually needs protecting, `db-migrate-<cloud>-<env>`:

- two dispatches for the same cloud and environment serialize;
- different clouds, and the same cloud in different environments, stay
  concurrent, so `cloud=all` still fans out across the three clouds.

**`cancel-in-progress: false`.** Cancelling mid-`migrate` leaves
`schema_migrations` dirty, which then needs the `CUDLY_FORCE_MIGRATION_VERSION`
recovery path in `internal/database/postgres/migrations/migrate.go`.

**Empty-group risk, handled explicitly.** `environment` is a required `choice`
constrained to `dev|staging|prod` on `workflow_dispatch`, but on the
`workflow_call` trigger it is a plain `type: string`; `required: true` makes a
caller pass the key, but GitHub does not enforce a non-empty value. An empty
interpolation would collapse every environment into one group, so the
expression falls back to an `unset` sentinel. `validate` rejects an environment
outside the allowlist before any `migrate-*` job runs, so the sentinel should be
unreachable today; it is there so the group cannot become silently ambiguous if
that ordering changes. There is currently no in-repo `uses:` caller of this
workflow.

`validate` and `summary` touch no database and get no group. No top-level group
either, since that would serialize the three clouds against each other.

## Verification

- YAML parses before and after (`yaml.safe_load`).
- Post-change enumeration over the defining predicate, not a sample: 3/3
  `migrate-*` jobs have a group with `cancel-in-progress: false`, 0 uncovered,
  3 distinct groups, 0 non-`migrate-*` jobs given a group, top-level still
  `None`.
- `actionlint` reports the identical 5 pre-existing shellcheck `info` findings
  before and after (line numbers shift only); no new findings. Confirmed
  non-vacuous by a negative control: swapping in a bogus `inputs.*` reference
  makes actionlint flag that exact `group:` line, so it does type-check the
  key. Note `actionlint` is not wired into this repo's CI or pre-commit; this
  was a local run.
- Pre-commit hooks passed; nothing bypassed.

Runtime concurrency behaviour cannot be verified without dispatching real
migrations, so it is argued from the trigger definitions and GitHub's
documented semantics rather than observed.

## Noted, not fixed here

Adding a group makes eviction possible: GitHub keeps one pending entry per
group, so a queued migration can be cancelled by a later dispatch. Unlike
`rollback.yml`, this workflow's `summary` job does not exit 1 on a non-success
result, so an evicted migration would leave the run green. That is a separate
concern from #1593 and is documented inline rather than changed here. #1589
(`terraform init` with no `-backend-config`) is likewise out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved database migration scheduling across AWS, GCP, and Azure.
  * Migrations are now serialized by cloud and environment while allowing work for different databases to proceed independently.
  * In-progress migrations are preserved rather than canceled when new runs start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->