### PR TITLE
fix(cli): rescale count-derived money when --max-instances truncates a row

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -149,11 +149,10 @@ func applyCoverage(recs []common.Recommendation, coverage float64, drops *common
 		// missing-Details record is a logged anomaly, not a reason to
 		// erase coverage from the run.
 		if common.IsSavingsPlan(rec.Service) {
-			if details, ok := rec.Details.(*common.SavingsPlanDetails); ok {
-				newDetails := *details // Copy the struct
-				newDetails.HourlyCommitment *= ratio
+			if _, ok := rec.Details.(*common.SavingsPlanDetails); ok {
+				// ScaleRecommendationCosts scales HourlyCommitment along with
+				// the cost fields and replaces Details with a scaled copy.
 				adjusted = common.ScaleRecommendationCosts(adjusted, ratio)
-				adjusted.Details = &newDetails
 			} else {
 				AppLogger.Printf("WARNING: SP recommendation for service %q has unexpected Details type %T; passing through unscaled\n", rec.Service, rec.Details)
 			}
@@ -448,16 +447,14 @@ func applyTargetCoverageSP(rec common.Recommendation, targetPct float64) (common
 	// leaving ProjectedUtilization at zero. Setting projection fields on a
 	// rec whose commitment fields couldn't be scaled would produce a
 	// misleading row (projection=target%, savings=full-unscaled).
-	details, ok := rec.Details.(*common.SavingsPlanDetails)
-	if !ok {
+	if _, ok := rec.Details.(*common.SavingsPlanDetails); !ok {
 		AppLogger.Printf("WARNING: SP recommendation for service %q has unexpected Details type %T; passing through unscaled\n", rec.Service, rec.Details)
 		return rec, true
 	}
 	ratio := targetPct / 100.0
-	newDetails := *details // copy
-	newDetails.HourlyCommitment *= ratio
+	// ScaleRecommendationCosts scales HourlyCommitment along with the cost
+	// fields and replaces Details with a scaled copy.
 	adjusted := common.ScaleRecommendationCosts(rec, ratio)
-	adjusted.Details = &newDetails
 	// Shrinking commitment raises projected utilization by 1/ratio
 	// (used is fixed = orig_commit * RecUtil, bought is orig_commit * ratio).
 	// Clamp to 100 since utilization caps at full use.
@@ -511,6 +508,15 @@ func ApplyCountOverride(recs []common.Recommendation, overrideCount int32) []com
 // Recommendations are consumed in slice order, so the caller controls which
 // ones survive by ordering the slice (the main path caps the scorer's
 // savings-sorted output, keeping the highest-value commitments).
+//
+// A truncated recommendation has its extensive money fields scaled by the
+// discrete count ratio, like every other sizing path (see
+// common.ScaleRecommendationCosts). EstimatedSavings and friends are
+// whole-row totals for the count the provider proposed, so cutting Count
+// alone leaves the row claiming the savings of instances the run will not
+// buy. The run summary and the purchase report then overstate the benefit
+// of a capped run, which is the wrong direction to be wrong in on a money
+// path (#1830).
 func ApplyInstanceLimit(recs []common.Recommendation, maxInstances int32) []common.Recommendation {
 	if maxInstances <= 0 {
 		return recs
@@ -525,7 +531,13 @@ func ApplyInstanceLimit(recs []common.Recommendation, maxInstances int32) []comm
 			break
 		}
 		adjusted := rec
+		// rec.Count > remaining and remaining >= 1 together imply rec.Count
+		// >= 2, so the denominator is always positive here. A non-positive
+		// Count can never enter this branch and so is never rescaled: it
+		// buys nothing, there is nothing to scale down to, and a zero or
+		// negative denominator would produce NaN or a sign flip.
 		if rec.Count > remaining {
+			adjusted = common.ScaleRecommendationCosts(rec, float64(remaining)/float64(rec.Count))
 			adjusted.Count = remaining
 		}
 		result = append(result, adjusted)

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -485,6 +485,11 @@ func applySizing(recs []common.Recommendation, cfg Config, coverage float64, dro
 }
 
 // ApplyCountOverride overrides the count for all recommendations.
+//
+// It does NOT rescale the count-derived money fields, so an overridden row
+// still carries the savings of the count the provider proposed. That is the
+// same defect ApplyInstanceLimit had before #1830, on a neighbouring flag,
+// and it runs upstream of the cap. Tracked by #1844.
 func ApplyCountOverride(recs []common.Recommendation, overrideCount int32) []common.Recommendation {
 	if overrideCount <= 0 {
 		return recs

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -425,12 +425,22 @@ func applyTargetCoverageSP(rec common.Recommendation, targetPct float64) (common
 	if rec.RecommendedUtilization <= 0 {
 		return rec, false
 	}
+	// If Details isn't a *SavingsPlanDetails (defensive — should always be
+	// for SP recs), log a warning and pass through UNCHANGED — including
+	// leaving ProjectedUtilization at zero. Setting projection fields on a
+	// rec whose commitment fields couldn't be scaled would produce a
+	// misleading row (projection=target%, savings=full-unscaled).
+	details, ok := rec.Details.(*common.SavingsPlanDetails)
+	if !ok {
+		AppLogger.Printf("WARNING: SP recommendation for service %q has unexpected Details type %T; passing through unscaled\n", rec.Service, rec.Details)
+		return rec, true
+	}
 	// Also treat a $0 HourlyCommitment as "no signal" — CE occasionally
 	// returns placeholder recs with zero commitment. Sizing such a rec
 	// would produce nonsense ($0 commitment * ratio = $0) while still
 	// claiming the target coverage is achieved, which is incoherent.
 	// Pass through unchanged and count in the skip summary.
-	if details, ok := rec.Details.(*common.SavingsPlanDetails); ok && details.HourlyCommitment <= 0 {
+	if details.HourlyCommitment <= 0 {
 		return rec, false
 	}
 
@@ -441,16 +451,6 @@ func applyTargetCoverageSP(rec common.Recommendation, targetPct float64) (common
 	// zero value means we can't sanity-check the result); the scaling itself
 	// uses targetPct directly rather than a recUtil/target ratio so the flag's
 	// intent is honored even when AWS already projects above target.
-	//
-	// If Details isn't a *SavingsPlanDetails (defensive — should always be
-	// for SP recs), log a warning and pass through UNCHANGED — including
-	// leaving ProjectedUtilization at zero. Setting projection fields on a
-	// rec whose commitment fields couldn't be scaled would produce a
-	// misleading row (projection=target%, savings=full-unscaled).
-	if _, ok := rec.Details.(*common.SavingsPlanDetails); !ok {
-		AppLogger.Printf("WARNING: SP recommendation for service %q has unexpected Details type %T; passing through unscaled\n", rec.Service, rec.Details)
-		return rec, true
-	}
 	ratio := targetPct / 100.0
 	// ScaleRecommendationCosts scales HourlyCommitment along with the cost
 	// fields and replaces Details with a scaled copy.

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -488,7 +488,7 @@ func applySizing(recs []common.Recommendation, cfg Config, coverage float64, dro
 //
 // It does NOT rescale the count-derived money fields, so an overridden row
 // still carries the savings of the count the provider proposed. That is the
-// same defect ApplyInstanceLimit had before #1830, on a neighbouring flag,
+// same defect ApplyInstanceLimit had before #1830, on a neighboring flag,
 // and it runs upstream of the cap. Tracked by #1844.
 func ApplyCountOverride(recs []common.Recommendation, overrideCount int32) []common.Recommendation {
 	if overrideCount <= 0 {

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -143,18 +143,22 @@ func applyCoverage(recs []common.Recommendation, coverage float64, drops *common
 		adjusted := rec
 
 		// For Savings Plans, reduce the hourly commitment instead of count.
-		// If the type assertion fails (defensive — Details should always
-		// be *SavingsPlanDetails for SP recs), preserve the recommendation
-		// at its original values rather than silently dropping it. A
-		// missing-Details record is a logged anomaly, not a reason to
-		// erase coverage from the run.
+		// If Details is the wrong type or a nil pointer (defensive — it
+		// should always be a non-nil *SavingsPlanDetails for SP recs),
+		// preserve the recommendation at its original values rather than
+		// silently dropping it. A missing-Details record is a logged
+		// anomaly, not a reason to erase coverage from the run.
+		//
+		// The nil check matters: an interface holding a typed nil satisfies
+		// the assertion, so testing ok alone would send an unscalable rec
+		// down the scaling path.
 		if common.IsSavingsPlan(rec.Service) {
-			if _, ok := rec.Details.(*common.SavingsPlanDetails); ok {
+			if details, ok := rec.Details.(*common.SavingsPlanDetails); ok && details != nil {
 				// ScaleRecommendationCosts scales HourlyCommitment along with
 				// the cost fields and replaces Details with a scaled copy.
 				adjusted = common.ScaleRecommendationCosts(adjusted, ratio)
 			} else {
-				AppLogger.Printf("WARNING: SP recommendation for service %q has unexpected Details type %T; passing through unscaled\n", rec.Service, rec.Details)
+				AppLogger.Printf("WARNING: SP recommendation for service %q has missing or unexpected Details (%T); passing through unscaled\n", rec.Service, rec.Details)
 			}
 			result = append(result, adjusted)
 			continue
@@ -425,14 +429,18 @@ func applyTargetCoverageSP(rec common.Recommendation, targetPct float64) (common
 	if rec.RecommendedUtilization <= 0 {
 		return rec, false
 	}
-	// If Details isn't a *SavingsPlanDetails (defensive — should always be
-	// for SP recs), log a warning and pass through UNCHANGED — including
-	// leaving ProjectedUtilization at zero. Setting projection fields on a
-	// rec whose commitment fields couldn't be scaled would produce a
-	// misleading row (projection=target%, savings=full-unscaled).
+	// If Details isn't a non-nil *SavingsPlanDetails (defensive — it should
+	// always be one for SP recs), log a warning and pass through UNCHANGED —
+	// including leaving ProjectedUtilization at zero. Setting projection
+	// fields on a rec whose commitment fields couldn't be scaled would
+	// produce a misleading row (projection=target%, savings=full-unscaled).
+	//
+	// The nil check must precede the HourlyCommitment read below: an
+	// interface holding a typed nil satisfies the assertion, so reading the
+	// field off it would dereference nil.
 	details, ok := rec.Details.(*common.SavingsPlanDetails)
-	if !ok {
-		AppLogger.Printf("WARNING: SP recommendation for service %q has unexpected Details type %T; passing through unscaled\n", rec.Service, rec.Details)
+	if !ok || details == nil {
+		AppLogger.Printf("WARNING: SP recommendation for service %q has missing or unexpected Details (%T); passing through unscaled\n", rec.Service, rec.Details)
 		return rec, true
 	}
 	// Also treat a $0 HourlyCommitment as "no signal" — CE occasionally

--- a/cmd/helpers_instance_limit_rescale_test.go
+++ b/cmd/helpers_instance_limit_rescale_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math"
 	"testing"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
@@ -138,7 +139,7 @@ func TestApplyInstanceLimitNonPositiveCountIsNotRescaled(t *testing.T) {
 
 	require.Len(t, got, 2)
 	for i := range got {
-		assert.False(t, isNaNOrInf(got[i].EstimatedSavings),
+		assert.False(t, math.IsNaN(got[i].EstimatedSavings) || math.IsInf(got[i].EstimatedSavings, 0),
 			"%s: savings must not become NaN/Inf via a non-positive denominator", got[i].ResourceType)
 	}
 	assert.Equal(t, 0, got[0].Count)
@@ -213,8 +214,4 @@ func TestApplyInstanceLimitTotalMatchesSumOfKeptRows(t *testing.T) {
 	want := 500.0 + 100.0*(4.0/6.0)
 	assert.InDelta(t, want, total, 0.0001,
 		"the reported total must equal the savings of the instances the run will actually buy")
-}
-
-func isNaNOrInf(f float64) bool {
-	return f != f || f > 1e300 || f < -1e300
 }

--- a/cmd/helpers_instance_limit_rescale_test.go
+++ b/cmd/helpers_instance_limit_rescale_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/LeanerCloud/CUDly/pkg/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// float64Ptr is local to this file so the rescale tests can express "the
+// provider returned a monthly breakdown" without borrowing a helper whose
+// nil-vs-zero semantics might change elsewhere.
+func float64Ptr(v float64) *float64 { return &v }
+
+// TestApplyInstanceLimitRescalesTruncatedRow pins the #1830 invariant: a row
+// the cap truncates from N to M carries M/N of the money it entered with.
+//
+// The assertion is the ratio, not a literal figure, so the test keeps
+// meaning if the fixture's dollar values are ever changed.
+func TestApplyInstanceLimitRescalesTruncatedRow(t *testing.T) {
+	const (
+		origCount = 100
+		maxKept   = 10
+		ratio     = float64(maxKept) / float64(origCount)
+	)
+
+	rec := common.Recommendation{
+		Service:              common.ServiceEC2,
+		Region:               "us-east-1",
+		ResourceType:         "m5.large",
+		Count:                origCount,
+		EstimatedSavings:     600,
+		CommitmentCost:       2400,
+		OnDemandCost:         3000,
+		SavingsPercentage:    20,
+		RecurringMonthlyCost: float64Ptr(200),
+	}
+
+	got := ApplyInstanceLimit([]common.Recommendation{rec}, maxKept)
+
+	require.Len(t, got, 1)
+	require.Equal(t, maxKept, got[0].Count, "the cap must truncate Count to the budget")
+
+	assert.InDelta(t, rec.EstimatedSavings*ratio, got[0].EstimatedSavings, 0.0001,
+		"EstimatedSavings is a whole-row total and must scale with the truncated Count")
+	assert.InDelta(t, rec.CommitmentCost*ratio, got[0].CommitmentCost, 0.0001,
+		"CommitmentCost is a whole-row total and must scale with the truncated Count")
+	assert.InDelta(t, rec.OnDemandCost*ratio, got[0].OnDemandCost, 0.0001,
+		"OnDemandCost is a whole-row total and must scale with the truncated Count")
+
+	require.NotNil(t, got[0].RecurringMonthlyCost,
+		"a present monthly breakdown must stay present after truncation")
+	assert.InDelta(t, *rec.RecurringMonthlyCost*ratio, *got[0].RecurringMonthlyCost, 0.0001,
+		"RecurringMonthlyCost is a whole-row total and must scale with the truncated Count")
+
+	// SavingsPercentage is a ratio of two figures that scale together, so it
+	// is invariant under truncation. Scaling it would be the mirror-image bug.
+	assert.InDelta(t, rec.SavingsPercentage, got[0].SavingsPercentage, 0.0001,
+		"SavingsPercentage is intensive and must not be scaled")
+
+	// The caller's rec must not be mutated: RecurringMonthlyCost is a pointer
+	// and a shared target would corrupt the pre-cap slice the reporter diffs
+	// against.
+	assert.Equal(t, origCount, rec.Count, "the input rec must not be mutated")
+	assert.InDelta(t, 600.0, rec.EstimatedSavings, 0.0001, "the input rec must not be mutated")
+	require.NotNil(t, rec.RecurringMonthlyCost)
+	assert.InDelta(t, 200.0, *rec.RecurringMonthlyCost, 0.0001,
+		"the input rec's pointer target must not be mutated")
+}
+
+// TestApplyInstanceLimitLeavesUntruncatedRowsUntouched is the other direction:
+// a fix that rescaled every row would satisfy the truncation test above while
+// silently shrinking rows that fit inside the budget.
+func TestApplyInstanceLimitLeavesUntruncatedRowsUntouched(t *testing.T) {
+	monthly := float64Ptr(200)
+	rec := common.Recommendation{
+		Service:              common.ServiceEC2,
+		Region:               "us-east-1",
+		ResourceType:         "m5.large",
+		Count:                4,
+		EstimatedSavings:     600,
+		CommitmentCost:       2400,
+		OnDemandCost:         3000,
+		SavingsPercentage:    20,
+		RecurringMonthlyCost: monthly,
+	}
+
+	// A budget strictly larger than the row's Count, so the row fits whole.
+	got := ApplyInstanceLimit([]common.Recommendation{rec}, 10)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, 4, got[0].Count, "a row that fits the budget keeps its Count")
+	assert.InDelta(t, 600.0, got[0].EstimatedSavings, 0.0001,
+		"an untruncated row must keep its savings; rescaling everything is the mirror-image bug")
+	assert.InDelta(t, 2400.0, got[0].CommitmentCost, 0.0001, "an untruncated row must keep its commitment cost")
+	assert.InDelta(t, 3000.0, got[0].OnDemandCost, 0.0001, "an untruncated row must keep its on-demand cost")
+	require.NotNil(t, got[0].RecurringMonthlyCost)
+	assert.InDelta(t, 200.0, *got[0].RecurringMonthlyCost, 0.0001,
+		"an untruncated row must keep its monthly cost")
+}
+
+// TestApplyInstanceLimitPreservesNilRecurringMonthlyCost pins the
+// absent-versus-zero rule: nil means "the provider returned no monthly
+// breakdown" and the frontend renders it as "—". Truncation must not turn
+// that into a confident $0.
+func TestApplyInstanceLimitPreservesNilRecurringMonthlyCost(t *testing.T) {
+	recs := []common.Recommendation{
+		{
+			Service:              common.ServiceEC2,
+			Region:               "us-east-1",
+			ResourceType:         "truncated",
+			Count:                100,
+			EstimatedSavings:     600,
+			RecurringMonthlyCost: nil,
+		},
+	}
+
+	got := ApplyInstanceLimit(recs, 10)
+
+	require.Len(t, got, 1)
+	require.Equal(t, 10, got[0].Count)
+	assert.Nil(t, got[0].RecurringMonthlyCost,
+		"a nil monthly cost means absent, not zero, and must survive truncation as nil")
+}
+
+// TestApplyInstanceLimitNonPositiveCountIsNotRescaled guards the divide-by-zero
+// denominator. A Count of 0 or below buys nothing and cannot be truncated, so
+// it must pass through with its money untouched rather than through a ratio
+// computed from a zero denominator (NaN) or a negative one (sign flip).
+func TestApplyInstanceLimitNonPositiveCountIsNotRescaled(t *testing.T) {
+	recs := []common.Recommendation{
+		{ResourceType: "zero-count", Count: 0, EstimatedSavings: 600, OnDemandCost: 100},
+		{ResourceType: "negative-count", Count: -5, EstimatedSavings: 300, OnDemandCost: 50},
+	}
+
+	got := ApplyInstanceLimit(recs, 10)
+
+	require.Len(t, got, 2)
+	for i := range got {
+		assert.False(t, isNaNOrInf(got[i].EstimatedSavings),
+			"%s: savings must not become NaN/Inf via a non-positive denominator", got[i].ResourceType)
+	}
+	assert.Equal(t, 0, got[0].Count)
+	assert.InDelta(t, 600.0, got[0].EstimatedSavings, 0.0001, "a zero-count row is not truncated, so it is not rescaled")
+	assert.InDelta(t, 100.0, got[0].OnDemandCost, 0.0001, "a zero-count row is not truncated, so it is not rescaled")
+	assert.Equal(t, -5, got[1].Count)
+	assert.InDelta(t, 300.0, got[1].EstimatedSavings, 0.0001, "a negative-count row is not truncated, so it is not rescaled")
+	assert.InDelta(t, 50.0, got[1].OnDemandCost, 0.0001, "a negative-count row is not truncated, so it is not rescaled")
+}
+
+// TestApplyInstanceLimitRescalesSavingsPlanHourlyCommitment covers the Savings
+// Plan case. SP recs are parsed at Count 1 and so are normally undivisible,
+// but --override-count sets Count on every rec without discriminating by
+// commitment type (ApplyCountOverride), which lets an SP reach the cap at a
+// count the budget can truncate. HourlyCommitment is the SP's actual money
+// quantity, so leaving it whole while the cost fields shrink produces exactly
+// the internally-inconsistent row #1830 warns about.
+func TestApplyInstanceLimitRescalesSavingsPlanHourlyCommitment(t *testing.T) {
+	const ratio = 2.0 / 5.0
+
+	rec := common.Recommendation{
+		Service:          common.ServiceSavingsPlansCompute,
+		Region:           "us-east-1",
+		Count:            5,
+		EstimatedSavings: 500,
+		Details: &common.SavingsPlanDetails{
+			PlanType:         "Compute",
+			HourlyCommitment: 10,
+		},
+	}
+
+	got := ApplyInstanceLimit([]common.Recommendation{rec}, 2)
+
+	require.Len(t, got, 1)
+	require.Equal(t, 2, got[0].Count)
+	assert.InDelta(t, 500*ratio, got[0].EstimatedSavings, 0.0001)
+
+	details, ok := got[0].Details.(*common.SavingsPlanDetails)
+	require.True(t, ok, "SP details must survive truncation with their concrete type")
+	assert.InDelta(t, 10*ratio, details.HourlyCommitment, 0.0001,
+		"an SP's hourly commitment must scale with the truncated Count, like every other extensive figure")
+
+	// The caller's Details must not be mutated through the shared pointer.
+	orig, ok := rec.Details.(*common.SavingsPlanDetails)
+	require.True(t, ok)
+	assert.InDelta(t, 10.0, orig.HourlyCommitment, 0.0001,
+		"the input rec's Details pointer target must not be mutated")
+}
+
+// TestApplyInstanceLimitTotalMatchesSumOfKeptRows is the run-summary invariant:
+// what the summary adds up must equal what the run will actually buy. It is
+// asserted against an independently computed expectation rather than against
+// the function's own output, so it cannot agree with a wrong implementation.
+func TestApplyInstanceLimitTotalMatchesSumOfKeptRows(t *testing.T) {
+	recs := []common.Recommendation{
+		{ResourceType: "whole", Count: 6, EstimatedSavings: 500},     // fits whole
+		{ResourceType: "truncated", Count: 6, EstimatedSavings: 100}, // truncated 6 -> 4
+		{ResourceType: "dropped", Count: 6, EstimatedSavings: 900},   // budget exhausted
+	}
+
+	got := ApplyInstanceLimit(recs, 10)
+
+	require.Len(t, got, 2, "the third row must be dropped once the budget is spent")
+	assert.Equal(t, 10, CalculateTotalInstances(got), "the cap is a hard budget")
+
+	var total float64
+	for i := range got {
+		total += got[i].EstimatedSavings
+	}
+	// 500 for the whole row + 100*(4/6) for the truncated one. The dropped
+	// row contributes nothing.
+	want := 500.0 + 100.0*(4.0/6.0)
+	assert.InDelta(t, want, total, 0.0001,
+		"the reported total must equal the savings of the instances the run will actually buy")
+}
+
+func isNaNOrInf(f float64) bool {
+	return f != f || f > 1e300 || f < -1e300
+}

--- a/cmd/helpers_typed_nil_details_test.go
+++ b/cmd/helpers_typed_nil_details_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/LeanerCloud/CUDly/pkg/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// typedNilSPDetails returns a ServiceDetails interface holding a TYPED nil
+// *SavingsPlanDetails. This is not the same value as a plain nil interface:
+// a type assertion to *SavingsPlanDetails succeeds on this one (ok == true)
+// and yields a nil pointer, so any unguarded dereference panics. A plain nil
+// interface fails the assertion and takes the warning path instead, which is
+// why only the typed form reproduces the crash.
+func typedNilSPDetails() common.ServiceDetails {
+	var d *common.SavingsPlanDetails // nil pointer of concrete type
+	return d
+}
+
+// TestTypedNilSPDetailsAssertionSucceeds pins the Go semantic the other tests
+// in this file depend on. If this ever stops holding, the guards below are
+// guarding nothing and the tests would pass vacuously.
+func TestTypedNilSPDetailsAssertionSucceeds(t *testing.T) {
+	details, ok := typedNilSPDetails().(*common.SavingsPlanDetails)
+	require.True(t, ok, "a typed nil must still satisfy the type assertion")
+	require.Nil(t, details, "and must yield a nil pointer, which is what makes an unguarded deref panic")
+
+	var plain common.ServiceDetails
+	_, plainOK := plain.(*common.SavingsPlanDetails)
+	require.False(t, plainOK, "a plain nil interface must NOT satisfy it; the two values differ")
+}
+
+// TestScaleRecommendationCostsSurvivesTypedNilDetails covers the helper
+// itself. A malformed recommendation must degrade, not crash: the cost fields
+// still scale (they do not depend on Details) and Details is left exactly as
+// it was rather than being replaced with a fabricated zero-value struct.
+func TestScaleRecommendationCostsSurvivesTypedNilDetails(t *testing.T) {
+	rec := common.Recommendation{
+		Service:          common.ServiceSavingsPlansCompute,
+		Count:            4,
+		EstimatedSavings: 500,
+		CommitmentCost:   200,
+		OnDemandCost:     700,
+		Details:          typedNilSPDetails(),
+	}
+
+	var got common.Recommendation
+	require.NotPanics(t, func() {
+		got = common.ScaleRecommendationCosts(rec, 0.5)
+	}, "a typed nil *SavingsPlanDetails must not panic the sizing helper")
+
+	assert.InDelta(t, 250.0, got.EstimatedSavings, 0.0001, "cost fields do not depend on Details and must still scale")
+	assert.InDelta(t, 100.0, got.CommitmentCost, 0.0001)
+	assert.InDelta(t, 350.0, got.OnDemandCost, 0.0001)
+
+	details, ok := got.Details.(*common.SavingsPlanDetails)
+	require.True(t, ok)
+	assert.Nil(t, details,
+		"a nil commitment must stay nil rather than becoming a fabricated zero-value struct")
+}
+
+// TestApplyInstanceLimitSurvivesTypedNilSPDetails is the #1830 path. A capped
+// run must still produce a report when one recommendation is malformed;
+// panicking mid-run leaves the operator with no report at all rather than a
+// degraded one.
+func TestApplyInstanceLimitSurvivesTypedNilSPDetails(t *testing.T) {
+	recs := []common.Recommendation{
+		{
+			Service:          common.ServiceSavingsPlansCompute,
+			ResourceType:     "malformed",
+			Count:            10,
+			EstimatedSavings: 500,
+			Details:          typedNilSPDetails(),
+		},
+		{
+			Service:          common.ServiceEC2,
+			ResourceType:     "healthy",
+			Count:            4,
+			EstimatedSavings: 100,
+		},
+	}
+
+	var got []common.Recommendation
+	require.NotPanics(t, func() {
+		got = ApplyInstanceLimit(recs, 4)
+	}, "a malformed row must not crash the whole capped run")
+
+	require.Len(t, got, 1, "the budget is spent by the first row")
+	assert.Equal(t, 4, got[0].Count)
+	assert.InDelta(t, 500.0*4.0/10.0, got[0].EstimatedSavings, 0.0001,
+		"the truncated row's money still rescales even though its Details are malformed")
+}
+
+// TestApplyCoverageSurvivesTypedNilSPDetails covers the applyCoverage SP
+// branch, which discards the asserted pointer and so cannot see the nil
+// itself. A typed nil must take the same warning-and-pass-through path as a
+// wrong Details type, since neither can have its commitment scaled.
+func TestApplyCoverageSurvivesTypedNilSPDetails(t *testing.T) {
+	rec := common.Recommendation{
+		Service:          common.ServiceSavingsPlansCompute,
+		Count:            1,
+		EstimatedSavings: 500,
+		CommitmentCost:   200,
+		Details:          typedNilSPDetails(),
+	}
+
+	var got []common.Recommendation
+	require.NotPanics(t, func() {
+		got = ApplyCoverage([]common.Recommendation{rec}, 50)
+	}, "a typed nil must not panic the coverage sizing path")
+
+	require.Len(t, got, 1, "a malformed rec is preserved, not dropped")
+	assert.InDelta(t, 500.0, got[0].EstimatedSavings, 0.0001,
+		"an unscalable commitment must pass through UNSCALED rather than scaling costs it cannot match")
+	assert.InDelta(t, 200.0, got[0].CommitmentCost, 0.0001)
+}
+
+// TestApplyTargetCoverageSurvivesTypedNilSPDetails covers applyTargetCoverageSP,
+// which reads HourlyCommitment off the asserted pointer for its no-signal
+// guard and so dereferences before any nil check.
+func TestApplyTargetCoverageSurvivesTypedNilSPDetails(t *testing.T) {
+	rec := common.Recommendation{
+		Service:                common.ServiceSavingsPlansCompute,
+		Count:                  1,
+		RecommendedUtilization: 90,
+		EstimatedSavings:       500,
+		CommitmentCost:         200,
+		Details:                typedNilSPDetails(),
+	}
+
+	var got []common.Recommendation
+	require.NotPanics(t, func() {
+		got = ApplyTargetCoverage([]common.Recommendation{rec}, 80, nil)
+	}, "a typed nil must not panic the target-coverage sizing path")
+
+	require.Len(t, got, 1, "a malformed rec is preserved, not dropped")
+	assert.InDelta(t, 500.0, got[0].EstimatedSavings, 0.0001,
+		"an unscalable commitment must pass through UNSCALED")
+	assert.InDelta(t, 200.0, got[0].CommitmentCost, 0.0001)
+	assert.InDelta(t, 0.0, got[0].ProjectedUtilization, 0.0001,
+		"projection fields stay zero on a rec whose commitment could not be scaled")
+}

--- a/cmd/multi_service_csv_cap.go
+++ b/cmd/multi_service_csv_cap.go
@@ -92,9 +92,15 @@ func savingsPerInstance(rec common.Recommendation) float64 {
 // entirely, which would otherwise leave file order deciding between equals on
 // exactly the path #1741 is about.
 //
-// It must run before the cap, never after: ApplyInstanceLimit truncates Count
-// without rescaling EstimatedSavings (#1830), so a post-cap row's rate is
-// inflated by exactly the amount the cap removed.
+// It must run before the cap, never after: ApplyInstanceLimit consumes its
+// input in slice order, so by the time it returns the selection has already
+// been made and re-ordering the survivors decides nothing.
+//
+// The rate itself is now invariant across the cap. ApplyInstanceLimit scales
+// a truncated row's EstimatedSavings by the same ratio it cuts Count by
+// (#1830), and savings/count is unchanged by scaling both, so ranking is
+// unaffected by where the cap runs. It was not always so: before #1830 a
+// post-cap row's rate was inflated by exactly the amount the cap removed.
 func sortBySavingsPerInstance(recs []common.Recommendation) {
 	sort.SliceStable(recs, func(i, j int) bool {
 		a, b := recs[i], recs[j]

--- a/cmd/multi_service_csv_cap.go
+++ b/cmd/multi_service_csv_cap.go
@@ -94,13 +94,11 @@ func savingsPerInstance(rec common.Recommendation) float64 {
 //
 // It must run before the cap, never after: ApplyInstanceLimit consumes its
 // input in slice order, so by the time it returns the selection has already
-// been made and re-ordering the survivors decides nothing.
-//
-// The rate itself is now invariant across the cap. ApplyInstanceLimit scales
-// a truncated row's EstimatedSavings by the same ratio it cuts Count by
-// (#1830), and savings/count is unchanged by scaling both, so ranking is
-// unaffected by where the cap runs. It was not always so: before #1830 a
-// post-cap row's rate was inflated by exactly the amount the cap removed.
+// been made and re-ordering the survivors decides nothing. The rate values
+// themselves are invariant across the cap since #1830 (a truncated row's
+// savings and Count are scaled by the same ratio, and savings/count is
+// unchanged by scaling both), but that only means a post-cap sort would be
+// harmless rather than useful. Ordering still has to happen first.
 func sortBySavingsPerInstance(recs []common.Recommendation) {
 	sort.SliceStable(recs, func(i, j int) bool {
 		a, b := recs[i], recs[j]

--- a/cmd/multi_service_max_instances_test.go
+++ b/cmd/multi_service_max_instances_test.go
@@ -511,8 +511,12 @@ rds,us-east-1,db.t3.large,postgres,6,100.00,1yr,All Upfront,123456789012
 	assert.InDelta(t, 500.00, got[0].EstimatedSavings, 0.001)
 	assert.Equal(t, countPerRow, got[0].Count)
 	assert.Equal(t, "db.t3.large", got[1].ResourceType)
-	assert.InDelta(t, 100.00, got[1].EstimatedSavings, 0.001)
 	assert.Equal(t, maxInstances-countPerRow, got[1].Count)
+	// This row is truncated, so its savings are the file's figure scaled by
+	// the share of the row the budget actually buys (#1830). Asserting the
+	// unscaled 100.00 here is what the bug looked like.
+	assert.InDelta(t, 100.00*float64(maxInstances-countPerRow)/float64(countPerRow),
+		got[1].EstimatedSavings, 0.001)
 
 	// Nothing shrinks silently: the row the cap dropped is named.
 	assert.Contains(t, out, "db.t3.small")

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -277,13 +277,30 @@ type ServiceDetails interface {
 	GetDetailDescription() string
 }
 
-// ScaleRecommendationCosts multiplies all cost-bearing fields of rec by
-// ratio and returns the result. RecurringMonthlyCost is allocated as a
-// new pointer when present so callers don't mutate the upstream rec's
-// pointer target. Used by sizing paths (ApplyCoverage, ApplyTargetCoverage,
-// family-NU) to keep Count and cost in sync when a recommendation is
-// sized down (or up) from AWS's proposal — without this helper the same
-// four-field scaling pattern was duplicated at every sizing site.
+// ScaleRecommendationCosts multiplies every extensive (whole-row) money field
+// of rec by ratio and returns the result. Used by sizing paths (ApplyCoverage,
+// ApplyTargetCoverage, ApplyInstanceLimit, family-NU) to keep Count and cost in
+// sync when a recommendation is sized down (or up) from AWS's proposal.
+// Without this helper the same scaling pattern was duplicated at every sizing
+// site, and #1830 was a sizing site that forgot it entirely.
+//
+// Extensive fields scale here; intensive ones deliberately do not.
+// SavingsPercentage and BreakEvenMonths are ratios of two figures that scale
+// together, so they are invariant. RecommendedCount is a frozen record of the
+// provider's pre-sizing proposal. AverageInstancesUsedPerHour and UsageHistory
+// describe observed demand, which does not change with what we choose to buy.
+//
+// Pointer and pointed-to state is copied rather than mutated: callers hold the
+// pre-sizing slice (the reporter diffs against it), so writing through a
+// shared pointer would corrupt their copy.
+//
+//   - RecurringMonthlyCost is allocated as a new pointer when present. A nil
+//     stays nil: nil means "the provider returned no monthly breakdown" and
+//     renders as "—", which is not the same claim as $0.
+//   - SavingsPlanDetails.HourlyCommitment is the SP's own money quantity (an
+//     SP commitment is dollar-denominated, not count-denominated), so it
+//     scales with the rest. Details is replaced with a scaled copy. A rec
+//     whose Details is any other type is left alone.
 func ScaleRecommendationCosts(rec Recommendation, ratio float64) Recommendation {
 	rec.CommitmentCost *= ratio
 	rec.OnDemandCost *= ratio
@@ -291,6 +308,11 @@ func ScaleRecommendationCosts(rec Recommendation, ratio float64) Recommendation 
 	if rec.RecurringMonthlyCost != nil {
 		scaled := *rec.RecurringMonthlyCost * ratio
 		rec.RecurringMonthlyCost = &scaled
+	}
+	if details, ok := rec.Details.(*SavingsPlanDetails); ok {
+		scaled := *details
+		scaled.HourlyCommitment *= ratio
+		rec.Details = &scaled
 	}
 	return rec
 }

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -284,11 +284,19 @@ type ServiceDetails interface {
 // Without this helper the same scaling pattern was duplicated at every sizing
 // site, and #1830 was a sizing site that forgot it entirely.
 //
-// Extensive fields scale here; intensive ones deliberately do not.
+// Extensive MONEY fields scale here; intensive ones deliberately do not.
 // SavingsPercentage and BreakEvenMonths are ratios of two figures that scale
 // together, so they are invariant. RecommendedCount is a frozen record of the
 // provider's pre-sizing proposal. AverageInstancesUsedPerHour and UsageHistory
 // describe observed demand, which does not change with what we choose to buy.
+//
+// Two count-linear NON-money fields are deliberately out of scope here and are
+// the caller's problem: ProjectedCoverage / ProjectedUtilization (recomputed
+// from the chosen quantity by the target-coverage callers, which is why
+// scaling them here would be wrong) and DataWarehouseDetails.NumberOfNodes
+// (a Redshift count mirror set at parse time). Neither is re-derived by
+// ApplyInstanceLimit, so a capped run can still report a projection sized for
+// the pre-cap count. Tracked separately; purchases read Count, not these.
 //
 // Pointer and pointed-to state is copied rather than mutated: callers hold the
 // pre-sizing slice (the reporter diffs against it), so writing through a

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -296,7 +296,7 @@ type ServiceDetails interface {
 // scaling them here would be wrong) and DataWarehouseDetails.NumberOfNodes
 // (a Redshift count mirror set at parse time). Neither is re-derived by
 // ApplyInstanceLimit, so a capped run can still report a projection sized for
-// the pre-cap count. Tracked separately; purchases read Count, not these.
+// the pre-cap count. Tracked by #1845; purchases read Count, not these.
 //
 // Pointer and pointed-to state is copied rather than mutated: callers hold the
 // pre-sizing slice (the reporter diffs against it), so writing through a

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -317,7 +317,12 @@ func ScaleRecommendationCosts(rec Recommendation, ratio float64) Recommendation 
 		scaled := *rec.RecurringMonthlyCost * ratio
 		rec.RecurringMonthlyCost = &scaled
 	}
-	if details, ok := rec.Details.(*SavingsPlanDetails); ok {
+	// The nil check is not redundant with the comma-ok: an interface holding a
+	// typed nil (*SavingsPlanDetails)(nil) satisfies the assertion with
+	// ok == true, so copying without it dereferences nil. A malformed rec is
+	// left exactly as it was rather than gaining a fabricated zero-value
+	// commitment.
+	if details, ok := rec.Details.(*SavingsPlanDetails); ok && details != nil {
 		scaled := *details
 		scaled.HourlyCommitment *= ratio
 		rec.Details = &scaled


### PR DESCRIPTION
## What

`ApplyInstanceLimit` truncated a recommendation's `Count` to fit the `--max-instances` budget but copied the struct wholesale, so every whole-row money figure survived at its full pre-cap value.

Reproduced by the new test against the pre-fix code: a row entering with `Count=100, EstimatedSavings=600` left as `Count=10, EstimatedSavings=600`, a **10x** overstatement for that row.

The figure flows into the run summary, the `ConfirmPurchase` prompt, the purchase report and the CSV, so an operator saw a capped run promising savings it cannot deliver. On a money path that is the wrong direction to be wrong in. Affects both the default and the `--input-csv` path, and is pre-existing rather than introduced by #1825.

## The enumeration

The issue asked for every count-derived field to be enumerated before patching any one of them, since a report that is internally inconsistent is harder to notice than one uniformly wrong. The full `Recommendation` struct:

**Rescaled (extensive, whole-row totals):**

| Field | Why |
| --- | --- |
| `EstimatedSavings` | savings for the full recommended quantity |
| `CommitmentCost` | upfront for the full quantity |
| `OnDemandCost` | on-demand cost for the full quantity |
| `RecurringMonthlyCost` | monthly charge for the full quantity (`*float64`; nil stays nil) |
| `SavingsPlanDetails.HourlyCommitment` | the SP's own money quantity |

**Deliberately not rescaled:**

| Field | Why |
| --- | --- |
| `SavingsPercentage`, `BreakEvenMonths` | ratios of two figures that scale together, so invariant |
| `RecommendedCount` | a frozen record of the provider's pre-sizing proposal, deliberately preserved for audit |
| `AverageInstancesUsedPerHour`, `UsageHistory` | observed demand; does not change with what we choose to buy |
| `ExistingCoveragePct`, `ExistingCoverageKnown` | describes commitments already owned |
| identity/metadata fields, `RawRecommendation` | not quantities |

`UpfrontCost` and `TotalCost`, named as candidates in the issue, are fields of `OfferingDetails`, a sibling struct that is not embedded in `Recommendation` and is not reachable from this path. No change needed.

Two count-linear **non-money** fields are left alone and filed separately rather than silently ignored: `ProjectedCoverage`/`ProjectedUtilization` and `DataWarehouseDetails.NumberOfNodes` (#1845). Both are documented as out of scope on the helper.

## How

Truncated rows are scaled by the discrete count ratio through `common.ScaleRecommendationCosts`, the helper `ApplyCoverage`, `ApplyTargetCoverage` and family-NU sizing already used. `ApplyInstanceLimit` was the one sizing path that mutated `Count` without it.

`ScaleRecommendationCosts` now also scales `SavingsPlanDetails.HourlyCommitment`. That line was duplicated at both of its existing call sites and missing at this new third one, which is precisely how the omission happened. An SP commitment is dollar-denominated, and `ApplyCountOverride` sets `Count` on SP recs without discriminating by commitment type, so an SP can reach the cap at a truncatable count; scaling its costs while leaving its commitment whole would produce an internally inconsistent row. The two existing call sites now delegate, which is provably equivalent (both previously overwrote `Details` with their own scaled copy after calling the helper, so the commitment is scaled exactly once either way).

`rec.Count > remaining` and `remaining >= 1` together imply `rec.Count >= 2`, so the denominator is always positive and a non-positive `Count` can never enter the branch.

## Interaction with the #1825 ranking key

`savingsPerInstance` divides `EstimatedSavings` by `Count`. Scaling both by the same ratio leaves the quotient exactly unchanged, so **ranking behaviour is unaffected** and the ordering still happens before the cap regardless.

The comment on `sortBySavingsPerInstance` cited #1830 as its justification ("a post-cap row's rate is inflated by exactly the amount the cap removed"). That reason evaporates with this fix, so it is corrected: the sort must still run first because the cap's *selection* consumes slice order, which has nothing to do with #1830.

## Existing compensation

Searched for anything that compensates for the un-rescaled value and would now double-correct. Nothing does. `sumPassedRecs`, `reporter.RenderSummary`, `calculateServiceStats` and the CSV writer are all plain summations of the post-cap rows, so they are silently wrong today and become correct with no change. The only reference to the bug was the stale comment above.

One pre-existing test assertion (`TestCSVCapKeepsHighestSavingsNotFileOrder`) hardcoded the un-rescaled `100.00` on a row truncated 6 to 4. That assertion encoded the bug and is updated to the invariant.

## Verification

Regression tests confirmed to **fail against the pre-fix code**, by assertion rather than panic:

```
TestApplyInstanceLimitRescalesTruncatedRow                 FAIL  600 vs expected 60 (the issue's 10x)
TestApplyInstanceLimitRescalesSavingsPlanHourlyCommitment  FAIL  500 vs expected 200
TestApplyInstanceLimitTotalMatchesSumOfKeptRows            FAIL  600 vs expected 566.67
```

Mutation-verified individually with `-run '^ExactName$' -count=1`, every failure by assertion:

| Mutation | Caught by |
| --- | --- |
| no rescale at all | the 3 tests above |
| rescale every row, not just truncated | `LeavesUntruncatedRowsUntouched`, `TotalMatchesSumOfKeptRows` |
| drop the non-positive-Count guard | `NonPositiveCountIsNotRescaled` (observed `+Inf`/`NaN`) |
| coerce nil `RecurringMonthlyCost` to 0 | `PreservesNilRecurringMonthlyCost` |
| drop SP `HourlyCommitment` scaling | the SP test, **and the pre-existing coverage tests**, confirming the two simplified call sites genuinely delegate |

Both directions are covered: truncated rows are rescaled, and untruncated rows keep their money including pointer fields.

Suites: `cmd` 859 passed, `pkg` 744 passed, `providers/aws` 1212 passed (separate modules in the `go.work` monorepo). `gocyclo -over 10` clean at the pre-commit hook's exact scope. `golangci-lint v2.10.1` (the CI-pinned version) reports 0 issues on the root module; the `pkg` module's 205 findings are identical to `origin/main`, verified by diffing the normalized finding sets.

## Follow-ups filed

- #1844 (p1) `--override-count` has the identical defect on a neighbouring flag and runs **upstream** of the cap, so the cap's new rescale computes against an already-wrong base. Kept out of this PR to hold it to one concern.
- #1845 (p2) the projection and node-count mirrors that no sizing path re-derives.

Closes #1830


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Savings and cost estimates now scale proportionally when recommendations are reduced by instance limits.
  - Savings Plan hourly commitments adjust consistently with retained recommendation counts.
  - Overall savings totals accurately reflect the recommendations shown.
  - Unaffected recommendations and missing cost values remain unchanged.
  - Invalid or incomplete recommendation details no longer cause scaling errors.
  - Recommendation data remains intact when scaling is applied.

- **Documentation**
  - Clarified how recommendation counts, instance limits, and monetary values are handled during scaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->