### PR TITLE
ci(frontend-e2e): fail the job when Chromium install wedges, and cache it

### DIFF
--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -1,7 +1,16 @@
-name: Frontend E2E (PR)
+name: Frontend E2E
 
 on:
   pull_request:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-e2e.yml"
+  # On main only to populate the browser cache in the default-branch scope: a
+  # cache written by a pull_request run is readable only within that PR, so
+  # without this the first run of every PR misses.
+  push:
     branches:
       - main
     paths:
@@ -12,14 +21,26 @@ permissions:
   contents: read
 
 concurrency:
-  group: frontend-e2e-pr-${{ github.ref }}
-  cancel-in-progress: true
+  group: frontend-e2e-${{ github.ref }}
+  # PRs only. Superseding a push on main would cancel the run that populates
+  # the cache and the one carrying the post-merge signal, which are the two
+  # reasons the push trigger exists.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   playwright:
     name: Playwright Chromium
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Raised from 10 so the install step's own 8-minute cap is always what
+    # fires. Every other step at its worst across all attempts sums to 78s
+    # (75s if you look only at green runs, which understates it, and no sample
+    # exercised the spec-failure path at all), plus roughly 30s for the cache
+    # restore and save. So a full 480s install lands at ~600s: exactly the old
+    # cap, leaving nothing for the job timeout to be a backstop with. And a
+    # job timeout cancels, which is the conclusion #1869 is about. A cap is
+    # not a cost: the median successful job takes 69s, and only pathological
+    # runs ever approach either limit.
+    timeout-minutes: 12
     defaults:
       run:
         working-directory: frontend
@@ -45,8 +66,53 @@ jobs:
       - name: Build
         run: npm run build
 
+      # The resolved version, not the `^1.60.0` range in package.json, so a
+      # floating range cannot silently reuse the previous browser build.
+      - name: Resolve Playwright version
+        id: playwright
+        run: |
+          set -euo pipefail
+          version="$(jq -re '.packages["node_modules/@playwright/test"].version' package-lock.json)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Playwright ${version}"
+
+      # Split restore/save rather than the combined actions/cache, whose save is
+      # a post step gated on `post-if: success()` and so skips the run being
+      # iterated on: the one whose specs are still failing.
+      - name: Restore Chromium
+        id: chromium-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ steps.playwright.outputs.version }}-chromium
+
       - name: Install Chromium
+        # This step timeout is the fix for #1869, where this install wedged
+        # five times on 2026-08-19 (#1864, #1868) and ran until the job cap,
+        # ending each run `cancelled` with every spec skipped. Cancelled is not
+        # failed, so the missing e2e signal showed up as nothing at all. A step
+        # that busts its own timeout FAILS, so a future wedge is a red X naming
+        # this step.
+        #
+        # 8 minutes sits in the gap measured over the last 40 runs and all
+        # their attempts: 39 successful installs, 36 at or under 39s with
+        # outliers at 101s, 140s and 381s, against 5 wedges none under 585s.
+        # Above the healthy maximum, below every wedge, under the job cap.
+        # That gap is also why there is no retry: an attempt capped under 381s
+        # fails healthy runs, and two capped above it do not fit in the job.
+        timeout-minutes: 8
+        # Idempotent on a cache hit: skips the download when the restored
+        # browser is complete and re-fetches when it is not.
         run: npx playwright install --with-deps chromium
+
+      - name: Save Chromium
+        # Skipped on a hit, and on an install failure (an untaken `if:` still
+        # implies success()), so only a complete browser reaches the key.
+        if: steps.chromium-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ steps.chromium-cache.outputs.cache-primary-key }}
 
       - name: Run Playwright tests
         run: npm run test:e2e


### PR DESCRIPTION
Closes #1869

## What makes this work rather than reduce the odds

Two measured facts carry the whole change.

**The separation is clean.** Walking the last 40 runs and *every* attempt of each (not just the latest, which is what hid this):

- **39 successful installs**: 36 at or under 39s, outliers at **101s, 140s, 381s**
- **5 wedges**: none under 585s

Nothing sits between 381s and 585s, so "slow" and "wedged" are separable by a cap, but only by one well above 381s.

**A step timeout fails; a job timeout cancels.** This is not inferred from the docs. `actions/runner`, `src/Runner.Worker/StepsRunner.cs` (~L322-337): when the step's own cancellation token fired and the job's did not, the runner sets `TaskResult.Failed`; otherwise `TaskResult.Canceled`. So moving the bound from the job to the step converts the exact failure #1869 is about, a `cancelled` run that skipped every spec and read as not-a-failure, into a red X reading "The action 'Install Chromium' has timed out after 8 minutes".

This is the repo's first step-level `timeout-minutes` (every other one in `.github/workflows` is job-level), so there was no local precedent to copy and the runner source was the only available proof.

## The change

| | |
|---|---|
| `timeout-minutes: 8` on `Install Chromium` | The fix. 480s is above the 381s slowest healthy install and below the 585s floor of every wedge. |
| job `timeout-minutes` 10 → 12 | **Required, not cosmetic.** Worst case was 480 + 78 + ~30 = 588s against a 600s cap, i.e. 12s of margin, so the *job* would have timed out first and cancelled the run, reproducing the bug. |
| cache restore + save of `~/.cache/ms-playwright` | Keyed on the Playwright version resolved from `package-lock.json`. Removes the download from the common path. |
| `push: branches: [main]` | A cache written by a `pull_request` run is readable only within that PR. With no default-branch run there is no base scope to inherit, so the first run of every PR would miss. Also gives main a post-merge Playwright signal it lacked (`frontend-build-sentinel` runs jest, which cannot resolve stylesheets into layout, which is what #1777 and #1776 were). |
| `cancel-in-progress` scoped to `pull_request` | Unconditional, it would supersede the very main run that warms the cache and carries that signal. |
| workflow renamed `Frontend E2E (PR)` → `Frontend E2E` | The name became wrong once it also runs on main. Safe: the required-check context is the **job** name, `Playwright Chromium`, which is deliberately untouched. |

## No retry, and that is a finding rather than an omission

The issue suggested one, and my first draft used 3 × 90s. The distribution above kills it: a per-attempt cap under 381s turns the three healthy outliers red, and two attempts capped above it do not fit the job budget alongside `npm ci`, the build and the specs. The 22s figure in the issue is the best case, not the distribution. The cache is what removes the download from the common path; a retry is what would have to replace it, and cannot.

## The wedge durations are lower bounds, not measurements

All five wedged attempts were **truncated by the job cap**, not self-terminating. Job wall clock is a constant 615-618s across all five against the then-600s cap plus cancellation overhead, and the install duration varies inversely with the preamble, which is what confirms truncation:

| run | attempt | job wall clock | `Install Chromium` | everything else |
|---|---|---|---|---|
| 32273788976 | 1 | 618s | 585s | 33s |
| 32273788976 | 2 | 615s | 586s | 29s |
| 32273788976 | 3 | 618s | 586s | 32s |
| 32293420755 | 1 | 615s | 592s | 23s |
| 32293420755 | 2 | 617s | 591s | 26s |

So 585-592s is a floor. Nothing observed says whether the install would have cleared at 601s or never, and a slow download is indistinguishable from a wedged lock in this data. A `__dirlock` contention hypothesis and the concrete diagnostic for a recurrence are recorded in #1871.

## What this does not fix

`Playwright Chromium` is **not** in the `protect-default-branch` ruleset's required contexts (it requires only `CI Success` and `Run pre-commit hooks`), so a wedge is now visible but still gates nothing. That is the other half of #1869 and is filed as **#1871**, separately because adding it interacts with the `paths:` filter: a required check that never reports on PRs missing the filter blocks them with no failing job to point at.

## Verification

- `actionlint 1.7.12` (pinned digest) and `zizmor 1.29.0 --offline --persona=pedantic --min-severity=medium`, the versions gated by #1870: both **exit 0**, with the finding count identical to a clean `origin/main` checkout at *every* severity (106 ignored, 14 suppressed), including the `cache-poisoning` audit that a cache plus a default-branch trigger could trip.
- Both `run` blocks were extracted from the parsed YAML and executed: the cache key resolves to `Linux-X64-playwright-1.62.0-chromium`, changes on a Playwright bump, does **not** change on an unrelated lockfile edit, and the step fails rather than emitting an empty key if the lockfile entry is missing.
- 20 structural assertions on the parsed workflow cover the timeout ordering (381 < 480 < 585, and 480 + 108 < 720) and that `Run Playwright tests` is unconditional and reachable on both the cache-hit and cache-miss paths.

**Not verified:** the wedge is upstream and not reproducible on demand. Nothing here shows the download stops hanging; it shows a hang costs a named red step instead of a silently skipped suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved frontend end-to-end test execution with more reliable browser setup and caching.
  * Frontend tests now run automatically for relevant pull requests and changes merged to the main branch.
  * Increased test execution limits to reduce failures caused by longer-running checks.
* **Chores**
  * Updated the workflow naming and concurrency behavior for clearer, more efficient validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->