### PR TITLE
sec(build): bump the runtime base to alpine:3.24.1 for fixable OS advisories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,10 @@ RUN npm run build
 # Runtime stage - multi-arch base image
 # ==============================================
 # Image pinned to a SHA256 digest for reproducible builds.
-FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
+# To refresh: `docker buildx imagetools inspect alpine:3.24.1` and update the
+# digest below. This is the multi-arch index digest, not a per-platform one, so
+# it stays correct for every TARGETARCH this image is built for.
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 # Re-declare args for use in this stage
 ARG TARGETARCH

--- a/scripts/scan-shipped-image.sh
+++ b/scripts/scan-shipped-image.sh
@@ -39,9 +39,11 @@
 # WHAT IT DOES NOT COVER. OS package CVEs in the base image (musl, openssl,
 # zlib, curl). govulncheck only knows about Go modules and the Go standard
 # library. A Trivy scan-type: image step would cover those; it is not added
-# here because the pinned alpine:3.21.3 runtime base already carries fixable
-# CRITICAL/HIGH openssl, musl and zlib advisories, so such a gate would land
-# red. Tracked separately.
+# here, and is tracked separately. The reason it was originally deferred is
+# gone: the runtime base was alpine:3.21.3, which carried fixable CRITICAL/HIGH
+# openssl, musl and zlib advisories that would have landed such a gate red on
+# day one. The base is now alpine:3.24.1, measured clean of fixable
+# CRITICAL/HIGH OS advisories, so adding that gate is unblocked.
 #
 # Exit 0 = every Go binary found, and no advisory with a published fix.
 # Exit 1 = at least one fixable advisory, or the enumeration came back empty.


### PR DESCRIPTION
## What

The runtime stage was pinned to `alpine:3.21.3`, which ships 17 OS package advisories that all have a published fix: 2 CRITICAL and 15 HIGH across `libcrypto3`, `libssl3`, `musl`, `musl-utils` and `zlib`.

The CRITICAL is CVE-2026-31789, a heap buffer overflow reachable from a large X.509 certificate, in a service that terminates TLS and connects to its database over TLS.

The base is now `alpine:3.24.1`, pinned by digest.

## Why 3.24.1

`3.21.7` also clears the fixable set and would have been the smaller move, but 3.24 is the current release line and 3.21 reaches end of support first, so this buys a longer runway for the same change. All four candidate lines were measured rather than assumed, because `3.23.5` and `3.22.5` were rebuilt on 2026-06-22, *after* `3.24.1` was published on 2026-06-16, so "latest" was not automatically the cleanest:

| candidate | fixable CRITICAL/HIGH |
|---|---|
| `alpine:3.21.3` (current) | **17** (2 CRITICAL, 15 HIGH) |
| `alpine:3.21.7` | 0 |
| `alpine:3.22.5` | 0 |
| `alpine:3.23.5` | 0 |
| `alpine:3.24.1` (chosen) | 0 |

## The digest

`sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b`

This is the multi-arch OCI index digest, not a per-platform manifest digest, so the pin stays correct for every `TARGETARCH` this image is built for. The new index covers the same eight platforms as the old one (`386`, `amd64`, `arm64v8`, `armv6`, `armv7`, `ppc64le`, `riscv64`, `s390x`).

Resolved three ways that agree:

| method | value |
|---|---|
| `docker buildx imagetools inspect` `Digest:` | `sha256:28bd5fe8...943f8b` |
| registry v2 `Docker-Content-Digest` header | `sha256:28bd5fe8...943f8b` |
| recomputed SHA-256 over the raw index document | `sha256:28bd5fe8...943f8b` |

The third matters because it hashes the content rather than trusting a value the server reports. A genuine digest went stale mid-flight during #1835 when the upstream tag was re-pushed onto a rebuilt image, and the pin is what caught it.

## Measured on the built artifact, not the base tag

A clean base does not prove a clean image: the runtime stage installs `ca-certificates`, `postgresql-client`, `curl` and `tzdata` on top of it. So the identical Dockerfile was built on both bases and the resulting images scanned.

### Before, base tag: `trivy image --severity CRITICAL,HIGH --ignore-unfixed --scanners vuln alpine:3.21.3`

```
alpine:3.21.3 (alpine 3.21.3)
=============================
Total: 17 (HIGH: 15, CRITICAL: 2)

┌────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                             │
├────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2026-31789 │ CRITICAL │ fixed  │ 3.3.3-r0          │ 3.3.7-r0      │ openssl: OpenSSL: Heap buffer overflow on 32-bit systems     │
│            │                │          │        │                   │               │ from large X.509 certificate...                              │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-31789                   │
│            ├────────────────┼──────────┤        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2025-15467 │ HIGH     │        │                   │ 3.3.6-r0      │ openssl: OpenSSL: Remote code execution or Denial of Service │
│            │                │          │        │                   │               │ via oversized Initialization...                              │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-15467                   │
│            ├────────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2025-69421 │          │        │                   │               │ openssl: OpenSSL: Denial of Service via malformed PKCS#12    │
│            │                │          │        │                   │               │ file processing                                              │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-69421                   │
│            ├────────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-28387 │          │        │                   │ 3.3.7-r0      │ openssl: OpenSSL: Arbitrary code execution due to            │
│            │                │          │        │                   │               │ use-after-free in DANE TLSA authentication...                │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-28387                   │
│            ├────────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-28388 │          │        │                   │               │ openssl: OpenSSL: Denial of Service due to NULL pointer      │
│            │                │          │        │                   │               │ dereference in delta...                                      │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-28388                   │
│            ├────────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-28389 │          │        │                   │               │ openssl: OpenSSL: Denial of Service vulnerability in CMS     │
│            │                │          │        │                   │               │ processing                                                   │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-28389                   │
│            ├────────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-28390 │          │        │                   │               │ openssl: OpenSSL: Denial of Service due to NULL pointer      │
│            │                │          │        │                   │               │ dereference in CMS...                                        │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-28390                   │
├────────────┼────────────────┼──────────┤        │                   │               ├──────────────────────────────────────────────────────────────┤
│ libssl3    │ CVE-2026-31789 │ CRITICAL │        │                   │               │ openssl: OpenSSL: Heap buffer overflow on 32-bit systems     │
│            │                │          │        │                   │               │ from large X.509 certificate...                              │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-31789                   │
│            ├────────────────┼──────────┤        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2025-15467 │ HIGH     │        │                   │ 3.3.6-r0      │ openssl: OpenSSL: Remote code execution or Denial of Service │
│            │                │          │        │                   │               │ via oversized Initialization...                              │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-15467                   │
│            ├────────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2025-69421 │          │        │                   │               │ openssl: OpenSSL: Denial of Service via malformed PKCS#12    │
│            │                │          │        │                   │               │ file processing                                              │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-69421                   │
│            ├────────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-28387 │          │        │                   │ 3.3.7-r0      │ openssl: OpenSSL: Arbitrary code execution due to            │
│            │                │          │        │                   │               │ use-after-free in DANE TLSA authentication...                │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-28387                   │
│            ├────────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-28388 │          │        │                   │               │ openssl: OpenSSL: Denial of Service due to NULL pointer      │
│            │                │          │        │                   │               │ dereference in delta...                                      │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-28388                   │
│            ├────────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-28389 │          │        │                   │               │ openssl: OpenSSL: Denial of Service vulnerability in CMS     │
│            │                │          │        │                   │               │ processing                                                   │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-28389                   │
│            ├────────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2026-28390 │          │        │                   │               │ openssl: OpenSSL: Denial of Service due to NULL pointer      │
│            │                │          │        │                   │               │ dereference in CMS...                                        │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-28390                   │
├────────────┼────────────────┤          │        ├───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ musl       │ CVE-2026-40200 │          │        │ 1.2.5-r9          │ 1.2.5-r11     │ musl: musl libc: Arbitrary code execution and denial of      │
│            │                │          │        │                   │               │ service via stack-based...                                   │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-40200                   │
├────────────┤                │          │        │                   │               │                                                              │
│ musl-utils │                │          │        │                   │               │                                                              │
│            │                │          │        │                   │               │                                                              │
│            │                │          │        │                   │               │                                                              │
├────────────┼────────────────┤          │        ├───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ zlib       │ CVE-2026-22184 │          │        │ 1.3.1-r2          │ 1.3.2-r0      │ zlib: zlib: Arbitrary code execution via buffer overflow in  │
│            │                │          │        │                   │               │ untgz utility                                                │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-22184                   │
└────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
```

### After, base tag: same command against `alpine:3.24.1`

```

Report Summary

┌───────────────────────────────┬────────┬─────────────────┐
│            Target             │  Type  │ Vulnerabilities │
├───────────────────────────────┼────────┼─────────────────┤
│ alpine:3.24.1 (alpine 3.24.1) │ alpine │        0        │
└───────────────────────────────┴────────┴─────────────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)

```

### Built artifact, old base (`cudly:1842-oldbase`)

```
Report Summary

┌────────────────────────────────────┬──────────┬─────────────────┐
│               Target               │   Type   │ Vulnerabilities │
├────────────────────────────────────┼──────────┼─────────────────┤
│ cudly:1842-oldbase (alpine 3.21.3) │  alpine  │       17        │
├────────────────────────────────────┼──────────┼─────────────────┤
│ app/cudly                          │ gobinary │        0        │
├────────────────────────────────────┼──────────┼─────────────────┤
│ usr/local/bin/migrate              │ gobinary │        0        │
└────────────────────────────────────┴──────────┴─────────────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


```

### Built artifact, new base (`cudly:1842-amd64`)

```
Report Summary

┌──────────────────────────────────┬──────────┬─────────────────┐
│              Target              │   Type   │ Vulnerabilities │
├──────────────────────────────────┼──────────┼─────────────────┤
│ cudly:1842-amd64 (alpine 3.24.1) │  alpine  │        0        │
├──────────────────────────────────┼──────────┼─────────────────┤
│ app/cudly                        │ gobinary │        0        │
├──────────────────────────────────┼──────────┼─────────────────┤
│ usr/local/bin/migrate            │ gobinary │        0        │
└──────────────────────────────────┴──────────┴─────────────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)

```

Both Go binaries (`/app/cudly`, `/usr/local/bin/migrate`) are at 0 on both bases, so the entire delta is OS packages, which is exactly the class #1841's govulncheck-based scanner does not cover.

## The #1841 image scanner still passes

`bash scripts/scan-shipped-image.sh cudly:1842-amd64` exits 0:

```
==> 2 Go binary/binaries in cudly:1842-amd64
  -> /app/cudly (built with go1.26.6)
    no fix   GO-2026-5932  in golang.org/x/crypto  (tolerated: no published fix)
    => /app/cudly: clean (1 advisory/advisories without a published fix)
  -> /usr/local/bin/migrate (built with go1.26.6)
    => /usr/local/bin/migrate: clean (0 advisory/advisories without a published fix)

OK: 2 Go binary/binaries scanned in cudly:1842-amd64; no advisory with a published fix.
```

Its own self-test suite (`scripts/test-scan-shipped-image.sh`) is 9 passed, 0 failed.

## The application still starts

An Alpine minor bump can move package names, so this was checked rather than assumed. `psql`, `pg_dump`, `curl`, `sh`, `addgroup`, `adduser`, `ca-certificates` and `tzdata` all resolve on both `linux/amd64` and `linux/arm64`.

End to end against a `postgres:16-alpine` container, the image:

- ran all 97 migrations to completion (`migrate` v4.19.1, exercising `psql`/libpq and TLS libs),
- served `/health` with **HTTP 200**,
- and Docker's own `HEALTHCHECK` reported **healthy**, which exercises the in-image `curl` and `/bin/sh`.

`hadolint` v2.15.1 (the digest pinned in `.pre-commit-config.yaml`) is clean on the modified Dockerfile, and `shellcheck` is clean on the modified script.

## Scope

This is the base bump only. Trivy `scan-type: image` is deliberately **not** added here, and remains tracked separately. Adding the gate in the same commit as the fix it depends on would mean both land together with no independent evidence that the gate can actually fail. Ordering is bump first, confirm clean, then gate.

The stale justification in `scripts/scan-shipped-image.sh`, which cited `alpine:3.21.3` as the reason an image gate would land red, is updated in this PR to record that the blocker is gone.

## Pin sites checked

Searched with a loose pattern (`alpine:?3`, `FROM[[:space:]]+alpine`) across the whole repo and classified every hit, rather than a targeted one:

| site | classification |
|---|---|
| `Dockerfile:123` `FROM alpine:3.21.3@sha256:...` | **the runtime base, changed** |
| `scripts/scan-shipped-image.sh:42` | stale comment citing the old base, **updated** |
| `Dockerfile:18` `golang:1.26.6-alpine3.24` | builder stage, does not ship |
| `Dockerfile:94` `node:24-alpine` | frontend builder stage, does not ship |
| `Dockerfile.dev:8`, `Dockerfile.test:8` | dev/test images, never shipped |
| `docker-compose*.yml`, `internal/**/postgres.go` `postgres:16-alpine`, `nginx:alpine` | local dev and test fixtures, not the runtime base |
| `.github/runbooks/compromised-dependency.md:74,77` | illustrative example text, not a live pin |
| `.hadolint.yaml` | prose about Alpine, no version pin |

`Dockerfile` is the only file in the repo with a runtime `FROM alpine`.

## Note on this issue's state

This issue was closed automatically on 2026-08-18T06:16:22Z by the merge of #1841, whose body contains a sentence of the form "This PR does not resolve" immediately followed by a reference to this issue number. GitHub's closing-keyword parser matches the keyword and ignores the negation, so the issue was closed despite the text saying the opposite. Issue #1837 hit the same thing earlier in this run.

That sentence is deliberately paraphrased rather than quoted here, because quoting it verbatim would re-trigger the same parser from this PR body. It has been reopened, and this PR closes it for real.

Refs #1836, #1841.

Closes #1842


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated the runtime environment to a newer Alpine Linux release.
  - Resolved fixable critical and high-severity operating-system package vulnerabilities in the shipped image.

- **Maintenance**
  - Updated image refresh guidance to reflect the new multi-architecture runtime image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->