### PR TITLE
fix(ci): bump pinned Go toolchain to 1.26.6 for stdlib CVE fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 # Required GitHub Secrets: None (all checks run without cloud credentials)
 #
 # Required GitHub Variables:
-#   - GO_VERSION: Go version to use (default: 1.26.5)
+#   - GO_VERSION: Go version to use (default: 1.26.6)
 #
 # Triggered by:
 #   - Pull requests to main/develop
@@ -23,7 +23,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.26.6'
   DOCKER_BUILDKIT: 1
   COMPOSE_DOCKER_CLI_BUILD: 1
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## What

Bumps the pinned Go toolchain from `1.26.5` to `1.26.6` in the two workflows that pin it explicitly. 2 files, 3 lines.

| File | Line | Change |
|---|---|---|
| `.github/workflows/ci.yml` | 9 | doc comment `default: 1.26.5` -> `1.26.6` |
| `.github/workflows/ci.yml` | 26 | `GO_VERSION: '1.26.5'` -> `'1.26.6'` |
| `.github/workflows/pre-commit.yml` | 35 | `go-version: "1.26.5"` -> `"1.26.6"` |

Deliberately minimal: `main` is red repo-wide and every open PR is blocked behind this, so this PR is scoped to the smallest change that unblocks the queue. The remaining work is sequenced separately (see "Follow-up" below).

## Why

`Security Scanning` -> `Run govulncheck CVE scanner (all modules)` fails on every branch with 7 Go **standard library** advisories, each `Found in: <pkg>@go1.26.5` / `Fixed in: <pkg>@go1.26.6`: GO-2026-6218 (`net/url`), GO-2026-6091 (`html/template`), GO-2026-6090 (`crypto/tls`), GO-2026-6089 (`net/http`), GO-2026-6088 (`encoding/xml`), GO-2026-5972 (`encoding/asn1`), GO-2026-5026 (`net/http`). `CI Success` fails downstream, so no PR can satisfy the merge gate.

Time-based, not change-based: `govulncheck` fetches the vulnerability DB at run time, so a commit that passed before these advisories were published fails afterwards.

`go1.26.6` confirmed as the current stable patch release via the `go.dev/dl` JSON feed; there is no 1.26.7.

### `pre-commit.yml` was a second stale pin

Issue #1829 identified `ci.yml` as the only pin. It is not: `pre-commit.yml:35` carried the same `1.26.5` in a **double-quoted** form, which the issue's search pattern (`go-version: '`) did not match. It is bumped here so both workflows resolve one toolchain.

### Nothing suppressed

No ignore list, no `-scan` narrowing, no `continue-on-error`, no allowlist. These are real advisories against the running standard library, and the bump resolves them at the root.

## Verification

Against a real `go1.26.6` toolchain (installed via `golang.org/dl/go1.26.6`) using the **exact CI-pinned tool versions**, over the CI module loop `. pkg providers/aws providers/azure providers/gcp tests/e2e`.

**govulncheck v1.1.4 before (go1.26.5)** - reproduces the CI failure exactly:

| Module | Result |
|---|---|
| `.` | 7 vulns, exit **3** |
| `pkg` | 5 vulns, exit **3** |
| `providers/aws` | 5 vulns, exit **3** |
| `providers/azure` | 6 vulns, exit **3** |
| `providers/gcp` | 4 vulns, exit **3** |
| `tests/e2e` | clean, exit 0 |

Root reports precisely the 7 IDs above. Vuln DB stamp `2026-08-13 21:43:54 UTC`, consistent with the pass-then-fail timeline in #1829.

**After (go1.26.6)**: all six modules `No vulnerabilities found.`, **exit 0** each.

**`tests/e2e` specifically** (it declares `go 1.25`, unlike the others): with 1.26.6 as the local toolchain and `GOTOOLCHAIN=auto`, `go version` there resolves `go1.26.6` and `govulncheck -version` reports `Go: go1.26.6`, since auto only ever upgrades. Its `./...` matches no packages because `e2e_test.go` is behind a `//go:build e2e` tag; that is pre-existing and identical on both toolchains.

**Collateral on the newer toolchain** (exit codes captured explicitly, not inferred from empty output):

| Check | Version | Result |
|---|---|---|
| `golangci-lint run --timeout=10m` | **v2.10.1**, exact CI pin | `0 issues.`, exit **0** |
| `go vet ./...` (root, as CI) | go1.26.6 | exit **0** |
| `gosec` per-module, all 6 | **v2.28.0**, exact CI pin | exit **0** each |
| `go build ./...`, all 6 modules | go1.26.6 | exit **0** each |
| `go test ./...` (root) | go1.26.6 | **exit 0**, 32 packages ok, 0 failures |

**Real CI on this exact commit passed end to end**, including `Run govulncheck CVE scanner (all modules) => success`, `Run gosec Security Scanner => success`, `Run golangci-lint => success`, `Run go vet => success`, plus `pre-commit`, `AWS Sanity` and `Azure Sanity`.

## Follow-up (not in this PR)

This PR fixes the CI gate. It does **not** fix the shipped artifact, and that gap is recorded rather than hidden:

- `Dockerfile` (plus `Dockerfile.dev` / `Dockerfile.test`) builds from `golang:1.26.5-alpine3.24`, so the **production binary still contains the 7 vulnerable stdlib packages** until that bump lands.
- The `go` directives in `go.mod` / `go.work` / `pkg` / `providers/*` remain `1.26.5`. `database-migration.yml`, `aws_sanity.yml` and `azure_sanity.yml` resolve their toolchain via `go-version-file: go.mod`, so those five steps keep installing 1.26.5.

That work is prepared and verified on a separate branch, to be sequenced after this merges so the unblock is not coupled to a slower, riskier change.

Closes #1829
