### PR TITLE
test(api): cover retry-any:purchases carve-out at the retry handler

### DIFF
--- a/internal/api/retry_carveout_test.go
+++ b/internal/api/retry_carveout_test.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LeanerCloud/CUDly/internal/auth"
+	"github.com/LeanerCloud/CUDly/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Handler-level coverage for the retry-any:purchases carve-out (issue #1743).
+//
+// retry-any is the third #923 money verb, and the only one whose enforcement
+// point is NOT requirePermission: retryPurchase authorizes through
+// authorizeSessionRetry, which calls HasPermissionAPI directly.
+// TestGrantAdmin_CarveOutIsEnforcedAtHandler pins the verb at the
+// requirePermission seam, but nothing reached it through the retry handler,
+// because the retry suite's shared fixture (buildSessionRetryHandler)
+// hand-registers HasPermissionAPI with a caller-supplied boolean and the
+// literal "retry-any". The real matcher, and with it adminCarvedOuts, was
+// never consulted on this path, which is also why instrumenting grantAdmin
+// recorded zero asks for the pair.
+//
+// The two tests below differ in the PRINCIPAL only. Same failed row, same
+// request, same fixture: whether the retry is refused or allowed turns purely
+// on whether the caller holds retry-any explicitly. Both directions are
+// covered on purpose, since a refusal-only test passes equally well against a
+// handler that refuses everyone.
+
+// retryCarveoutFailedExec is the fixture both tests act on: a failed row
+// created by a DIFFERENT user. Creator-owned rows are reachable via retry-own,
+// which is deliberately not carved out, so only a foreign row isolates
+// retry-any as the deciding grant.
+func retryCarveoutFailedExec() *config.PurchaseExecution {
+	creator := retryOtherID
+	return &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "failed",
+		Error:           "send failed: transient SES throttle",
+		CreatedByUserID: &creator,
+		Recommendations: []config.RecommendationRecord{
+			{Provider: "aws", Service: "ec2", Term: 1, UpfrontCost: 100},
+		},
+	}
+}
+
+// wireRetryCarveout registers the mocks a retryPurchase call needs against a
+// principal holding exactly perms, answered by the REAL matcher via
+// grantPermissions rather than by a hardcoded boolean.
+//
+// The mocks are constructed by the caller rather than returned from here so
+// each assertion site's receiver binds to a new(...) in the test's own scope,
+// which is what internal/mocks.TestNoUnfailableMockAssertions needs in order
+// to check the matcher counts instead of reporting the site as unanalyzable.
+func wireRetryCarveout(t *testing.T, failed *config.PurchaseExecution, mockConfig *MockConfigStore, mockAuth *MockAuthService, perms []auth.Permission) *Handler {
+	t.Helper()
+
+	mockConfig.On("GetExecutionByID", mock.Anything, failed.ExecutionID).Return(failed, nil)
+	mockConfig.On("GetGlobalConfig", mock.Anything).Return(&config.GlobalConfig{}, nil).Maybe()
+
+	t.Cleanup(func() { mockAuth.AssertExpectations(t) })
+	session := &Session{UserID: retryCallerID, Email: "operator@example.com"}
+	mockAuth.On("ValidateSession", mock.Anything, "sess-tok").Return(session, nil)
+	mockAuth.grantPermissions(perms)
+
+	return &Handler{config: mockConfig, auth: mockAuth}
+}
+
+// TestRetryCarveOut_PlainAdminIsRefused pins the refusal direction end to end
+// through retryPurchase. This is the assertion that fails if retry-any is
+// dropped from adminCarvedOuts: without the carve-out the admin's wildcard
+// answers retry-any true and the retry is authorized against another user's
+// failed row.
+func TestRetryCarveOut_PlainAdminIsRefused(t *testing.T) {
+	failed := retryCarveoutFailedExec()
+	mockConfig := new(MockConfigStore)
+	mockAuth := new(MockAuthService)
+	h := wireRetryCarveout(t, failed, mockConfig, mockAuth, []auth.Permission{
+		{Action: auth.ActionAdmin, Resource: auth.ResourceAll},
+	})
+
+	result, err := h.retryPurchase(context.Background(), sessionRetryReq(), failed.ExecutionID)
+
+	require.Error(t, err, "admin:* must NOT grant retry-any:purchases (issue #923)")
+	assert.Nil(t, result)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "a carve-out denial must be a client error, not a 500")
+	assert.Equal(t, 403, ce.code)
+
+	// The refusal must come from authorizeSessionRetry's creator check, which
+	// is only reached because retry-any was denied. retryPurchase runs that
+	// gate before the SEC-01 constraint gate, so this pins the RBAC decision
+	// rather than a later denial that would also produce a 403.
+	//
+	// Do NOT relax this to a bare require.Error. Dropping retry-any from
+	// adminCarvedOuts lets the caller past this gate, but the SEC-01 gate then
+	// refuses it on execute:purchases with a different message and still a 403.
+	// The message is what distinguishes the two, so this line IS the regression
+	// barrier: without it the test passes with the carve-out deleted.
+	assert.Contains(t, err.Error(), "another user's failed purchase")
+
+	// Assert the pair was actually asked BEFORE asserting the absence of a
+	// write: a request that never reached the permission check would satisfy
+	// the AssertNotCalled below vacuously.
+	mockAuth.AssertCalled(t, "HasPermissionAPI", mock.Anything, retryCallerID,
+		auth.ActionRetryAny, auth.ResourcePurchases)
+	mockConfig.AssertNotCalled(t, "SavePurchaseExecution")
+	mockConfig.AssertNotCalled(t, "WithTx")
+}
+
+// TestRetryCarveOut_AdminPurchaserIsAllowed pins the other direction on the
+// identical row and request. Without it, a handler that refused every caller
+// would satisfy the refusal test above, hiding a Purchaser group that failed
+// to grant the verb at all.
+func TestRetryCarveOut_AdminPurchaserIsAllowed(t *testing.T) {
+	failed := retryCarveoutFailedExec()
+	mockConfig := new(MockConfigStore)
+	mockAuth := new(MockAuthService)
+	h := wireRetryCarveout(t, failed, mockConfig, mockAuth, []auth.Permission{
+		{Action: auth.ActionAdmin, Resource: auth.ResourceAll},
+		{Action: auth.ActionExecute, Resource: auth.ResourcePurchases},
+		{Action: auth.ActionRetryAny, Resource: auth.ResourcePurchases},
+	})
+
+	saved := []*config.PurchaseExecution{}
+	mockConfig.On("SavePurchaseExecution", mock.Anything, mock.AnythingOfType("*config.PurchaseExecution")).
+		Run(func(args mock.Arguments) {
+			snap := *args.Get(1).(*config.PurchaseExecution)
+			saved = append(saved, &snap)
+		}).
+		Return(nil)
+
+	result, err := h.retryPurchase(context.Background(), sessionRetryReq(), failed.ExecutionID)
+
+	require.NoError(t, err, "admin + Purchaser must be able to retry another user's failed row")
+	resp, ok := result.(map[string]any)
+	require.True(t, ok, "retryPurchase must return a response map")
+	assert.Equal(t, failed.ExecutionID, resp["original_execution"])
+	assert.NotEmpty(t, resp["execution_id"])
+
+	require.GreaterOrEqual(t, len(saved), 2,
+		"expected the successor write plus the linkage update on the original")
+	assert.Equal(t, 1, saved[0].RetryAttemptN, "fresh first retry -> n=1")
+	require.NotNil(t, saved[1].RetryExecutionID, "original must point at the successor")
+	assert.Equal(t, saved[0].ExecutionID, *saved[1].RetryExecutionID)
+
+	mockAuth.AssertCalled(t, "HasPermissionAPI", mock.Anything, retryCallerID,
+		auth.ActionRetryAny, auth.ResourcePurchases)
+}


### PR DESCRIPTION
Closes #1743

## What

Handler-level coverage for the `retry-any:purchases` carve-out (#923) at the retry handler.
Test-only: one new file, no production code touched.

## The issue's premise was wrong, and the reason is the finding

#1743 was filed on the possibility that this verb might be unenforced. It is not. Full premise
correction with evidence is on the issue:
https://github.com/LeanerCloud/CUDly/issues/1743#issuecomment-5334894363

Please read that before reviewing, so the disproved "no non-test reference in `internal/api`" claim
does not get re-derived from scratch.

Short version. The verb is enforced at `internal/api/handler_purchases.go:1962` and the path is
reachable:

```
POST /api/purchases/retry/{id}          router.go:178  (Auth: AuthUser)
  -> Handler.retryPurchase              handler_purchases.go:1611
  -> loadAndValidateRetryRequest        handler_purchases.go:1672
  -> Handler.authorizeSessionRetry      handler_purchases.go:1699 -> 1952
  -> h.auth.HasPermissionAPI(ActionRetryAny, ResourcePurchases)   handler_purchases.go:1962
  -> auth.Service.permissionsAllow      service_group.go:325
  -> adminCarvedOuts consulted          service_group.go:328
```

## Why the gap existed

`retry-any` is the only one of the three carved-out money verbs whose enforcement point is **not**
`requirePermission`, so the handler coverage added by #1744 sits at a seam this path never crosses.

Every existing `retryPurchase` test goes through `buildSessionRetryHandler`
(`handler_purchases_test.go:3053-3076`), which hand-registers the decision with a caller-supplied
boolean and the bare literal `"retry-any"` rather than `auth.ActionRetryAny`. The real matcher, and
with it `adminCarvedOuts`, is never consulted on this path. That is also why instrumenting
`grantAdmin` recorded zero asks for the pair.

Measured: removing `retry-any` from `adminCarvedOuts` fails only the generic `requirePermission`
test from #1744. **Zero `retryPurchase` tests notice.**

## REVIEWERS: please do not simplify the message assertion

`TestRetryCarveOut_PlainAdminIsRefused` asserts that `err.Error()` contains
`"another user's failed purchase"`. **That single line is the regression barrier.**

Dropping `retry-any` from `adminCarvedOuts` lets the caller past the RBAC gate, but `retryPurchase`
then hits the SEC-01 constraint gate, which asks `execute:purchases`, still carved out, and refuses
with a different message and still a 403. So a bare `require.Error` passes against the mutated code
and asserts nothing.

Relaxing that `assert.Contains` deletes the coverage with no test going red. There is a comment on
the line saying exactly this; please keep both.

## What the tests do

Two tests differing in the PRINCIPAL only, same failed row, same request, same fixture, so the
carve-out is the sole variable:

- `TestRetryCarveOut_PlainAdminIsRefused`: `admin:*` is refused.
- `TestRetryCarveOut_AdminPurchaserIsAllowed`: admin + Purchaser is allowed, successor written and
  linked to the original.

Both drive the real `retryPurchase` end to end against the real matcher, rather than
`requirePermission`. The fixture row is created by a different user on purpose: a creator-owned row
is reachable via `retry-own`, which is deliberately not carved out, so only a foreign row isolates
`retry-any` as the deciding grant.

## Verification

- **Mutation** (remove the verb from `adminCarvedOuts`): `TestRetryCarveOut_PlainAdminIsRefused`
  fails by assertion, not panic. Restored, both pass. Re-run against the committed code.
- `go build ./...` passes.
- `go test ./...`: 7073 passed, 0 failed, 43 packages.
- `golangci-lint` at the CI-pinned **v2.10.1**: `0 issues`, exit 0. Checked at the pin deliberately,
  since a newer local version returns a false exit 0.
- `internal/mocks.TestNoUnfailableMockAssertions` passes. It rejected the first draft, where the
  mocks were returned from a helper via multi-value assignment and the guard could not resolve the
  receivers; each test now binds `new(MockAuthService)` in its own scope so the sites are actually
  checked rather than reported as unanalyzable.

Vacuity traps handled explicitly: `AssertExpectations` via `t.Cleanup`; a positive `AssertCalled` on
the `retry-any` pair before any `AssertNotCalled`, so the negative cannot be satisfied by a request
that never reached the permission gate; and the name-only `AssertNotCalled` form on
`MockConfigStore`, which shadows that helper (`internal/mocks/assertions.go:154`) and reads a call
log where name-only is the strongest form rather than the vacuous one.

## Known residual gap, pre-existing and not introduced here

The tests exercise `AuthContext.HasPermission` through the mock, but production reaches the
carve-out via `Service.permissionsAllow`. Both consult `adminCarvedOuts` and both were read to
confirm it, but nothing pins them in sync: a regression removing the check from `permissionsAllow`
alone would not be caught. Identical in shape for the two sibling verbs and for #1644, so it may
warrant a separate issue.

## Label note

The `type/security` and `severity/high` labels were applied on the unenforced-control premise, which
does not hold. Labels are mirrored from the issue as-is here; re-triage is the maintainer's call and
is flagged on the issue thread rather than acted on.

Related: #1596, #1744, #923, #1644


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added regression coverage for purchase retry permissions.
  - Verified unauthorized retries are rejected with a clear error.
  - Verified appropriately authorized retries succeed and retain their retry linkage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->