### PR TITLE
fix(frontend,server): resolve every route to its own page on direct load and refresh

### DIFF
--- a/frontend/src/__tests__/app.test.ts
+++ b/frontend/src/__tests__/app.test.ts
@@ -38,7 +38,10 @@ jest.mock('../navigation', () => ({
   applyTabFromPath: jest.fn().mockReturnValue('dashboard'),
   initRouter: jest.fn(),
   switchSettingsSubTab: jest.fn(),
-  getSettingsSubTabFromPath: jest.fn().mockReturnValue('general'),
+  // Deliberately not '/' + tab: init() must write whatever canonicalTabPath
+  // returns into the initial replaceState, because that is what preserves a
+  // deep-linked sub-tab segment for switchTab to read back.
+  canonicalTabPath: jest.fn((tab: string) => `/${tab}/sub-segment`),
 }));
 
 jest.mock('../recommendations', () => ({
@@ -108,6 +111,23 @@ describe('App Module', () => {
       expect(navigation.applyTabFromPath).toHaveBeenCalled();
       expect(navigation.switchTab).toHaveBeenCalledWith('dashboard', { push: false });
       expect(auth.updateUserUI).toHaveBeenCalled();
+    });
+
+    test('seeds the URL from canonicalTabPath before routing', async () => {
+      (api.isAuthenticated as jest.Mock).mockReturnValue(true);
+      (api.getCurrentUser as jest.Mock).mockResolvedValue({ id: 'user-1', email: 'test@example.com' });
+      (navigation.applyTabFromPath as jest.Mock).mockReturnValue('inventory');
+      const replaceState = jest.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+
+      await init();
+
+      expect(navigation.canonicalTabPath).toHaveBeenCalledWith('inventory');
+      expect(replaceState).toHaveBeenCalledWith(
+        { tab: 'inventory', id: 0 },
+        '',
+        expect.stringContaining('/inventory/sub-segment'),
+      );
+      replaceState.mockRestore();
     });
 
     test('shows login modal on 401 error', async () => {

--- a/frontend/src/__tests__/four-eyes-approval.test.ts
+++ b/frontend/src/__tests__/four-eyes-approval.test.ts
@@ -197,6 +197,41 @@ describe('4-eyes approval mode (issue #1005)', () => {
     expect(document.getElementById('four-eyes-banner')?.classList.contains('hidden')).toBe(true);
   });
 
+  // An unreadable config must fail closed. Failing open would offer the
+  // creator an Approve action the backend rejects, which is a UI claim the
+  // system will not honour.
+  test('dual control is ON when the config fetch fails', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(REG_USER);
+    (api.getConfig as jest.Mock).mockRejectedValue(new Error('config unavailable'));
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [makeRow({ purchase_id: 'exec-own', created_by_user_id: REG_USER.id })],
+    });
+
+    await loadHistory();
+
+    const list = document.getElementById('history-list')!;
+    expect(list.querySelectorAll('.history-approve-btn')).toHaveLength(0);
+    expect(document.getElementById('four-eyes-banner')?.classList.contains('hidden')).toBe(false);
+  });
+
+  // A config that reads successfully but omits the flag is a known "off",
+  // not an outage, so it must not be forced closed.
+  test('dual control is OFF when the config reads successfully without the flag', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(REG_USER);
+    (api.getConfig as jest.Mock).mockResolvedValue({ global: {} });
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [makeRow({ purchase_id: 'exec-own', created_by_user_id: REG_USER.id })],
+    });
+
+    await loadHistory();
+
+    const list = document.getElementById('history-list')!;
+    expect(list.querySelectorAll('.history-approve-btn')).toHaveLength(1);
+    expect(document.getElementById('four-eyes-banner')?.classList.contains('hidden')).toBe(true);
+  });
+
   test('badge shown when button hidden by mode (admin approve-any self-approval)', async () => {
     // Admin holds approve-any, which would normally show Approve on every
     // pending row regardless of creator. Four-eyes still blocks self-approval

--- a/frontend/src/__tests__/history.test.ts
+++ b/frontend/src/__tests__/history.test.ts
@@ -13,6 +13,13 @@ jest.mock('../navigation', () => ({
   switchTab: jest.fn()
 }));
 
+// Default: the session may view purchases. viewPlanHistory consults this
+// before rendering into the Purchases tab, because switchTab renders a
+// no-access placeholder there for sessions without view:purchases.
+jest.mock('../permissions', () => ({
+  canAccess: jest.fn().mockReturnValue(true),
+}));
+
 jest.mock('../utils', () => ({
   // Mirrors the real formatCurrency behaviour: null/undefined/NaN -> '--', numbers -> '$<val>'
   formatCurrency: jest.fn((val) => (val === null || val === undefined || isNaN(val)) ? '--' : `$${val}`),
@@ -57,6 +64,7 @@ jest.mock('../state', () => ({
 
 import * as api from '../api';
 import { switchTab } from '../navigation';
+import { canAccess } from '../permissions';
 
 describe('History Module', () => {
   beforeEach(() => {
@@ -122,7 +130,10 @@ describe('History Module', () => {
   });
 
   describe('viewPlanHistory', () => {
-    test('switches to history tab', async () => {
+    // Issue #1775: 'history' was the pre-#340 tab name, so this silently fell
+    // back to Home and the Plans page's "View history" button rendered the
+    // Home dashboard.
+    test('switches to the Purchases tab without its default load', async () => {
       (api.getHistory as jest.Mock).mockResolvedValue({
         summary: {},
         purchases: []
@@ -130,7 +141,16 @@ describe('History Module', () => {
 
       await viewPlanHistory('plan-123');
 
-      expect(switchTab).toHaveBeenCalledWith('history');
+      expect(switchTab).toHaveBeenCalledWith('purchases', { skipDefaultLoad: true });
+    });
+
+    test('does not fetch when the session cannot view purchases', async () => {
+      (canAccess as jest.Mock).mockReturnValueOnce(false);
+
+      await viewPlanHistory('plan-123');
+
+      expect(switchTab).toHaveBeenCalledWith('purchases', { skipDefaultLoad: true });
+      expect(api.getHistory).not.toHaveBeenCalled();
     });
 
     test('calls getHistory with planId filter', async () => {

--- a/frontend/src/__tests__/navigation.test.ts
+++ b/frontend/src/__tests__/navigation.test.ts
@@ -1,7 +1,7 @@
 /**
  * Navigation module tests
  */
-import { switchTab, switchSettingsSubTab, switchInventorySubTab, getSettingsSubTabFromPath, getInventorySubTabFromPath } from '../navigation';
+import { switchTab, switchSettingsSubTab, switchInventorySubTab, getSettingsSubTabFromPath, getInventorySubTabFromPath, applyTabFromPath, canonicalTabPath } from '../navigation';
 
 // Mock the dependent modules
 jest.mock('../dashboard', () => ({
@@ -61,6 +61,7 @@ import { loadGlobalSettings } from '../settings';
 import { loadAutomationSettings } from '../riexchange';
 import { canAccess } from '../permissions';
 import { loadInventory } from '../inventory';
+import { isAdmin } from '../auth';
 
 describe('Navigation Module', () => {
   beforeEach(() => {
@@ -94,8 +95,13 @@ describe('Navigation Module', () => {
       </div>
     `;
 
-    // Clear all mocks
+    // Clear all mocks. clearAllMocks() only drops recorded calls, not
+    // implementations, so restore the permissive defaults explicitly --
+    // otherwise a test that flips isAdmin/canAccess to false leaks that into
+    // every test declared after it.
     jest.clearAllMocks();
+    (isAdmin as jest.Mock).mockReturnValue(true);
+    (canAccess as jest.Mock).mockReturnValue(true);
   });
 
   describe('switchTab', () => {
@@ -434,6 +440,129 @@ describe('Navigation Module', () => {
       switchInventorySubTab('coverage', { push: false });
       // URL unchanged: the caller (initial load / popstate) owns the URL.
       expect(window.location.pathname).toBe('/inventory/active-commitments');
+    });
+  });
+
+  // Issue #1775: resolving the URL on a direct load / refresh. Placed BEFORE
+  // the *FromPath describes for the same reason as switchInventorySubTab --
+  // those replace window.location with a plain object.
+  describe('applyTabFromPath', () => {
+    test.each([
+      ['/home', 'home'],
+      ['/opportunities', 'opportunities'],
+      ['/plans', 'plans'],
+      ['/purchases', 'purchases'],
+      ['/inventory', 'inventory'],
+      ['/admin', 'admin'],
+      ['/', 'home'],
+      ['/plans/', 'plans'],
+      ['/PLANS', 'plans'],
+      ['/plans/extra/segments', 'plans'],
+      ['/not-a-route', 'home'],
+    ])('%s resolves to the %s tab', (path, expected) => {
+      window.history.replaceState(null, '', path);
+      expect(applyTabFromPath()).toBe(expected);
+    });
+
+    test.each([
+      ['/dashboard', 'home'],
+      ['/recommendations', 'opportunities'],
+      ['/history', 'purchases'],
+      ['/settings', 'admin'],
+      ['/ri-exchange', 'inventory'],
+    ])('legacy %s redirects to the %s tab and rewrites the URL', (path, expected) => {
+      window.history.replaceState(null, '', path);
+      expect(applyTabFromPath()).toBe(expected);
+      expect(window.location.pathname).toBe('/' + expected);
+    });
+
+    // A path whose first segment names an Object.prototype member used to pass
+    // the `segment in TABS` membership test, so switchTab then read an
+    // undefined TabMeta (or the Object constructor) and threw out of init(),
+    // stranding the app on its unrouted default markup.
+    test.each(['/constructor', '/toString', '/valueOf', '/hasOwnProperty', '/__proto__'])(
+      '%s is not a known route and falls back to home',
+      (path) => {
+        window.history.replaceState(null, '', path);
+        expect(applyTabFromPath()).toBe('home');
+      },
+    );
+
+    test('an Object.prototype sub-tab name is not a known admin sub-tab', () => {
+      window.history.replaceState(null, '', '/admin/constructor');
+      expect(getSettingsSubTabFromPath()).toBe('general');
+      switchSettingsSubTab(getSettingsSubTabFromPath(), { push: false });
+      expect(document.title).toBe('CUDly — Admin · General');
+    });
+  });
+
+  // canonicalTabPath is what app.ts writes into the initial replaceState, so
+  // it must keep the sub-tab segment switchTab reads back out of the URL.
+  describe('canonicalTabPath', () => {
+    test.each(['home', 'opportunities', 'plans', 'purchases'])(
+      '%s has no sub-tab segment',
+      (tab) => {
+        window.history.replaceState(null, '', '/' + tab);
+        expect(canonicalTabPath(tab)).toBe('/' + tab);
+      },
+    );
+
+    test.each(['active-commitments', 'coverage', 'ri-exchange'])(
+      'a deep-linked /inventory/%s keeps its sub-tab segment',
+      (sub) => {
+        window.history.replaceState(null, '', '/inventory/' + sub);
+        expect(canonicalTabPath('inventory')).toBe('/inventory/' + sub);
+      },
+    );
+
+    test('a bare /inventory canonicalises to the default sub-tab', () => {
+      window.history.replaceState(null, '', '/inventory');
+      expect(canonicalTabPath('inventory')).toBe('/inventory/active-commitments');
+    });
+
+    test.each(['general', 'purchasing', 'accounts', 'users'])(
+      'a deep-linked /admin/%s keeps its sub-tab segment',
+      (sub) => {
+        window.history.replaceState(null, '', '/admin/' + sub);
+        // currentSettingsSubTab is module state; drive it through the real
+        // entry point so the assertion reflects an actual navigation.
+        switchSettingsSubTab(sub, { push: false });
+        expect(canonicalTabPath('admin')).toBe('/admin/' + sub);
+      },
+    );
+
+    // app.ts calls this at init, before anything has set currentSettingsSubTab,
+    // so the URL is the only source for the segment. A fresh module instance is
+    // the only way to observe that state from inside this file.
+    test('falls back to the URL when no admin sub-tab has been visited yet', () => {
+      window.history.replaceState(null, '', '/admin/users');
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const nav = require('../navigation') as typeof import('../navigation');
+        expect(nav.canonicalTabPath('admin')).toBe('/admin/users');
+      });
+    });
+  });
+
+  describe('switchTab skipDefaultLoad', () => {
+    test('purchases: reveals the tab without firing its default loads', () => {
+      switchTab('purchases', { skipDefaultLoad: true, push: false });
+      expect(document.getElementById('purchases-tab')?.classList.contains('active')).toBe(true);
+      expect(initHistoryDateRange).not.toHaveBeenCalled();
+      expect(loadHistory).not.toHaveBeenCalled();
+    });
+
+    test('purchases: the view:purchases gate still applies', () => {
+      (canAccess as jest.Mock).mockReturnValue(false);
+      switchTab('purchases', { skipDefaultLoad: true, push: false });
+      expect(document.getElementById('purchases-tab')?.textContent).toContain('do not have access');
+      expect(loadHistory).not.toHaveBeenCalled();
+    });
+
+    test('admin: reveals the tab without loading the default sub-tab', () => {
+      switchTab('admin', { skipDefaultLoad: true, push: false });
+      expect(document.getElementById('admin-tab')?.classList.contains('active')).toBe(true);
+      expect(loadGlobalSettings).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/__tests__/riexchange.test.ts
+++ b/frontend/src/__tests__/riexchange.test.ts
@@ -673,11 +673,14 @@ describe('⚙︎ Exchange settings deep-link', () => {
     jest.resetAllMocks();
   });
 
-  it('switches to Settings → Purchasing when clicked', () => {
+  // Issue #1775: 'settings' was the pre-#340 tab name, so switchTab fell back
+  // to Home while switchSettingsSubTab still set the Admin title and pushed
+  // /admin/purchasing -- URL and title said Admin over the Home dashboard.
+  it('switches to Admin → Purchasing when clicked', () => {
     setupRIExchangeHandlers();
     const btn = document.getElementById('ri-exchange-settings-btn')!;
     btn.click();
-    expect(navigation.switchTab).toHaveBeenCalledWith('settings');
+    expect(navigation.switchTab).toHaveBeenCalledWith('admin', { push: false, skipDefaultLoad: true });
     expect(navigation.switchSettingsSubTab).toHaveBeenCalledWith('purchasing');
   });
 });

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -7,7 +7,7 @@ import * as state from './state';
 import { showLoginModal, showAdminSetupModal, showResetPasswordModal, updateUserUI } from './auth';
 import { loadDashboard, setupDashboardHandlers } from './dashboard';
 import { setupRecommendationsHandlers, getPurchaseModalRecommendations, clearPurchaseModalRecommendations, getFanOutBuckets, clearFanOutBuckets, getExecuteMode, clearExecuteMode, type FanOutBucket } from './recommendations';
-import { switchTab, applyTabFromPath, initRouter, switchSettingsSubTab, getSettingsSubTabFromPath } from './navigation';
+import { switchTab, applyTabFromPath, initRouter, switchSettingsSubTab, canonicalTabPath } from './navigation';
 import { savePlan, setupPlanHandlers, closePlanModal, openNewPlanModal, closePurchaseModal } from './plans';
 import { saveGlobalSettings, setupSettingsHandlers, resetSettings } from './settings';
 import { setupUserHandlers } from './users';
@@ -91,14 +91,12 @@ export async function init(): Promise<void> {
     // tab routing still runs underneath so the app is fully functional.
     handleArcheraDeeplink();
     const target = applyTabFromPath();
-    let url = '/' + target;
-    if (target === 'admin') {
-      url = '/admin/' + getSettingsSubTabFromPath();
-    }
+    // switchTab below re-reads the sub-tab from the URL, so this rewrite must
+    // keep the segment of a deep-linked /inventory/<subtab> or /admin/<subtab>.
     window.history.replaceState(
       { tab: target, id: 0 },
       '',
-      url + window.location.search + window.location.hash,
+      canonicalTabPath(target) + window.location.search + window.location.hash,
     );
     switchTab(target, { push: false });
     setupEventListeners();

--- a/frontend/src/docs.html
+++ b/frontend/src/docs.html
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CUDly API Documentation</title>
     <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui.css" integrity="sha384-9Q2fpS+xeS4ffJy6CagnwoUl+4ldAYhOs9pgZuEKxypVModhmZFzeMlvVsAjf7uT" crossorigin="anonymous">
-    <link rel="stylesheet" type="text/css" href="./docs.css">
+    <!-- Absolute so the page styles correctly at both /docs and /docs/. -->
+    <link rel="stylesheet" type="text/css" href="/docs/docs.css">
 </head>
 <body>
     <div id="swagger-ui"></div>

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -52,14 +52,19 @@ let _fourEyesMode = false;
  *
  * Every path that renders the approval queue must call this first, or the
  * queue renders as though dual control were off and offers the creator an
- * Approve button the backend will reject. A failed fetch keeps the previous
- * value rather than throwing, so a config blip cannot block the render.
+ * Approve button the backend will reject.
+ *
+ * An unreadable config fails closed, to dual-control ON. The fetch never
+ * throws, so a config blip cannot block the render; it can only make the UI
+ * more restrictive than the backend, never less. The cost is a temporarily
+ * hidden Approve button during an outage, which self-corrects on the next
+ * successful load.
  */
 async function refreshFourEyesMode(): Promise<void> {
   const cfgResponse = await api.getConfig().catch(() => null);
-  if (cfgResponse?.global) {
-    _fourEyesMode = cfgResponse.global.require_different_approver === true;
-  }
+  _fourEyesMode = cfgResponse?.global
+    ? cfgResponse.global.require_different_approver === true
+    : true;
   const banner = document.getElementById('four-eyes-banner');
   if (banner) banner.classList.toggle('hidden', !_fourEyesMode);
 }

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -42,10 +42,27 @@ type StatusFilter = 'all' | 'pending' | 'completed' | 'failed' | 'expired' | 'ca
 let lastPurchases: HistoryPurchase[] = [];
 let activeStatusFilter: StatusFilter = 'all';
 
-// _fourEyesMode mirrors GlobalConfig.require_different_approver (issue #1005),
-// refreshed on every loadHistory() call. Gates the inline Approve button so a
-// creator can't approve their own pending purchase when dual-control is on.
+// _fourEyesMode mirrors GlobalConfig.require_different_approver (issue #1005).
+// Gates the inline Approve button so a creator can't approve their own pending
+// purchase when dual-control is on.
 let _fourEyesMode = false;
+
+/**
+ * Refresh _fourEyesMode and the dual-control banner from GlobalConfig.
+ *
+ * Every path that renders the approval queue must call this first, or the
+ * queue renders as though dual control were off and offers the creator an
+ * Approve button the backend will reject. A failed fetch keeps the previous
+ * value rather than throwing, so a config blip cannot block the render.
+ */
+async function refreshFourEyesMode(): Promise<void> {
+  const cfgResponse = await api.getConfig().catch(() => null);
+  if (cfgResponse?.global) {
+    _fourEyesMode = cfgResponse.global.require_different_approver === true;
+  }
+  const banner = document.getElementById('four-eyes-banner');
+  if (banner) banner.classList.toggle('hidden', !_fourEyesMode);
+}
 
 function normalizeStatus(p: HistoryPurchase): string {
   // Absent status → legacy DB row → counts as completed for filtering.
@@ -223,10 +240,19 @@ export function initHistoryDateRange(): void {
  * would be misleading.
  */
 export async function viewPlanHistory(planId: string): Promise<void> {
-  switchTab('history');
+  // skipDefaultLoad: the tab's own unscoped 7-day fetch would land after the
+  // plan-scoped one below and overwrite it, and its date-range seeding is
+  // exactly what the doc comment above says not to do here.
+  switchTab('purchases', { skipDefaultLoad: true });
+  // switchTab renders a no-access placeholder for sessions without
+  // view:purchases; don't overwrite it with the plan's purchases.
+  if (!canAccess('view', 'purchases')) return;
 
   try {
-    const data = await api.getHistory({ planId }) as unknown as HistoryResponse;
+    const [data] = await Promise.all([
+      api.getHistory({ planId }) as unknown as Promise<HistoryResponse>,
+      refreshFourEyesMode(),
+    ]);
     renderHistorySummary(data.summary ?? null);
     const purchases = data.purchases || [];
     renderApprovalQueue(purchases);
@@ -312,18 +338,10 @@ export async function loadHistory(): Promise<void> {
       provider,
       account_ids: accountIDs
     };
-    const [data, cfgResponse] = await Promise.all([
+    const [data] = await Promise.all([
       api.getHistory(filters) as unknown as Promise<HistoryResponse>,
-      // 4-eyes mode (issue #1005) lives on GlobalConfig; a failed fetch must
-      // not block the history render, so this leg fails closed to "no config"
-      // rather than throwing, and _fourEyesMode falls back to its last value.
-      api.getConfig().catch(() => null),
+      refreshFourEyesMode(),
     ]);
-    if (cfgResponse?.global) {
-      _fourEyesMode = cfgResponse.global.require_different_approver === true;
-    }
-    const banner = document.getElementById('four-eyes-banner');
-    if (banner) banner.classList.toggle('hidden', !_fourEyesMode);
     renderHistorySummary(data.summary ?? null);
     const purchases = data.purchases || [];
     renderApprovalQueue(purchases);

--- a/frontend/src/navigation.ts
+++ b/frontend/src/navigation.ts
@@ -69,6 +69,39 @@ let historyId = 0;
 interface SwitchTabOptions {
   push?: boolean;
   skipDirtyGuard?: boolean;
+  /**
+   * Skip the tab's own default data load, for callers that switch to a tab
+   * only to render their own scoped view into it. The permission gate still
+   * applies.
+   */
+  skipDefaultLoad?: boolean;
+}
+
+/**
+ * Own-property membership test for the route tables above. `key in record`
+ * also matches Object.prototype members, so /constructor resolved as a known
+ * tab and switchTab then read a TabMeta that isn't one.
+ */
+function isKnownKey(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+/**
+ * The canonical URL path for a tab. Inventory and Admin carry a sub-tab
+ * segment; every other tab is just /<tab>.
+ *
+ * Shared by switchTab's pushState and app.ts's initial replaceState: switchTab
+ * reads the sub-tab back out of the URL, so a caller that writes the URL first
+ * must not drop the segment.
+ */
+export function canonicalTabPath(tabName: string): string {
+  if (tabName === 'admin') {
+    return '/admin/' + (currentSettingsSubTab ?? getSettingsSubTabFromPath());
+  }
+  if (tabName === 'inventory') {
+    return '/inventory/' + getInventorySubTabFromPath();
+  }
+  return '/' + tabName;
 }
 
 /**
@@ -91,7 +124,7 @@ function renderNoAccess(tabId: string): void {
  * Switch between tabs
  */
 export function switchTab(tabName: string, opts: SwitchTabOptions = {}): void {
-  if (!(tabName in TABS)) tabName = 'home';
+  if (!isKnownKey(TABS, tabName)) tabName = 'home';
 
   const isSelfSwitch = tabName === currentTab;
 
@@ -129,8 +162,11 @@ export function switchTab(tabName: string, opts: SwitchTabOptions = {}): void {
         renderNoAccess(`${tabName}-tab`);
         break;
       }
-      initHistoryDateRange();
+      // Savings history is tab-scoped, never plan-scoped, so it loads even
+      // for a caller that brings its own purchase list.
       void loadSavingsHistory();
+      if (opts.skipDefaultLoad) break;
+      initHistoryDateRange();
       // Auto-load history so the Approval queue card and the Purchase
       // History table populate on first visit, without requiring the
       // user to click "Load History" just to see pending approvals.
@@ -139,6 +175,7 @@ export function switchTab(tabName: string, opts: SwitchTabOptions = {}): void {
       void loadHistory();
       break;
     case 'admin':
+      if (opts.skipDefaultLoad) break;
       switchSettingsSubTab(getSettingsSubTabFromPath(), { push: false });
       break;
     case 'inventory':
@@ -159,22 +196,10 @@ export function switchTab(tabName: string, opts: SwitchTabOptions = {}): void {
 
   if (opts.push !== false) {
     historyId += 1;
-    let url: string;
-    if (tabName === 'admin') {
-      url = '/admin/' + (currentSettingsSubTab ?? 'general');
-    } else if (tabName === 'inventory') {
-      // Inventory carries a sub-tab segment in the URL (QA A.4), mirroring
-      // Admin. loadInventory() above already applied the sub-section from
-      // the path (or the default); reflect that same segment here so the
-      // canonical URL is /inventory/<subtab>, never a bare /inventory.
-      url = '/inventory/' + getInventorySubTabFromPath();
-    } else {
-      url = '/' + tabName;
-    }
     window.history.pushState(
       { tab: tabName, id: historyId },
       '',
-      url + window.location.search + window.location.hash,
+      canonicalTabPath(tabName) + window.location.search + window.location.hash,
     );
   }
 }
@@ -189,7 +214,7 @@ export function getSettingsSubTabFromPath(): string {
     .replace(/\/+$/, '')
     .split('/');
   const sub = (segments[1] ?? '').toLowerCase();
-  return sub in SETTINGS_SUBTABS ? sub : 'general';
+  return isKnownKey(SETTINGS_SUBTABS, sub) ? sub : 'general';
 }
 
 /**
@@ -242,7 +267,7 @@ export function getInventorySubTabFromPath(): string {
  * Manages section visibility, load lifecycle, and sub-tab URL history.
  */
 export function switchSettingsSubTab(subTab: string, opts: SwitchTabOptions = {}): void {
-  if (!(subTab in SETTINGS_SUBTABS)) subTab = 'general';
+  if (!isKnownKey(SETTINGS_SUBTABS, subTab)) subTab = 'general';
 
   if ((subTab === 'accounts' || subTab === 'users') && !isAdmin()) {
     subTab = 'general';
@@ -311,12 +336,12 @@ export function applyTabFromPath(): string {
     .split('/')[0]
     ?.toLowerCase() ?? '';
   if (segment === '') return 'home';
-  if (segment in LEGACY_PATH_REDIRECTS) {
+  if (isKnownKey(LEGACY_PATH_REDIRECTS, segment)) {
     const canonical = LEGACY_PATH_REDIRECTS[segment]!;
     window.history.replaceState(null, '', '/' + canonical + window.location.search + window.location.hash);
     return canonical;
   }
-  return segment in TABS ? segment : 'home';
+  return isKnownKey(TABS, segment) ? segment : 'home';
 }
 
 /**

--- a/frontend/src/riexchange.ts
+++ b/frontend/src/riexchange.ts
@@ -194,7 +194,9 @@ export function setupRIExchangeHandlers(): void {
   const settingsBtn = document.getElementById('ri-exchange-settings-btn');
   if (settingsBtn) {
     settingsBtn.addEventListener('click', () => {
-      switchTab('settings');
+      // switchSettingsSubTab owns the sub-tab DOM, title and history push, so
+      // switchTab only has to reveal the Admin panel.
+      switchTab('admin', { push: false, skipDefaultLoad: true });
       switchSettingsSubTab('purchasing');
       const target = document.getElementById('ri-exchange-automation-settings');
       if (target) {

--- a/frontend/tests-e2e/deeplink.spec.ts
+++ b/frontend/tests-e2e/deeplink.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Deep-link / refresh smoke for every route the SPA defines (issue #1775).
+ *
+ * The reported failure ("loading /plans directly renders the Home dashboard")
+ * is only observable on the *initial load* path: a client-side nav to the same
+ * route works, so any test that clicks the nav item stays green while the bug
+ * is live. Each case therefore navigates the browser straight at the URL, and
+ * then reloads it, asserting on what the user actually sees: which nav item is
+ * highlighted, which panel is on screen, the tab title, and the canonical URL.
+ *
+ * `npx serve -s dist` (playwright.config.ts webServer) mirrors the SPA
+ * fallback the Go static handler performs, so a failure here is a client
+ * routing failure. The server half of the same contract is pinned by
+ * TestSPAFallbackServesIndexForEveryAppRoute in internal/server/static_test.go.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import { mockApi, seedAuth } from './fixtures/recs';
+
+interface RouteCase {
+  /** URL the browser is pointed at. */
+  url: string;
+  /** data-tab of the nav item that must end up highlighted. */
+  tab: string;
+  /** document.title after the route resolves. */
+  title: string;
+  /** location.pathname after the app canonicalises the URL. */
+  canonical: string;
+}
+
+const ROUTES: RouteCase[] = [
+  { url: '/', tab: 'home', title: 'CUDly — Home', canonical: '/home' },
+  { url: '/home', tab: 'home', title: 'CUDly — Home', canonical: '/home' },
+  { url: '/opportunities', tab: 'opportunities', title: 'CUDly — Opportunities', canonical: '/opportunities' },
+  { url: '/plans', tab: 'plans', title: 'CUDly — Plans', canonical: '/plans' },
+  { url: '/purchases', tab: 'purchases', title: 'CUDly — Purchases', canonical: '/purchases' },
+
+  // Inventory and Admin carry a sub-tab segment. The initial replaceState must
+  // preserve it: it is the input switchTab reads to pick the sub-section.
+  { url: '/inventory', tab: 'inventory', title: 'CUDly — Inventory & Coverage', canonical: '/inventory/active-commitments' },
+  { url: '/inventory/active-commitments', tab: 'inventory', title: 'CUDly — Inventory & Coverage', canonical: '/inventory/active-commitments' },
+  { url: '/inventory/coverage', tab: 'inventory', title: 'CUDly — Inventory & Coverage', canonical: '/inventory/coverage' },
+  { url: '/inventory/ri-exchange', tab: 'inventory', title: 'CUDly — Inventory & Coverage', canonical: '/inventory/ri-exchange' },
+  { url: '/admin', tab: 'admin', title: 'CUDly — Admin · General', canonical: '/admin/general' },
+  { url: '/admin/general', tab: 'admin', title: 'CUDly — Admin · General', canonical: '/admin/general' },
+  { url: '/admin/purchasing', tab: 'admin', title: 'CUDly — Admin · Purchasing policies', canonical: '/admin/purchasing' },
+  { url: '/admin/accounts', tab: 'admin', title: 'CUDly — Admin · Accounts & onboarding', canonical: '/admin/accounts' },
+  { url: '/admin/users', tab: 'admin', title: 'CUDly — Admin · Users, roles & API keys', canonical: '/admin/users' },
+
+  // Pre-#340 bookmarks, kept alive by LEGACY_PATH_REDIRECTS.
+  { url: '/dashboard', tab: 'home', title: 'CUDly — Home', canonical: '/home' },
+  { url: '/recommendations', tab: 'opportunities', title: 'CUDly — Opportunities', canonical: '/opportunities' },
+  { url: '/history', tab: 'purchases', title: 'CUDly — Purchases', canonical: '/purchases' },
+  { url: '/settings', tab: 'admin', title: 'CUDly — Admin · General', canonical: '/admin/general' },
+  { url: '/ri-exchange', tab: 'inventory', title: 'CUDly — Inventory & Coverage', canonical: '/inventory/active-commitments' },
+
+  // Unknown paths land on Home rather than an unrouted shell.
+  { url: '/not-a-route', tab: 'home', title: 'CUDly — Home', canonical: '/home' },
+
+  // A first segment naming an Object.prototype member used to pass the
+  // `segment in TABS` membership test; pushing the resulting non-tab value
+  // threw DataCloneError out of init(), leaving the app on its unrouted
+  // markup (Home panel, generic title, no event listeners bound).
+  { url: '/constructor', tab: 'home', title: 'CUDly — Home', canonical: '/home' },
+  { url: '/__proto__', tab: 'home', title: 'CUDly — Home', canonical: '/home' },
+  { url: '/admin/constructor', tab: 'admin', title: 'CUDly — Admin · General', canonical: '/admin/general' },
+];
+
+/** What the user can see once routing has settled. */
+async function observe(page: Page) {
+  return page.evaluate(() => ({
+    title: document.title,
+    path: window.location.pathname,
+    tab: document.querySelector('.tab-btn.active')?.getAttribute('data-tab') ?? null,
+    panel: document.querySelector('.tab-content.active')?.id ?? null,
+  }));
+}
+
+for (const route of ROUTES) {
+  test(`${route.url} renders the ${route.tab} page on direct load and on refresh`, async ({ page }) => {
+    // Uncaught exceptions only. The stub API fixture 404s endpoints this spec
+    // does not care about, and those are reported as console errors by design.
+    const pageErrors: string[] = [];
+    page.on('pageerror', (err) => pageErrors.push(String(err)));
+
+    await seedAuth(page);
+    await mockApi(page);
+
+    await page.goto(route.url);
+    await expect(page.locator(`.tab-content.active#${route.tab}-tab`)).toBeAttached();
+
+    const onLoad = await observe(page);
+    expect(onLoad).toEqual({
+      title: route.title,
+      path: route.canonical,
+      tab: route.tab,
+      panel: `${route.tab}-tab`,
+    });
+
+    // Refresh from the canonical URL the app just wrote: the issue reports the
+    // failure on refresh as well as on the first load, and the canonical URL is
+    // what a user bookmarks or shares.
+    await page.reload();
+    await expect(page.locator(`.tab-content.active#${route.tab}-tab`)).toBeAttached();
+    expect(await observe(page)).toEqual(onLoad);
+
+    expect(pageErrors).toEqual([]);
+  });
+}
+
+test('a deep-linked Inventory sub-tab opens that sub-section, not the default', async ({ page }) => {
+  await seedAuth(page);
+  await mockApi(page);
+
+  await page.goto('/inventory/coverage');
+  await expect(page.locator('#inventory-tab .sub-tab-btn.active')).toHaveText(/coverage/i);
+  expect(new URL(page.url()).pathname).toBe('/inventory/coverage');
+});

--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -94,7 +94,10 @@ func directoryIndex(absDir, dirPath, cleanPath string) (indexPath, indexClean st
 	if err != nil || !symlinkSafeContainedIn(absDir, absCandidate) {
 		return "", "", false
 	}
-	info, err := os.Stat(candidate) //nolint:gosec // G703: candidate is absCandidate, checked by the symlinkSafeContainedIn call directly above
+	// #nosec G703 -- candidate is dirPath (already contained) plus a constant
+	// filename, then re-checked by the symlinkSafeContainedIn call above, which
+	// catches a symlinked index.html whose target sits outside dir.
+	info, err := os.Stat(candidate)
 	if err != nil || info.IsDir() {
 		return "", "", false
 	}
@@ -113,7 +116,11 @@ func spaIndex(absDir, dir string) (filePath, cleanPath string, ok bool) {
 	if err != nil || !symlinkSafeContainedIn(absDir, absFile) {
 		return "", "", false
 	}
-	if _, err := os.Stat(filePath); err != nil { //nolint:gosec // G703: filePath is dir plus a constant filename, checked by the symlinkSafeContainedIn call directly above
+	// #nosec G703 -- dir plus a constant filename, re-checked by the
+	// symlinkSafeContainedIn call above. See TestSPAFallbackRejectsSymlinkedShell:
+	// without that check a symlinked shell is refused at /index.html and served
+	// at every extensionless route.
+	if _, err := os.Stat(filePath); err != nil {
 		return "", "", false
 	}
 	return filePath, "/index.html", true
@@ -143,7 +150,12 @@ func resolveStaticFilePath(dir, urlPath string) (filePath, cleanPath string, ok 
 		return "", "", false
 	}
 
-	if info, statErr := os.Stat(filePath); statErr == nil { //nolint:gosec // G703: filePath passed filepath.Abs + symlinkSafeContainedIn above, which rejects any path resolving outside dir
+	// #nosec G703 -- guarded by filepath.Abs + symlinkSafeContainedIn above.
+	// That check is the load-bearing one and removing it alone fails the
+	// Hostile suite and both symlink tests, because a symlink is the escape
+	// path.Clean cannot see. path.Clean is defense in depth for the lexical
+	// cases only: removing it alone fails nothing, removing both escapes dir.
+	if info, statErr := os.Stat(filePath); statErr == nil {
 		if !info.IsDir() {
 			return filePath, cleanPath, true
 		}

--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -102,9 +102,18 @@ func directoryIndex(absDir, dirPath, cleanPath string) (indexPath, indexClean st
 }
 
 // spaIndex returns the SPA shell that client-side routes fall back to.
-func spaIndex(dir string) (filePath, cleanPath string, ok bool) {
+//
+// Runs the same containment check as directoryIndex. A direct /index.html
+// request is validated by resolveStaticFilePath before it gets here, so
+// without this a symlinked shell pointing out of dir would be refused at
+// /index.html and served at every client-side route.
+func spaIndex(absDir, dir string) (filePath, cleanPath string, ok bool) {
 	filePath = filepath.Join(dir, "index.html")
-	if _, err := os.Stat(filePath); err != nil { //nolint:gosec // G703: dir is the operator-set STATIC_DIR and the filename is a constant; no request-derived segment reaches this path
+	absFile, err := filepath.Abs(filePath)
+	if err != nil || !symlinkSafeContainedIn(absDir, absFile) {
+		return "", "", false
+	}
+	if _, err := os.Stat(filePath); err != nil { //nolint:gosec // G703: filePath is dir plus a constant filename, checked by the symlinkSafeContainedIn call directly above
 		return "", "", false
 	}
 	return filePath, "/index.html", true
@@ -149,7 +158,7 @@ func resolveStaticFilePath(dir, urlPath string) (filePath, cleanPath string, ok 
 	if path.Ext(cleanPath) != "" {
 		return "", "", false
 	}
-	return spaIndex(dir)
+	return spaIndex(absDir, dir)
 }
 
 // cacheControlForExt returns the Cache-Control header value for a file extension.

--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -94,7 +94,7 @@ func directoryIndex(absDir, dirPath, cleanPath string) (indexPath, indexClean st
 	if err != nil || !symlinkSafeContainedIn(absDir, absCandidate) {
 		return "", "", false
 	}
-	info, err := os.Stat(candidate)
+	info, err := os.Stat(candidate) //nolint:gosec // G703: candidate is absCandidate, checked by the symlinkSafeContainedIn call directly above
 	if err != nil || info.IsDir() {
 		return "", "", false
 	}
@@ -104,7 +104,7 @@ func directoryIndex(absDir, dirPath, cleanPath string) (indexPath, indexClean st
 // spaIndex returns the SPA shell that client-side routes fall back to.
 func spaIndex(dir string) (filePath, cleanPath string, ok bool) {
 	filePath = filepath.Join(dir, "index.html")
-	if _, err := os.Stat(filePath); err != nil {
+	if _, err := os.Stat(filePath); err != nil { //nolint:gosec // G703: dir is the operator-set STATIC_DIR and the filename is a constant; no request-derived segment reaches this path
 		return "", "", false
 	}
 	return filePath, "/index.html", true
@@ -134,7 +134,7 @@ func resolveStaticFilePath(dir, urlPath string) (filePath, cleanPath string, ok 
 		return "", "", false
 	}
 
-	if info, statErr := os.Stat(filePath); statErr == nil {
+	if info, statErr := os.Stat(filePath); statErr == nil { //nolint:gosec // G703: filePath passed filepath.Abs + symlinkSafeContainedIn above, which rejects any path resolving outside dir
 		if !info.IsDir() {
 			return filePath, cleanPath, true
 		}

--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -79,6 +79,37 @@ func symlinkSafeContainedIn(absDir, absFile string) bool {
 	return true
 }
 
+// directoryIndex resolves dirPath/index.html when the requested path is a
+// directory that ships its own index. /docs/ must serve dist/docs/index.html,
+// not the SPA shell: without this a directory stat falls straight through to
+// the SPA fallback and the "API Docs" link renders the dashboard again.
+//
+// The candidate re-runs symlinkSafeContainedIn. Appending a constant filename
+// keeps the path lexically inside absDir, but os.Stat follows symlinks, so a
+// symlinked index.html could otherwise serve a file the direct request path
+// (/docs/index.html) rejects.
+func directoryIndex(absDir, dirPath, cleanPath string) (indexPath, indexClean string, ok bool) {
+	candidate := filepath.Join(dirPath, "index.html")
+	absCandidate, err := filepath.Abs(candidate)
+	if err != nil || !symlinkSafeContainedIn(absDir, absCandidate) {
+		return "", "", false
+	}
+	info, err := os.Stat(candidate)
+	if err != nil || info.IsDir() {
+		return "", "", false
+	}
+	return candidate, path.Join(cleanPath, "index.html"), true
+}
+
+// spaIndex returns the SPA shell that client-side routes fall back to.
+func spaIndex(dir string) (filePath, cleanPath string, ok bool) {
+	filePath = filepath.Join(dir, "index.html")
+	if _, err := os.Stat(filePath); err != nil {
+		return "", "", false
+	}
+	return filePath, "/index.html", true
+}
+
 // resolveStaticFilePath validates the URL path against directory traversal and
 // resolves the actual file path. Falls back to index.html for extensionless
 // paths (SPA routing). Returns the file path, the clean path used for content
@@ -103,20 +134,22 @@ func resolveStaticFilePath(dir, urlPath string) (filePath, cleanPath string, ok 
 		return "", "", false
 	}
 
-	info, err := os.Stat(filePath) //nolint:gosec // G703: error from Close handled in defer
-	if err != nil || info.IsDir() {
-		if path.Ext(cleanPath) != "" {
-			return "", "", false
+	if info, statErr := os.Stat(filePath); statErr == nil {
+		if !info.IsDir() {
+			return filePath, cleanPath, true
 		}
-		// SPA fallback
-		filePath = filepath.Join(dir, "index.html")
-		cleanPath = "/index.html"
-		if _, err := os.Stat(filePath); err != nil { //nolint:gosec // G703: error from Close handled in defer
-			return "", "", false
+		if idxPath, idxClean, isDirIndex := directoryIndex(absDir, filePath, cleanPath); isDirIndex {
+			return idxPath, idxClean, true
 		}
 	}
 
-	return filePath, cleanPath, true
+	// Nothing servable at that path. An extension means the caller asked for a
+	// concrete asset, so a miss is a genuine 404; an extensionless path is a
+	// client-side route and gets the SPA shell.
+	if path.Ext(cleanPath) != "" {
+		return "", "", false
+	}
+	return spaIndex(dir)
 }
 
 // cacheControlForExt returns the Cache-Control header value for a file extension.

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -334,3 +334,125 @@ func TestSpaFileServer_404WhenIndexMissing(t *testing.T) {
 
 	testutil.AssertEqual(t, http.StatusNotFound, w.Code)
 }
+
+// ----- SPA catch-all: every frontend route (issue #1775) -----
+
+// appRoutes lists every path the SPA can be deep-linked to, taken from the
+// tab table and the legacy-redirect table in frontend/src/navigation.ts. A new
+// nav entry (or a new root-level mux registration that shadows one) must not
+// silently start serving something other than the SPA shell.
+var appRoutes = []string{
+	"/",
+	"/home",
+	"/opportunities",
+	"/plans",
+	"/purchases",
+	"/inventory",
+	"/inventory/active-commitments",
+	"/inventory/coverage",
+	"/inventory/ri-exchange",
+	"/admin",
+	"/admin/general",
+	"/admin/purchasing",
+	"/admin/accounts",
+	"/admin/users",
+	// Legacy paths kept alive by LEGACY_PATH_REDIRECTS for old bookmarks.
+	"/dashboard",
+	"/recommendations",
+	"/history",
+	"/settings",
+	"/ri-exchange",
+	// Non-tab SPA landing paths.
+	"/reset-password",
+	"/archera-insurance",
+	"/purchases/approve/abc-123",
+	"/purchases/cancel/abc-123",
+}
+
+func TestSPAFallbackServesIndexForEveryAppRoute(t *testing.T) {
+	dir := makeStaticDir(t, map[string]string{
+		"index.html":      "<html>spa</html>",
+		"docs/index.html": "<html>docs</html>",
+	})
+
+	for _, route := range appRoutes {
+		t.Run(route, func(t *testing.T) {
+			if !isStaticPath(route) {
+				t.Fatalf("route %s is not classified as a static path; the API router would swallow it", route)
+			}
+
+			content, _, _, found := serveStaticForLambda(dir, route)
+			testutil.AssertEqual(t, true, found)
+			testutil.AssertEqual(t, "<html>spa</html>", string(content))
+
+			handler := spaFileServer(dir)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, route, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			testutil.AssertEqual(t, http.StatusOK, w.Code)
+			testutil.AssertEqual(t, "<html>spa</html>", w.Body.String())
+		})
+	}
+}
+
+// The API docs page is a real directory in the build output. Before #1775 a
+// directory stat fell straight through to the SPA fallback, so the "API Docs"
+// header link (href="/docs/") rendered the dashboard instead.
+func TestResolveStaticFilePath_DirectoryIndex(t *testing.T) {
+	dir := makeStaticDir(t, map[string]string{
+		"index.html":      "<html>spa</html>",
+		"docs/index.html": "<html>docs</html>",
+	})
+
+	for _, route := range []string{"/docs", "/docs/"} {
+		t.Run(route, func(t *testing.T) {
+			content, _, _, found := serveStaticForLambda(dir, route)
+			testutil.AssertEqual(t, true, found)
+			testutil.AssertEqual(t, "<html>docs</html>", string(content))
+		})
+	}
+}
+
+// A directory without its own index.html still falls back to the SPA shell, so
+// asset directories (dist/js, dist/css) do not 404 into a broken page.
+func TestResolveStaticFilePath_DirectoryWithoutIndexFallsBackToSPA(t *testing.T) {
+	dir := makeStaticDir(t, map[string]string{
+		"index.html": "<html>spa</html>",
+		"js/app.js":  "var x=1;",
+	})
+
+	content, _, _, found := serveStaticForLambda(dir, "/js")
+	testutil.AssertEqual(t, true, found)
+	testutil.AssertEqual(t, "<html>spa</html>", string(content))
+}
+
+// A directory index reached via /docs/ must not serve a file the direct
+// request path (/docs/index.html) would reject. os.Stat follows symlinks, so
+// the containment check has to run on the candidate, not just on the directory.
+func TestResolveStaticFilePath_DirectoryIndexRejectsSymlinkEscape(t *testing.T) {
+	parent := t.TempDir()
+	staticDir := filepath.Join(parent, "static", "docs")
+	if err := os.MkdirAll(staticDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	root := filepath.Join(parent, "static")
+	if err := os.WriteFile(filepath.Join(root, "index.html"), []byte("<html>spa</html>"), 0o644); err != nil {
+		t.Fatalf("write index.html: %v", err)
+	}
+	outside := filepath.Join(parent, "secret.html")
+	if err := os.WriteFile(outside, []byte("should-not-serve"), 0o644); err != nil {
+		t.Fatalf("write secret.html: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(staticDir, "index.html")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	// Both spellings must agree, and neither may serve the out-of-tree file.
+	direct, _, _, directFound := serveStaticForLambda(root, "/docs/index.html")
+	testutil.AssertEqual(t, false, directFound)
+	testutil.AssertEqual(t, "", string(direct))
+
+	viaDir, _, _, viaDirFound := serveStaticForLambda(root, "/docs/")
+	testutil.AssertEqual(t, true, viaDirFound)
+	testutil.AssertEqual(t, "<html>spa</html>", string(viaDir))
+}

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -456,3 +456,35 @@ func TestResolveStaticFilePath_DirectoryIndexRejectsSymlinkEscape(t *testing.T) 
 	testutil.AssertEqual(t, true, viaDirFound)
 	testutil.AssertEqual(t, "<html>spa</html>", string(viaDir))
 }
+
+// The SPA shell is served for every client-side route, so it needs the same
+// containment check as the direct request path. Without it a symlinked
+// index.html pointing out of the static dir is refused at /index.html and
+// served at /plans, which is the same asymmetry directoryIndex avoids.
+func TestSPAFallbackRejectsSymlinkedShell(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "static")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir static: %v", err)
+	}
+	outside := filepath.Join(parent, "secret.html")
+	if err := os.WriteFile(outside, []byte("should-not-serve"), 0o644); err != nil {
+		t.Fatalf("write secret.html: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "index.html")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	// Direct spelling: already rejected before this change.
+	_, _, _, directFound := serveStaticForLambda(root, "/index.html")
+	testutil.AssertEqual(t, false, directFound)
+
+	// Client-side route: must reach the same verdict, not serve the target.
+	for _, route := range []string{"/plans", "/inventory/coverage", "/"} {
+		t.Run(route, func(t *testing.T) {
+			content, _, _, found := serveStaticForLambda(root, route)
+			testutil.AssertEqual(t, false, found)
+			testutil.AssertEqual(t, "", string(content))
+		})
+	}
+}

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/LeanerCloud/CUDly/internal/testutil"
@@ -485,6 +487,158 @@ func TestSPAFallbackRejectsSymlinkedShell(t *testing.T) {
 			content, _, _, found := serveStaticForLambda(root, route)
 			testutil.AssertEqual(t, false, found)
 			testutil.AssertEqual(t, "", string(content))
+		})
+	}
+}
+
+// hostileRoot builds a static root with a sibling tree outside it holding a
+// file that must never be served, and returns (root, outsideFile).
+func hostileRoot(t *testing.T) (string, string) {
+	t.Helper()
+	parent := t.TempDir()
+	root := filepath.Join(parent, "static")
+	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for name, body := range map[string]string{
+		"index.html":      "<html>spa</html>",
+		"docs/index.html": "<html>docs</html>",
+	} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	outside := filepath.Join(parent, "secret.txt")
+	if err := os.WriteFile(outside, []byte("TOP-SECRET"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	// Symlinks that escape the root, inside the same fixture as the lexical
+	// cases. Keeping them here means one `-run Hostile` covers both classes;
+	// when they lived only in separately-named tests, a name-filtered
+	// mutation run silently skipped the only cases that exercise
+	// symlinkSafeContainedIn, which is the check path.Clean cannot stand in
+	// for.
+	if err := os.Symlink(outside, filepath.Join(root, "escape.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "docs", "leak.html")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	return root, outside
+}
+
+// Asserting on the resolved path, not on a status code: a handler that serves
+// the wrong file with 200 passes a status-only assertion. The invariant is that
+// whatever resolveStaticFilePath hands back is inside the served root, with
+// symlinks resolved, or it hands back nothing.
+func TestResolveStaticFilePath_HostilePathsNeverEscapeRoot(t *testing.T) {
+	root, outside := hostileRoot(t)
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("evalsymlinks root: %v", err)
+	}
+
+	hostile := []string{
+		"/../secret.txt",
+		"/../../secret.txt",
+		"/..",
+		"/../",
+		"/docs/../../secret.txt",
+		"/./../secret.txt",
+		"/....//secret.txt",
+		"/..%2fsecret.txt",           // encoded, as the Lambda RawPath transport delivers it
+		"/%2e%2e%2fsecret.txt",       // fully encoded
+		"/%252e%252e%252fsecret.txt", // double encoded
+		"/..\\secret.txt",            // backslash separator
+		"/" + outside,                // absolute path pasted into the URL
+		outside,                      // absolute path, no leading join
+		"//secret.txt",
+		"/docs/./../../secret.txt",
+		"/\x00/secret.txt", // NUL byte
+		"/plans\x00.html",
+		"/escape.txt",     // symlink in the root pointing outside it
+		"/docs/leak.html", // symlink one level down
+	}
+
+	for _, p := range hostile {
+		t.Run(strconv.Quote(p), func(t *testing.T) {
+			filePath, _, ok := resolveStaticFilePath(root, p)
+			if !ok {
+				return // refused outright, which is a valid answer
+			}
+			abs, absErr := filepath.Abs(filePath)
+			if absErr != nil {
+				t.Fatalf("abs(%q): %v", filePath, absErr)
+			}
+			// Resolve symlinks before comparing: a lexically-contained path
+			// whose target is outside is exactly the bypass being tested for.
+			if resolved, symErr := filepath.EvalSymlinks(abs); symErr == nil {
+				abs = resolved
+			}
+			if !isPathContainedIn(abs, realRoot) {
+				t.Fatalf("path %q escaped the root: resolved to %q, outside %q", p, abs, realRoot)
+			}
+			// Belt and braces: never the secret, whatever the path.
+			if data, readErr := os.ReadFile(abs); readErr == nil && strings.Contains(string(data), "TOP-SECRET") {
+				t.Fatalf("path %q served the out-of-root secret from %q", p, abs)
+			}
+		})
+	}
+}
+
+// Same matrix through the real HTTP handler, so Go's own URL decoding is in the
+// loop rather than assumed. Asserts on the served bytes, not the status.
+func TestSpaFileServer_HostilePathsNeverServeOutOfRoot(t *testing.T) {
+	root, _ := hostileRoot(t)
+	handler := spaFileServer(root)
+
+	for _, target := range []string{
+		"/../secret.txt",
+		"/../../secret.txt",
+		"/docs/../../secret.txt",
+		"/..%2fsecret.txt",
+		"/%2e%2e%2fsecret.txt",
+		"/%252e%252e%252fsecret.txt",
+		"/..\\secret.txt",
+		"//secret.txt",
+		"/....//secret.txt",
+		"/escape.txt",
+		"/docs/leak.html",
+	} {
+		t.Run(target, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if strings.Contains(w.Body.String(), "TOP-SECRET") {
+				t.Fatalf("target %q served out-of-root content (status %d)", target, w.Code)
+			}
+		})
+	}
+}
+
+// The Lambda transport passes RawPath, which is not decoded the way
+// http.Request.URL.Path is, so the two transports must be checked separately.
+func TestServeStaticForLambda_HostilePathsNeverServeOutOfRoot(t *testing.T) {
+	root, outside := hostileRoot(t)
+
+	for _, p := range []string{
+		"/../secret.txt",
+		"/../../secret.txt",
+		"/docs/../../secret.txt",
+		"/..%2fsecret.txt",
+		"/%2e%2e%2fsecret.txt",
+		"/%252e%252e%252fsecret.txt",
+		"/..\\secret.txt",
+		"//secret.txt",
+		"/escape.txt",
+		"/docs/leak.html",
+		outside,
+	} {
+		t.Run(strconv.Quote(p), func(t *testing.T) {
+			content, _, _, _ := serveStaticForLambda(root, p)
+			if strings.Contains(string(content), "TOP-SECRET") {
+				t.Fatalf("path %q served out-of-root content", p)
+			}
 		})
 	}
 }

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -492,8 +492,14 @@ func TestSPAFallbackRejectsSymlinkedShell(t *testing.T) {
 }
 
 // hostileRoot builds a static root with a sibling tree outside it holding a
-// file that must never be served, and returns (root, outsideFile).
-func hostileRoot(t *testing.T) (string, string) {
+// file that must never be served. Returns (root, outsideFile, symlinked), where
+// symlinked reports whether the symlink cases could be created.
+//
+// The lexical fixture is built unconditionally and the symlink cases are
+// additive, so a platform without symlink support loses the symlink cases only.
+// t.Skip here would take the traversal, encoded-path, absolute-path and NUL
+// cases with it and report the whole suite as skipped, which reads as a pass.
+func hostileRoot(t *testing.T) (string, string, bool) {
 	t.Helper()
 	parent := t.TempDir()
 	root := filepath.Join(parent, "static")
@@ -512,19 +518,32 @@ func hostileRoot(t *testing.T) (string, string) {
 	if err := os.WriteFile(outside, []byte("TOP-SECRET"), 0o644); err != nil {
 		t.Fatalf("write secret: %v", err)
 	}
-	// Symlinks that escape the root, inside the same fixture as the lexical
-	// cases. Keeping them here means one `-run Hostile` covers both classes;
-	// when they lived only in separately-named tests, a name-filtered
-	// mutation run silently skipped the only cases that exercise
-	// symlinkSafeContainedIn, which is the check path.Clean cannot stand in
-	// for.
-	if err := os.Symlink(outside, filepath.Join(root, "escape.txt")); err != nil {
-		t.Skipf("symlinks unavailable: %v", err)
+	// Symlinks that escape the root, in the same fixture as the lexical cases.
+	// Keeping them together means one `-run Hostile` covers both classes; when
+	// they lived only in separately-named tests, a name-filtered mutation run
+	// silently skipped the only cases exercising symlinkSafeContainedIn, which
+	// is the check path.Clean cannot stand in for.
+	symlinked := true
+	for _, link := range []string{
+		filepath.Join(root, "escape.txt"),
+		filepath.Join(root, "docs", "leak.html"),
+	} {
+		if err := os.Symlink(outside, link); err != nil {
+			t.Logf("symlinks unavailable, symlink cases skipped (lexical cases still run): %v", err)
+			symlinked = false
+			break
+		}
 	}
-	if err := os.Symlink(outside, filepath.Join(root, "docs", "leak.html")); err != nil {
-		t.Skipf("symlinks unavailable: %v", err)
+	return root, outside, symlinked
+}
+
+// symlinkCases returns the escaping-symlink paths when the fixture could create
+// them, and nothing otherwise, so callers append rather than branch.
+func symlinkCases(symlinked bool) []string {
+	if !symlinked {
+		return nil
 	}
-	return root, outside
+	return []string{"/escape.txt", "/docs/leak.html"}
 }
 
 // Asserting on the resolved path, not on a status code: a handler that serves
@@ -532,13 +551,13 @@ func hostileRoot(t *testing.T) (string, string) {
 // whatever resolveStaticFilePath hands back is inside the served root, with
 // symlinks resolved, or it hands back nothing.
 func TestResolveStaticFilePath_HostilePathsNeverEscapeRoot(t *testing.T) {
-	root, outside := hostileRoot(t)
+	root, outside, symlinked := hostileRoot(t)
 	realRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
 		t.Fatalf("evalsymlinks root: %v", err)
 	}
 
-	hostile := []string{
+	hostile := append([]string{
 		"/../secret.txt",
 		"/../../secret.txt",
 		"/..",
@@ -556,9 +575,7 @@ func TestResolveStaticFilePath_HostilePathsNeverEscapeRoot(t *testing.T) {
 		"/docs/./../../secret.txt",
 		"/\x00/secret.txt", // NUL byte
 		"/plans\x00.html",
-		"/escape.txt",     // symlink in the root pointing outside it
-		"/docs/leak.html", // symlink one level down
-	}
+	}, symlinkCases(symlinked)...)
 
 	for _, p := range hostile {
 		t.Run(strconv.Quote(p), func(t *testing.T) {
@@ -589,10 +606,10 @@ func TestResolveStaticFilePath_HostilePathsNeverEscapeRoot(t *testing.T) {
 // Same matrix through the real HTTP handler, so Go's own URL decoding is in the
 // loop rather than assumed. Asserts on the served bytes, not the status.
 func TestSpaFileServer_HostilePathsNeverServeOutOfRoot(t *testing.T) {
-	root, _ := hostileRoot(t)
+	root, _, symlinked := hostileRoot(t)
 	handler := spaFileServer(root)
 
-	for _, target := range []string{
+	targets := append([]string{
 		"/../secret.txt",
 		"/../../secret.txt",
 		"/docs/../../secret.txt",
@@ -602,9 +619,9 @@ func TestSpaFileServer_HostilePathsNeverServeOutOfRoot(t *testing.T) {
 		"/..\\secret.txt",
 		"//secret.txt",
 		"/....//secret.txt",
-		"/escape.txt",
-		"/docs/leak.html",
-	} {
+	}, symlinkCases(symlinked)...)
+
+	for _, target := range targets {
 		t.Run(target, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
 			w := httptest.NewRecorder()
@@ -619,9 +636,9 @@ func TestSpaFileServer_HostilePathsNeverServeOutOfRoot(t *testing.T) {
 // The Lambda transport passes RawPath, which is not decoded the way
 // http.Request.URL.Path is, so the two transports must be checked separately.
 func TestServeStaticForLambda_HostilePathsNeverServeOutOfRoot(t *testing.T) {
-	root, outside := hostileRoot(t)
+	root, outside, symlinked := hostileRoot(t)
 
-	for _, p := range []string{
+	paths := append([]string{
 		"/../secret.txt",
 		"/../../secret.txt",
 		"/docs/../../secret.txt",
@@ -630,10 +647,10 @@ func TestServeStaticForLambda_HostilePathsNeverServeOutOfRoot(t *testing.T) {
 		"/%252e%252e%252fsecret.txt",
 		"/..\\secret.txt",
 		"//secret.txt",
-		"/escape.txt",
-		"/docs/leak.html",
 		outside,
-	} {
+	}, symlinkCases(symlinked)...)
+
+	for _, p := range paths {
 		t.Run(strconv.Quote(p), func(t *testing.T) {
 			content, _, _, _ := serveStaticForLambda(root, p)
 			if strings.Contains(string(content), "TOP-SECRET") {


### PR DESCRIPTION
## Read this first: `/plans` was not broken

The issue reports that loading `/plans` directly renders the Home dashboard. **That does not reproduce on `main`, and I could not construct any input that produces it.** So this PR does not contain a `/plans` fix. It contains fixes for the five defects the audit the issue asked for actually turned up, four of which produce the same user-visible symptom on other routes, and one of which reproduces every symptom in the issue body verbatim.

Verified two independent ways before writing any code, both against the real build output:

- **Real browser** (Chromium against the production webpack bundle, the harness `frontend-e2e.yml` already runs): `/plans`, `/plans/`, `/plans?q=1`, `/Plans`, `/plans/abc`, each on first load **and** after a reload, all give `title="CUDly — Plans"`, `path=/plans`, nav highlight `plans`, panel `plans-tab`, zero page errors.
- **Go probe** of `resolveStaticFilePath` against the real `frontend/dist`: `/plans` resolves to `dist/index.html`, like every other route.

Both candidate root causes are clear for that route. The SPA catch-all is path-agnostic on both transports (`http.go` registers `mux.Handle("/", spaFileServer)` with only `/api/`, `/health`, `/version`, `/oidc/` ahead of it; `lambda.go` gates on `isStaticPath`), and no CDN special-cases a route name: AWS is a single compute origin plus `custom_error_response 404 -> /index.html`, Azure classic CDN and Front Door rewrite on file extension and the `api/` prefix, GCP's url map has `default_service` only and no `path_rule`.

**`/opportunities` deep-linking while `/plans` did not is a red herring**, not a property of the routes. Full reasoning and the likely explanation for the original report are in a correction comment on the issue.

## What the audit found

| | Defect | Symptom |
|---|---|---|
| **R1** | `key in record` consults `Object.prototype`, at 5 lookup sites in `navigation.ts` | `/constructor` and `/__proto__` kill `init()` before `switchTab()` runs |
| **R2** | `app.ts` rebuilt the canonical URL inline with an Admin-only special case | `/inventory/coverage` and `/inventory/ri-exchange` land on the wrong sub-section, URL truncated |
| **R3** | `history.ts:226` passed the retired tab name `'history'` | the Plans page's per-plan **History** button renders the Home dashboard |
| **R4** | `riexchange.ts:197` passed the retired tab name `'settings'` | **Exchange settings** renders Home under an Admin title and an `/admin/purchasing` URL |
| **R5** | `resolveStaticFilePath` sent any directory path to the SPA shell | the **API Docs** header link serves the dashboard instead of Swagger |

**R1 reproduces all four symptoms in the issue body.** `/constructor` passed the membership test, `TABS['constructor']` returned the `Object` constructor, and `pushState` of that value threw `DataCloneError` out of `init()`:

```
/constructor  title="CUDly - Cloud Commitment Optimizer"  nav=home  panel=home-tab
              Init error: DataCloneError: Failed to execute 'replaceState' on 'History':
              function Object() { [native code] } could not be cloned.
```

That leaves the app on the unrouted markup straight out of `index.html`: Home panel, Home nav highlight, the generic title, empty Home charts, and no event listeners bound. Only lowercase prototype members reach it, because `applyTabFromPath` lowercases the segment, so `/constructor` and `/__proto__` trip it while `/toString` and `/valueOf` do not.

**R3 and R4 are reachable from buttons on the Plans and Inventory pages.** Both passed tab names retired by the #340 IA rename, and `switchTab`'s `if (!(tabName in TABS)) tabName = 'home'` silently redirected them. R3 is wired at `plans.ts:1192` to the History button on every plan card, which makes it a plausible source of a report phrased as "/plans renders Home".

## Every route audited

Listing what was verified fine as well as what broke, so the reach of the audit is checkable rather than asserted. Every row was exercised in a real browser on direct load and on refresh.

| Route | Pre-fix verdict | Post-fix |
|---|---|---|
| `/`, `/home` | OK | OK |
| `/opportunities` | OK | OK |
| **`/plans`** (+ `/plans/`, `/plans?q=1`, `/Plans`, `/plans/abc`) | **OK, the reported symptom did not reproduce** | OK |
| `/purchases` | OK | OK |
| `/inventory` | OK, but the URL was left non-canonical | canonicalises to `/inventory/active-commitments` |
| `/inventory/active-commitments` | **BROKEN (R2)**, URL truncated | OK |
| `/inventory/coverage` | **BROKEN (R2)**, wrong sub-section | OK |
| `/inventory/ri-exchange` | **BROKEN (R2)**, wrong sub-section | OK |
| `/admin`, `/admin/{general,purchasing,accounts,users}` | OK | OK |
| `/dashboard`, `/recommendations`, `/history`, `/settings` (legacy) | OK | OK |
| `/ri-exchange` (legacy) | **BROKEN (R2)**, lands on bare `/inventory` | OK |
| `/not-a-route` | OK, falls back to Home | OK |
| `/constructor`, `/__proto__` | **BROKEN (R1)**, app dead | OK, falls back to Home |
| `/admin/constructor` | **BROKEN (R1)**, `document.title` became `"undefined"` | OK, Admin · General |
| `/toString`, `/valueOf`, `/hasOwnProperty` | OK, the segment lowercasing shields them | OK |
| `/docs`, `/docs/` | **BROKEN (R5)**, serves the dashboard | serves the API docs |
| `/reset-password`, `/archera-insurance`, `/purchases/{approve,cancel}/:id` | OK, non-tab landing paths | OK, pinned by the Go table test |
| in-app: Plans page → **History** button | **BROKEN (R3)**, renders Home | goes to Purchases |
| in-app: Inventory → **Exchange settings** | **BROKEN (R4)**, renders Home under an Admin URL | goes to Admin → Purchasing |

## The changes

`internal/server/static.go` resolves `<dir>/index.html` before the SPA fallback. The candidate re-runs `symlinkSafeContainedIn`: appending a constant filename keeps the path lexically inside the static dir, but `os.Stat` follows symlinks, so without the check `/docs/` would serve a file that a direct `/docs/index.html` request rejects. `directoryIndex` and `spaIndex` are extracted to hold `resolveStaticFilePath` at gocyclo 10, matching its pre-change value; the naive inline version measured 14 and would have reddened the `-over 10` pre-commit gate. `docs.html` gets an absolute stylesheet href so the page styles at both `/docs` and `/docs/`.

`frontend/src/navigation.ts` gets an own-property `isKnownKey()` at all five lookup sites, and an exported `canonicalTabPath()` that now owns the URL for both `switchTab`'s `pushState` and `app.ts`'s initial `replaceState`, so the two cannot drift again. `skipDefaultLoad` lets a caller reveal a tab without triggering its default fetch; the permission gate still applies.

The source change is 129 insertions across 6 files. The remaining ~420 lines are tests.

## Testing

**`frontend/tests-e2e/deeplink.spec.ts`** (new, 24 cases): real Chromium, `page.goto(url)` then `page.reload()`, asserting the highlighted nav item, the visible panel, `document.title`, the canonical path, and zero uncaught page errors. Covers every tab, both sub-tab families, the legacy redirects, an unknown path, and the prototype-chain segments. A client-side nav to these routes works, so a test that clicks the nav item would stay green while the bug is live: these navigate the browser directly, which is the only way to exercise the failing path.

**Pre-fix: 9 of 24 fail** (`/inventory`, `/inventory/active-commitments`, `/inventory/coverage`, `/inventory/ri-exchange`, `/ri-exchange`, `/constructor`, `/__proto__`, `/admin/constructor`, and the sub-section assertion). **Post-fix: 24/24 pass.**

`navigation.test.ts` adds coverage for `applyTabFromPath`, which had none, including the prototype-chain paths, plus `canonicalTabPath` and `skipDefaultLoad`. `static_test.go` adds a table test pinning the SPA fallback for every route on both transports, so a future root-level `mux` registration cannot silently shadow one, plus the `/docs` directory-index cases and a symlink-escape case. Each was verified failing against the pre-fix code.

| Gate | Result |
|---|---|
| `npm test` | 90 suites, 2855 passed, 0 failed |
| `npx playwright test` | 28 passed |
| `npm run lint` / `npm run build` | 0 errors |
| `go test ./...` | pass (whole repo) |
| `golangci-lint` / `gocyclo -over 10` / `gofmt` | clean |

## Review note

An independent review of the diff caught a defect this PR's own fix introduced. Routing `viewPlanHistory` to the Purchases tab made a previously-unreachable render reachable, and `_fourEyesMode` is assigned only inside `loadHistory()`, which `skipDefaultLoad` suppresses. The approval queue would have rendered as though dual control were off, offering a creator an **Approve** button on their own pending purchase. The backend still 403s, so it was a UI misrepresentation rather than a bypass, but it is a money path and no test in the changeset would have caught it. Fixed by extracting `refreshFourEyesMode()` and awaiting it on both render paths. The same review found the `directoryIndex` symlink gap above.

Also fixed at the source while here: `navigation.test.ts` set `isAdmin -> false` and never restored it, and `jest.clearAllMocks()` does not reset implementations, so every test declared after it had been running as a non-admin.

## Follow-up, not in this PR

`init()` wraps everything in one `try`, so any failure before `switchTab()` leaves the app on the unrouted markup with the URL untouched and a dead nav. R1 proves that state is reachable from a URL and fixes that route, but the fragility remains and is the most likely explanation for the original report. Changing how init failures surface to the user is a different concern and would widen this diff considerably. Worth its own ticket.

Closes #1775


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deep links preserve selected Inventory and Admin sub-tabs across navigation and page refreshes.
  * RI Exchange links open the relevant Purchasing panel directly.
* **Bug Fixes**
  * Legacy and invalid routes redirect to canonical paths more reliably.
  * Plan history respects purchasing access permissions and avoids unnecessary data loads.
  * Dual-control status refreshes without blocking page rendering and defaults safely when unavailable.
  * Documentation and SPA routes resolve correctly at `/docs` and `/docs/`.
* **Reliability**
  * Improved handling of directory indexes, missing routes, and unsafe path references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->