### PR TITLE
fix(sec): preserve constraints.accounts on group edit and refuse blank constraint entries

### DIFF
--- a/frontend/src/__tests__/group-edit-unrepresentable-permissions.test.ts
+++ b/frontend/src/__tests__/group-edit-unrepresentable-permissions.test.ts
@@ -49,10 +49,19 @@ jest.mock('../confirmDialog', () => ({
   confirmDialog: jest.fn().mockResolvedValue(true),
 }));
 
+// Only the toast functions are stubbed; escapeHtml and the rest stay real,
+// because the escaping tests below depend on the genuine implementation.
+jest.mock('../users/utils', () => ({
+  ...jest.requireActual('../users/utils'),
+  showError: jest.fn(),
+  showSuccess: jest.fn(),
+}));
+
 import * as api from '../api';
 import * as groupState from '../groups/state';
 import * as groupModals from '../groups/groupModals';
 import { setupGroupHandlers } from '../groups/handlers';
+import { showError } from '../users/utils';
 import { ALL_ACTIONS, ALL_RESOURCES } from '../permissions';
 
 // The exact seeded Purchaser group permission set (PURCHASER_PERMS in
@@ -484,5 +493,123 @@ describe('regression: group edit preserves constraints.accounts (#1629)', () => 
     expect(savedPermissions()).toEqual([
       { action: 'view', resource: 'history', constraints: { accounts: [payload] } },
     ]);
+  });
+
+  /**
+   * Raised by CodeRabbit on PR #1875 and taken rather than dismissed.
+   *
+   * Representing `accounts` fixes the common case but leaves one open: a
+   * value the comma-separated text encoding cannot carry back unchanged. A
+   * stored [""] renders blank and re-parses as ABSENT; [","] re-parses as an
+   * empty list; [" acct A "] comes back trimmed. Each re-submits a different
+   * restriction than the one loaded, and for a constraint list "different"
+   * means WIDER, because an empty list is "no restriction" at enforcement.
+   * The backend guard cannot catch it either: the form filters the value out
+   * before the request is built, so validateConstraintEntries never sees a
+   * blank to reject.
+   *
+   * The fix detects it when the row renders and refuses the save. A loud
+   * refusal beats a silent widening.
+   *
+   * Every assertion here is keyed on the outgoing payload or on the error
+   * message, never on the `data-unrepresentable` attribute the fix
+   * introduces: a negative keyed on a hook that does not exist pre-fix can
+   * never fail pre-fix.
+   */
+  describe('refuses to save a stored constraint value it cannot represent', () => {
+    function groupWithAccounts(accounts: string[]): api.APIGroup {
+      return {
+        id: 'operators-group-id',
+        name: 'Prod Operators',
+        description: 'Old description',
+        permissions: [{ action: 'view', resource: 'history', constraints: { accounts } }],
+        created_at: '2024-01-01T00:00:00Z',
+      };
+    }
+
+    // Each of these vanishes or mutates through parseConstraintList. The
+    // second is the case a per-entry "is it blank" check would miss: "," is
+    // not blank, but the split runs before the filter, so it still vanishes.
+    const UNREPRESENTABLE: Array<[string, string[]]> = [
+      ['a blank entry (deny-everything becomes allow-everything)', ['']],
+      ['a comma-only entry, which is not blank but still vanishes', [',']],
+      ['a whitespace-padded entry, which would come back as a different fence', [' acct A ']],
+      ['a blank entry beside a real one', ['acct-prod-1', '  ']],
+    ];
+
+    test.each(UNREPRESENTABLE)('%s refuses the save', async (_label, accounts) => {
+      await openEdit(groupWithAccounts(accounts));
+      (document.getElementById('group-description') as HTMLTextAreaElement).value = 'New description';
+
+      // The form is valid, so the browser submits and the handler runs: the
+      // refusal is this code's decision, not constraint validation's.
+      const form = document.getElementById('group-form') as HTMLFormElement;
+      expect(form.checkValidity()).toBe(true);
+      await clickSave();
+
+      expect(api.updateGroup).not.toHaveBeenCalled();
+      expect(showError).toHaveBeenCalledTimes(1);
+      const message = (showError as jest.Mock).mock.calls[0][0] as string;
+      // Names which permission and which constraint list, matching the
+      // specificity of the backend refusal.
+      expect(message).toContain('permission 0');
+      expect(message).toContain('view:history');
+      expect(message).toContain('accounts');
+    });
+
+    test('names every offending permission, by index, when several are unsafe', async () => {
+      const group = groupWithAccounts(['']);
+      group.permissions = [
+        { action: 'view', resource: 'plans' },
+        { action: 'view', resource: 'history', constraints: { accounts: [''] } },
+        { action: 'update-any', resource: 'purchases', constraints: { regions: [' us-east-1 '] } },
+      ];
+      await openEdit(group);
+      await clickSave();
+
+      expect(api.updateGroup).not.toHaveBeenCalled();
+      const message = (showError as jest.Mock).mock.calls[0][0] as string;
+      expect(message).toContain('permission 1 (view:history)');
+      expect(message).toContain('permission 2 (update-any:purchases)');
+      expect(message).toContain('regions');
+      // The clean row is not blamed.
+      expect(message).not.toContain('view:plans');
+    });
+
+    test('removing the offending row unblocks the save', async () => {
+      // The verdict lives on the row, so deleting the row clears it. Removing
+      // the permission outright is an explicit edit, not a silent drop.
+      await openEdit(groupWithAccounts(['']));
+      const removeBtn = document.querySelector('.permission-item .remove-permission-btn') as HTMLButtonElement;
+      removeBtn.click();
+      await clickSave();
+
+      expect(showError).not.toHaveBeenCalled();
+      expect(api.updateGroup).toHaveBeenCalledWith('operators-group-id', {
+        name: 'Prod Operators',
+        description: 'Old description',
+        permissions: [],
+      });
+    });
+
+    // Negative controls, payload-keyed: the refusal must not fire on the
+    // ordinary constraint shapes this form exists to edit. An absent or empty
+    // list both mean "no restriction" and are entirely normal.
+    const REPRESENTABLE: Array<[string, api.Permission]> = [
+      ['a populated list', { action: 'view', resource: 'history', constraints: { accounts: ['acct-prod-1', 'acct-prod-2'] } }],
+      ['an empty list', { action: 'view', resource: 'history', constraints: { accounts: [] } }],
+      ['no constraints at all', { action: 'view', resource: 'history' }],
+      ['a non-list constraint only', { action: 'view', resource: 'history', constraints: { max_amount: 5000 } }],
+    ];
+
+    test.each(REPRESENTABLE)('%s still saves', async (_label, permission) => {
+      const group = groupWithAccounts([]);
+      group.permissions = [permission];
+      await openEdit(group);
+      await clickSave();
+
+      expect(showError).not.toHaveBeenCalled();
+      expect(api.updateGroup).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/frontend/src/__tests__/group-edit-unrepresentable-permissions.test.ts
+++ b/frontend/src/__tests__/group-edit-unrepresentable-permissions.test.ts
@@ -611,5 +611,87 @@ describe('regression: group edit preserves constraints.accounts (#1629)', () => 
       expect(showError).not.toHaveBeenCalled();
       expect(api.updateGroup).toHaveBeenCalledTimes(1);
     });
+
+    /**
+     * The same widening from the typed direction, CodeRabbit's second finding
+     * on this PR. The render-time check above covers a STORED value; this
+     * covers what an operator types.
+     *
+     * "," is non-empty in the box but parseConstraintList reduces it to [],
+     * so the save would send an empty list, and an empty list is "no
+     * restriction" at enforcement. A stray comma would silently remove the
+     * fence. This is MORE reachable than the stored case, which needs data no
+     * shipped code produces; this one needs a typo.
+     */
+    describe('refuses typed input that parses to nothing', () => {
+      const TYPED_NOTHING: Array<[string, string]> = [
+        ['a bare comma', ','],
+        ['a comma padded with spaces', '  ,  '],
+        ['several commas', ',,,'],
+      ];
+
+      test.each(TYPED_NOTHING)('%s refuses the save and names the field', async (_label, typed) => {
+        await openEdit(groupWithAccounts(['acct-prod-1']));
+        accountsInput().value = typed;
+        await clickSave();
+
+        expect(api.updateGroup).not.toHaveBeenCalled();
+        expect(showError).toHaveBeenCalledTimes(1);
+        const message = (showError as jest.Mock).mock.calls[0][0] as string;
+        expect(message).toContain('permission 0');
+        expect(message).toContain('view:history');
+        expect(message).toContain('accounts');
+      });
+
+      test('names the offending dimension, not a different one', async () => {
+        const group = groupWithAccounts(['acct-prod-1']);
+        group.permissions = [{ action: 'view', resource: 'history', constraints: { regions: ['us-east-1'] } }];
+        await openEdit(group);
+        (document.querySelector('.perm-regions') as HTMLInputElement).value = ',';
+        await clickSave();
+
+        expect(api.updateGroup).not.toHaveBeenCalled();
+        const message = (showError as jest.Mock).mock.calls[0][0] as string;
+        expect(message).toContain('regions');
+        expect(message).not.toContain('accounts');
+      });
+
+      // The boundary that must not move: a box the operator empties still
+      // means "no restriction" and must save. Refusing here would make every
+      // unconstrained group uneditable, which is worse than the bug.
+      test('an emptied box still saves as no restriction', async () => {
+        await openEdit(groupWithAccounts(['acct-prod-1']));
+        accountsInput().value = '';
+        await clickSave();
+
+        expect(showError).not.toHaveBeenCalled();
+        expect(savedPermissions()).toEqual([{ action: 'view', resource: 'history' }]);
+      });
+
+      // A box holding only spaces looks identical to an empty one on screen,
+      // so it is treated as empty rather than refused: an error on a field
+      // that appears blank could not be acted on.
+      test('a whitespace-only box is treated as emptied, not refused', async () => {
+        await openEdit(groupWithAccounts(['acct-prod-1']));
+        accountsInput().value = '   ';
+        await clickSave();
+
+        expect(showError).not.toHaveBeenCalled();
+        expect(savedPermissions()).toEqual([{ action: 'view', resource: 'history' }]);
+      });
+
+      // A trailing comma is ordinary typing and still yields a usable entry,
+      // so it must save rather than trip the refusal.
+      test('a trailing comma beside a real value still saves', async () => {
+        await openEdit(groupWithAccounts(['acct-prod-1']));
+        accountsInput().value = 'acct-prod-1, acct-prod-2,';
+        await clickSave();
+
+        expect(showError).not.toHaveBeenCalled();
+        expect(savedPermissions()).toEqual([
+          { action: 'view', resource: 'history', constraints: { accounts: ['acct-prod-1', 'acct-prod-2'] } },
+        ]);
+      });
+    });
   });
 });

--- a/frontend/src/__tests__/group-edit-unrepresentable-permissions.test.ts
+++ b/frontend/src/__tests__/group-edit-unrepresentable-permissions.test.ts
@@ -52,6 +52,7 @@ jest.mock('../confirmDialog', () => ({
 import * as api from '../api';
 import * as groupState from '../groups/state';
 import * as groupModals from '../groups/groupModals';
+import { setupGroupHandlers } from '../groups/handlers';
 import { ALL_ACTIONS, ALL_RESOURCES } from '../permissions';
 
 // The exact seeded Purchaser group permission set (PURCHASER_PERMS in
@@ -282,5 +283,206 @@ describe('regression: group edit no longer drops/widens unrepresentable permissi
         permissions: [{ action: payload, resource: payload }],
       });
     });
+  });
+});
+
+/**
+ * The constraints axis of the same defect (#1629).
+ *
+ * PermissionConstraints (internal/auth/types.go) carries five dimensions;
+ * the form rendered inputs for four. constraints.accounts had nowhere to
+ * live and collectPermissions() never read one back, so every save dropped
+ * it. That WIDENS the permission: matchStringListConstraints
+ * (internal/auth/service_group.go) treats an empty list as "no restriction
+ * on this dimension", so a permission stored as "manage any scheduled
+ * purchase, but only in acct-prod-1" came back out of a cosmetic rename as
+ * "manage any scheduled purchase, in every cloud account". The backend
+ * grant ceiling does not catch it either: grantCeilingAllows short-circuits
+ * on the caller's admin:*.
+ *
+ * These tests drive the REAL save path -- the submit listener installed by
+ * setupGroupHandlers(), reached by clicking the form's submit button --
+ * rather than calling saveGroup(event) directly. #group-form carries no
+ * novalidate and .perm-resource is `required`, so a direct call bypasses
+ * browser constraint validation and cannot tell whether a fix is on the
+ * path the admin actually uses.
+ */
+describe('regression: group edit preserves constraints.accounts (#1629)', () => {
+  // Mirrors the #group-form markup in index.html: required name input, the
+  // permissions list, and a real submit button.
+  function setUpRealFormDom(): void {
+    document.body.innerHTML = `
+      <div id="group-modal" class="hidden">
+        <span id="group-modal-title"></span>
+        <form id="group-form">
+          <input type="hidden" id="group-id">
+          <input type="text" id="group-name" required>
+          <textarea id="group-description"></textarea>
+          <div id="permissions-list"></div>
+          <button type="submit" class="primary">Save Group</button>
+        </form>
+      </div>
+    `;
+    setupGroupHandlers();
+  }
+
+  function submitButton(): HTMLButtonElement {
+    return document.querySelector('#group-form button[type="submit"]') as HTMLButtonElement;
+  }
+
+  // Clicks Save the way an admin does and waits for saveGroup's promise
+  // chain to settle (the submit listener fires it without awaiting).
+  async function clickSave(): Promise<void> {
+    submitButton().click();
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  async function openEdit(group: api.APIGroup): Promise<void> {
+    (api.getGroup as jest.Mock).mockResolvedValue(group);
+    await groupModals.openEditGroupModal(group.id);
+  }
+
+  function accountsInput(index = 0): HTMLInputElement {
+    const items = document.querySelectorAll('.permission-item');
+    return items[index]!.querySelector('.perm-accounts') as HTMLInputElement;
+  }
+
+  function savedPermissions(): api.Permission[] {
+    const call = (api.updateGroup as jest.Mock).mock.calls[0];
+    return call[1].permissions as api.Permission[];
+  }
+
+  // A realistic account-scoped operator group. The second permission is the
+  // narrowest form of the bug: accounts is its ONLY constraint, so the old
+  // `if (providers || services || regions || maxAmount)` guard never fired
+  // and the permission round-tripped fully unconstrained.
+  const ACCOUNT_SCOPED_PERMISSIONS: api.Permission[] = [
+    { action: 'update-any', resource: 'purchases', constraints: { accounts: ['acct-prod-1'], max_amount: 5000 } },
+    { action: 'view', resource: 'history', constraints: { accounts: ['acct-prod-1'] } },
+  ];
+
+  function accountScopedGroup(): api.APIGroup {
+    return {
+      id: 'operators-group-id',
+      name: 'Prod Operators',
+      description: 'Old description',
+      permissions: ACCOUNT_SCOPED_PERMISSIONS,
+      created_at: '2024-01-01T00:00:00Z',
+    };
+  }
+
+  beforeEach(() => {
+    setUpRealFormDom();
+    groupState.setCurrentEditingGroup(null);
+    jest.clearAllMocks();
+  });
+
+  test('the harness really goes through browser constraint validation', async () => {
+    // Pins the property the rest of this describe relies on: an invalid form
+    // never reaches saveGroup. Without this, a fix that never runs could pass
+    // every test below.
+    await openEdit(accountScopedGroup());
+    (document.getElementById('group-name') as HTMLInputElement).value = '';
+
+    const form = document.getElementById('group-form') as HTMLFormElement;
+    expect(form.checkValidity()).toBe(false);
+    await clickSave();
+
+    expect(api.updateGroup).not.toHaveBeenCalled();
+  });
+
+  test('an account-scoped permission set survives an edit that only changes the description', async () => {
+    await openEdit(accountScopedGroup());
+    (document.getElementById('group-description') as HTMLTextAreaElement).value = 'New description';
+
+    const form = document.getElementById('group-form') as HTMLFormElement;
+    expect(form.checkValidity()).toBe(true);
+    await clickSave();
+
+    expect(api.updateGroup).toHaveBeenCalledWith('operators-group-id', {
+      name: 'Prod Operators',
+      description: 'New description',
+      permissions: ACCOUNT_SCOPED_PERMISSIONS,
+    });
+
+    // Non-vacuity: "no permission lost its fence" is trivially true of an
+    // empty list, and an empty list is itself one of this bug's outcomes.
+    const saved = savedPermissions();
+    expect(saved).toHaveLength(2);
+    expect(saved.every(p => (p.constraints?.accounts?.length ?? 0) > 0)).toBe(true);
+  });
+
+  test('the stored account fence is rendered into the form, so the admin edits what is actually stored', async () => {
+    await openEdit(accountScopedGroup());
+
+    expect(accountsInput(0).value).toBe('acct-prod-1');
+    expect(accountsInput(1).value).toBe('acct-prod-1');
+  });
+
+  test('narrowing the fence saves exactly what was entered', async () => {
+    const group = accountScopedGroup();
+    group.permissions = [
+      { action: 'update-any', resource: 'purchases', constraints: { accounts: ['acct-prod-1', 'acct-prod-2'] } },
+    ];
+    await openEdit(group);
+
+    accountsInput().value = 'acct-prod-1';
+    await clickSave();
+
+    expect(savedPermissions()).toEqual([
+      { action: 'update-any', resource: 'purchases', constraints: { accounts: ['acct-prod-1'] } },
+    ]);
+  });
+
+  test('clearing one fence removes only that one and is not blocked', async () => {
+    // The other direction: an admin who deliberately clears the field gets an
+    // unconstrained permission, which is what they asked for.
+    //
+    // Only the FIRST row is cleared, and the second is asserted to keep its
+    // fence. "The cleared row has no accounts" is on its own true of a build
+    // that renders the input but never reads it back -- the very defect this
+    // file exists for -- so the assertion is paired with one that such a build
+    // fails. Both are keyed on the outgoing payload rather than on any DOM
+    // hook this change introduces.
+    await openEdit(accountScopedGroup());
+
+    accountsInput(0).value = '';
+    await clickSave();
+
+    const saved = savedPermissions();
+    expect(saved).toHaveLength(2);
+    expect(saved[0]!.constraints?.accounts).toBeUndefined();
+    expect(saved[0]!.constraints?.max_amount).toBe(5000);
+    expect(saved[1]!.constraints?.accounts).toEqual(['acct-prod-1']);
+  });
+
+  test('adding a fence to a previously unconstrained permission saves it', async () => {
+    const group = accountScopedGroup();
+    group.permissions = [{ action: 'view', resource: 'history' }];
+    await openEdit(group);
+
+    accountsInput().value = 'acct-prod-1, acct-prod-2';
+    await clickSave();
+
+    expect(savedPermissions()).toEqual([
+      { action: 'view', resource: 'history', constraints: { accounts: ['acct-prod-1', 'acct-prod-2'] } },
+    ]);
+  });
+
+  test('an account id is escaped on the way into the input and round-trips byte-identically', async () => {
+    // The new value="" attribute is another API string reaching innerHTML.
+    const payload = '"><img src=x onerror=alert(1)>';
+    const group = accountScopedGroup();
+    group.permissions = [{ action: 'view', resource: 'history', constraints: { accounts: [payload] } }];
+    await openEdit(group);
+
+    expect(document.querySelectorAll('img, script, svg, iframe, style').length).toBe(0);
+    expect(accountsInput().value).toBe(payload);
+
+    await clickSave();
+
+    expect(savedPermissions()).toEqual([
+      { action: 'view', resource: 'history', constraints: { accounts: [payload] } },
+    ]);
   });
 });

--- a/frontend/src/groups/groupModals.ts
+++ b/frontend/src/groups/groupModals.ts
@@ -224,11 +224,12 @@ export function addPermission(permission?: Permission): void {
   // Record the verdict, not the value: which of this row's constraint lists
   // hold something the text encoding cannot carry back unchanged. saveGroup
   // refuses while any row carries this. The attribute lives and dies with the
-  // row, so removing the row clears it and nothing outlives the modal.
+  // row, so removing the row clears it and nothing outlives the modal. The
+  // action:resource label is read live from the selects at refusal time rather
+  // than stored here, so it cannot go stale against what the operator sees.
   const unsafe = unrepresentableDimensions(permission?.constraints);
   if (unsafe.length > 0) {
     permDiv.setAttribute('data-unrepresentable', unsafe.join(', '));
-    permDiv.setAttribute('data-permission-label', `${permission?.action ?? ''}:${permission?.resource ?? ''}`);
   }
 
   permDiv.innerHTML = `
@@ -312,11 +313,16 @@ function parseConstraintList(raw: string): string[] {
 // An absent or empty list is NOT flagged. Both mean "no restriction on this
 // dimension", both are perfectly normal, and refusing them would make
 // ordinary unconstrained groups uneditable.
+// The constraint dimensions the form renders as comma-separated text, each in
+// an input classed `perm-<dimension>`. One list, so the render-time check and
+// the typed-input check below cannot cover different sets.
+const LIST_CONSTRAINT_DIMENSIONS = ['accounts', 'providers', 'services', 'regions'] as const;
+
 function unrepresentableDimensions(constraints: Permission['constraints']): string[] {
   if (!constraints) return [];
 
   const unsafe: string[] = [];
-  for (const dimension of ['accounts', 'providers', 'services', 'regions'] as const) {
+  for (const dimension of LIST_CONSTRAINT_DIMENSIONS) {
     const values = constraints[dimension];
     if (!values || values.length === 0) continue;
     const reparsed = parseConstraintList(values.join(', '));
@@ -327,20 +333,54 @@ function unrepresentableDimensions(constraints: Permission['constraints']): stri
   return unsafe;
 }
 
-// Builds one message per flagged row, naming the permission by index and by
-// action:resource and naming the constraint list, so an operator with a
-// multi-permission group knows exactly which value to repair. Mirrors the
-// specificity of the backend's own refusal in validateConstraintEntries.
+// Every reason this form must refuse to save, as one message per problem,
+// naming the permission by index and by action:resource and naming the
+// constraint list. Mirrors the specificity of the backend's own refusal in
+// validateConstraintEntries.
+//
+// Two directions, one rule and one error path, because they are the same
+// defect: the form would send a constraint list that says something different
+// from what the operator is looking at, and for a constraint list "different"
+// is WIDER, since an empty list is "no restriction on this dimension" at
+// enforcement.
+//
+//  1. STORED: the loaded value cannot survive the text encoding (flagged when
+//     the row rendered, see unrepresentableDimensions).
+//  2. TYPED: the box holds something, but parseConstraintList reduces it to
+//     nothing -- "," or " , " being the reachable case, since it takes only a
+//     stray comma. Without this the save would send an empty list and silently
+//     remove the fence.
+//
+// Both use parseConstraintList itself as the predicate, never a second
+// implementation of "parses to nothing" that could drift from it.
+//
+// A BLANK box is not an error: it means "no restriction on this dimension",
+// which is ordinary. Blank is measured after trimming, so a box holding only
+// spaces counts as blank -- it is indistinguishable from empty on screen, and
+// erroring on a field that looks empty would be unfixable from the UI.
 function unrepresentablePermissionErrors(): string[] {
   const permissionsList = document.getElementById('permissions-list');
   if (!permissionsList) return [];
 
   const errors: string[] = [];
   permissionsList.querySelectorAll('.permission-item').forEach((item, index) => {
-    const dimensions = item.getAttribute('data-unrepresentable');
-    if (!dimensions) return;
-    const label = item.getAttribute('data-permission-label') || 'unknown';
-    errors.push(`permission ${index} (${label}) has a stored "${dimensions}" constraint value this form cannot represent`);
+    const action = (item.querySelector('.perm-action') as HTMLSelectElement | null)?.value || '';
+    const resource = (item.querySelector('.perm-resource') as HTMLSelectElement | null)?.value || '';
+    const label = `permission ${index} (${action}:${resource})`;
+
+    const stored = (item.getAttribute('data-unrepresentable') || '').split(', ').filter(d => d);
+    if (stored.length > 0) {
+      errors.push(`${label} has a stored "${stored.join(', ')}" constraint value this form cannot represent`);
+    }
+
+    for (const dimension of LIST_CONSTRAINT_DIMENSIONS) {
+      // Already refused for this row on the stored value; do not say it twice.
+      if (stored.includes(dimension)) continue;
+      const raw = (item.querySelector(`.perm-${dimension}`) as HTMLInputElement | null)?.value ?? '';
+      if (raw.trim() !== '' && parseConstraintList(raw).length === 0) {
+        errors.push(`${label} has a "${dimension}" value with no usable entries`);
+      }
+    }
   });
   return errors;
 }
@@ -393,10 +433,20 @@ function collectPermissions(): Permission[] {
 
     if (accounts || providers || services || regions || maxAmount) {
       permission.constraints = {};
-      if (accounts) permission.constraints.accounts = parseConstraintList(accounts);
-      if (providers) permission.constraints.providers = parseConstraintList(providers);
-      if (services) permission.constraints.services = parseConstraintList(services);
-      if (regions) permission.constraints.regions = parseConstraintList(regions);
+      // Attach a dimension only when it yields at least one entry, so a box
+      // that LOOKS empty produces the same payload as one that IS empty. An
+      // input holding only whitespace would otherwise send [], which means
+      // the same thing at enforcement but makes the request depend on
+      // invisible characters. A box that parses to nothing while holding
+      // something visible never reaches here: saveGroup already refused it.
+      const accountsList = parseConstraintList(accounts || '');
+      const providersList = parseConstraintList(providers || '');
+      const servicesList = parseConstraintList(services || '');
+      const regionsList = parseConstraintList(regions || '');
+      if (accountsList.length > 0) permission.constraints.accounts = accountsList;
+      if (providersList.length > 0) permission.constraints.providers = providersList;
+      if (servicesList.length > 0) permission.constraints.services = servicesList;
+      if (regionsList.length > 0) permission.constraints.regions = regionsList;
       if (maxAmount) {
         const parsed = parseFloat(maxAmount);
         // Reject non-finite or negative values (feedback_nullable_not_zero).
@@ -407,6 +457,11 @@ function collectPermissions(): Permission[] {
         if (Number.isFinite(parsed) && parsed >= 0) {
           permission.constraints.max_amount = parsed;
         }
+      }
+      // Nothing survived: the permission carries no restriction, so send no
+      // constraints object rather than an empty one.
+      if (Object.keys(permission.constraints).length === 0) {
+        delete permission.constraints;
       }
     }
 

--- a/frontend/src/groups/groupModals.ts
+++ b/frontend/src/groups/groupModals.ts
@@ -86,6 +86,22 @@ export function closeGroupModal(): void {
 export async function saveGroup(e: Event): Promise<void> {
   e.preventDefault();
 
+  // Refuse rather than widen. A stored constraint value this form cannot
+  // carry unchanged is flagged when the row is rendered; saving anyway would
+  // re-submit a materially different permission set than the one loaded, and
+  // for a constraint list that means an unintended widening (an empty list is
+  // "no restriction" at enforcement). The group stays uneditable through the
+  // form until the value is repaired via the API or in the database.
+  const blocked = unrepresentablePermissionErrors();
+  if (blocked.length > 0) {
+    showError(
+      `Cannot save: ${blocked.join('; ')}. ` +
+      'Saving would silently drop the restriction, so the edit is refused. ' +
+      'Repair the value through the API or in the database, then reload this page.'
+    );
+    return;
+  }
+
   const name = (document.getElementById('group-name') as HTMLInputElement).value;
   const description = (document.getElementById('group-description') as HTMLTextAreaElement).value;
   const permissions = collectPermissions();
@@ -204,6 +220,17 @@ export function addPermission(permission?: Permission): void {
 
   const permDiv = document.createElement('div');
   permDiv.className = 'permission-item';
+
+  // Record the verdict, not the value: which of this row's constraint lists
+  // hold something the text encoding cannot carry back unchanged. saveGroup
+  // refuses while any row carries this. The attribute lives and dies with the
+  // row, so removing the row clears it and nothing outlives the modal.
+  const unsafe = unrepresentableDimensions(permission?.constraints);
+  if (unsafe.length > 0) {
+    permDiv.setAttribute('data-unrepresentable', unsafe.join(', '));
+    permDiv.setAttribute('data-permission-label', `${permission?.action ?? ''}:${permission?.resource ?? ''}`);
+  }
+
   permDiv.innerHTML = `
     <div class="form-row">
       <label>Action:
@@ -255,6 +282,69 @@ export function addPermission(permission?: Permission): void {
   }
 }
 
+// The one tokenizer for every comma-separated constraint input. Both the save
+// path and the render-time safety check below go through it, deliberately: if
+// this drops or alters a value, the check must catch it, and sharing the
+// function is what stops the two from drifting apart.
+function parseConstraintList(raw: string): string[] {
+  return raw.split(',').map(s => s.trim()).filter(s => s);
+}
+
+// Names the constraint lists in `constraints` that this form cannot carry
+// back unchanged (issue #1629, raised again by CodeRabbit on PR #1875).
+//
+// The form encodes a list as comma-separated text, and that encoding is not
+// injective. A stored [""] renders blank and re-parses as ABSENT; a stored
+// [","] re-parses as an empty list; a stored [" acct A "] comes back trimmed,
+// which is a different fence, since enforcement compares values exactly. In
+// every case the form would re-submit a materially different restriction than
+// the one it loaded, and for a constraint list "different" means WIDER: an
+// empty list is "no restriction on this dimension" at enforcement
+// (matchStringListConstraints). The refusal in saveGroup is the loud
+// alternative to that silent widening.
+//
+// The test is a round trip through parseConstraintList rather than a
+// hand-written blank check, for two reasons: it is the same predicate the
+// save path uses, so the two cannot disagree; and a per-entry "is it blank"
+// test would MISS [","], whose entry is not blank yet still vanishes, because
+// the split runs before the filter.
+//
+// An absent or empty list is NOT flagged. Both mean "no restriction on this
+// dimension", both are perfectly normal, and refusing them would make
+// ordinary unconstrained groups uneditable.
+function unrepresentableDimensions(constraints: Permission['constraints']): string[] {
+  if (!constraints) return [];
+
+  const unsafe: string[] = [];
+  for (const dimension of ['accounts', 'providers', 'services', 'regions'] as const) {
+    const values = constraints[dimension];
+    if (!values || values.length === 0) continue;
+    const reparsed = parseConstraintList(values.join(', '));
+    if (reparsed.length !== values.length || reparsed.some((value, i) => value !== values[i])) {
+      unsafe.push(dimension);
+    }
+  }
+  return unsafe;
+}
+
+// Builds one message per flagged row, naming the permission by index and by
+// action:resource and naming the constraint list, so an operator with a
+// multi-permission group knows exactly which value to repair. Mirrors the
+// specificity of the backend's own refusal in validateConstraintEntries.
+function unrepresentablePermissionErrors(): string[] {
+  const permissionsList = document.getElementById('permissions-list');
+  if (!permissionsList) return [];
+
+  const errors: string[] = [];
+  permissionsList.querySelectorAll('.permission-item').forEach((item, index) => {
+    const dimensions = item.getAttribute('data-unrepresentable');
+    if (!dimensions) return;
+    const label = item.getAttribute('data-permission-label') || 'unknown';
+    errors.push(`permission ${index} (${label}) has a stored "${dimensions}" constraint value this form cannot represent`);
+  });
+  return errors;
+}
+
 /**
  * Render permissions list
  */
@@ -303,10 +393,10 @@ function collectPermissions(): Permission[] {
 
     if (accounts || providers || services || regions || maxAmount) {
       permission.constraints = {};
-      if (accounts) permission.constraints.accounts = accounts.split(',').map(s => s.trim()).filter(s => s);
-      if (providers) permission.constraints.providers = providers.split(',').map(s => s.trim()).filter(s => s);
-      if (services) permission.constraints.services = services.split(',').map(s => s.trim()).filter(s => s);
-      if (regions) permission.constraints.regions = regions.split(',').map(s => s.trim()).filter(s => s);
+      if (accounts) permission.constraints.accounts = parseConstraintList(accounts);
+      if (providers) permission.constraints.providers = parseConstraintList(providers);
+      if (services) permission.constraints.services = parseConstraintList(services);
+      if (regions) permission.constraints.regions = parseConstraintList(regions);
       if (maxAmount) {
         const parsed = parseFloat(maxAmount);
         // Reject non-finite or negative values (feedback_nullable_not_zero).

--- a/frontend/src/groups/groupModals.ts
+++ b/frontend/src/groups/groupModals.ts
@@ -221,6 +221,11 @@ export function addPermission(permission?: Permission): void {
     <div class="constraints-section">
       <h4>Constraints (Optional)</h4>
       <div class="form-row">
+        <label>Cloud Account IDs (comma-separated):
+          <input type="text" class="perm-accounts" value="${escapeHtml(permission?.constraints?.accounts?.join(', ') || '')}" placeholder="2f1c8e40-...-uuid, unattributed">
+        </label>
+      </div>
+      <div class="form-row">
         <label>Providers (comma-separated):
           <input type="text" class="perm-providers" value="${escapeHtml(permission?.constraints?.providers?.join(', ') || '')}" placeholder="aws, azure, gcp">
         </label>
@@ -284,14 +289,21 @@ function collectPermissions(): Permission[] {
 
     const permission: Permission = { action, resource };
 
-    // Collect constraints
+    // Collect constraints. Dropping `accounts` here WIDENS the permission
+    // rather than merely losing data: an empty AccountIDs list means "no
+    // restriction on this dimension" at enforcement
+    // (matchStringListConstraints), so a permission scoped to one cloud
+    // account came back out of a cosmetic rename scoped to all of them
+    // (issue #1629).
+    const accounts = (item.querySelector('.perm-accounts') as HTMLInputElement)?.value;
     const providers = (item.querySelector('.perm-providers') as HTMLInputElement)?.value;
     const services = (item.querySelector('.perm-services') as HTMLInputElement)?.value;
     const regions = (item.querySelector('.perm-regions') as HTMLInputElement)?.value;
     const maxAmount = (item.querySelector('.perm-max-amount') as HTMLInputElement)?.value;
 
-    if (providers || services || regions || maxAmount) {
+    if (accounts || providers || services || regions || maxAmount) {
       permission.constraints = {};
+      if (accounts) permission.constraints.accounts = accounts.split(',').map(s => s.trim()).filter(s => s);
       if (providers) permission.constraints.providers = providers.split(',').map(s => s.trim()).filter(s => s);
       if (services) permission.constraints.services = services.split(',').map(s => s.trim()).filter(s => s);
       if (regions) permission.constraints.regions = regions.split(',').map(s => s.trim()).filter(s => s);

--- a/internal/auth/group_ceiling.go
+++ b/internal/auth/group_ceiling.go
@@ -122,6 +122,9 @@ func (s *Service) checkGrantCeiling(ctx context.Context, actorUserID string, req
 // deliberately NOT rejected: vocabulary validation is a separate concern
 // (#1629) and rejecting values this endpoint can legitimately already have
 // stored would break edits of existing groups.
+//
+// The values inside a permission's constraint lists get the same treatment;
+// see validateConstraintEntries.
 func validateRequestedPermissions(requested []Permission) error {
 	for i, p := range requested {
 		if strings.TrimSpace(p.Action) == "" {
@@ -133,6 +136,63 @@ func validateRequestedPermissions(requested []Permission) error {
 			return fmt.Errorf(
 				"%w: entry %d has a blank resource (action %q); a blank resource is malformed input, not a request for the %q wildcard",
 				ErrInvalidPermission, i, p.Action, ResourceAll)
+		}
+		if err := validateConstraintEntries(i, p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateConstraintEntries applies the same rule to the values inside a
+// permission's constraint lists, for the same reason.
+//
+// A blank entry and an absent one mean OPPOSITE things at enforcement:
+// matchStringListConstraints reads an empty list as "no restriction on this
+// dimension" (allow everything), while a list holding only "" matches
+// nothing (deny everything). The group-edit form's comma-joined text
+// encoding cannot tell the two apart -- [""] renders blank and re-parses as
+// absent -- so a permission fenced to nothing would come back out of a
+// cosmetic edit fenced to everything. Refusing blanks removes that case,
+// and closes it for API clients that never touch the form too.
+//
+// It does NOT make the encoding lossless in general, and should not be read
+// as claiming that: a stored value carrying leading or trailing spaces, or
+// one containing a comma, still re-parses into something different through
+// the form. Those values are accepted here deliberately -- see the blank
+// definition below -- so this refusal is narrower than "the form can always
+// round-trip what the API stored".
+//
+// Blank means empty after strings.TrimSpace, matching the action/resource
+// rule above. A value that merely CONTAINS whitespace is left alone:
+// enforcement compares these exactly (containsAny), so normalizing or
+// refusing them here would diverge from what the stored value does and
+// would break edits of data this endpoint already accepted.
+//
+// MaxPurchaseAmount has no blank form: zero already means "no cap" on both
+// sides of the comparison, so there is nothing here to disambiguate.
+func validateConstraintEntries(permIndex int, p Permission) error {
+	if p.Constraints == nil {
+		return nil
+	}
+	dimensions := []struct {
+		name   string
+		values []string
+	}{
+		// Named as the API serializes them (APIPermissionConstraint's JSON
+		// tags), so the refusal points at the field the client sent.
+		{"accounts", p.Constraints.AccountIDs},
+		{"providers", p.Constraints.Providers},
+		{"services", p.Constraints.Services},
+		{"regions", p.Constraints.Regions},
+	}
+	for _, dim := range dimensions {
+		for j, value := range dim.values {
+			if strings.TrimSpace(value) == "" {
+				return fmt.Errorf(
+					"%w: entry %d (%s:%s) has a blank %s constraint at position %d; a blank constraint value is malformed input, not an absent restriction",
+					ErrInvalidPermission, permIndex, p.Action, p.Resource, dim.name, j)
+			}
 		}
 	}
 	return nil

--- a/internal/auth/group_ceiling_validation_test.go
+++ b/internal/auth/group_ceiling_validation_test.go
@@ -8,6 +8,7 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -147,4 +148,156 @@ func TestGrantCeiling_RejectsBlankActionOrResource(t *testing.T) {
 
 		require.NoError(t, err, "an admin holding admin:* may grant view:*; only a BLANK resource is malformed")
 	})
+}
+
+// TestGrantCeiling_RejectsBlankConstraintEntries covers the constraint-list
+// half of the same rule (issue #1629).
+//
+// A blank entry and an absent one mean opposite things at enforcement --
+// matchStringListConstraints reads an empty list as "no restriction"
+// (allow everything) while a list holding only "" matches nothing (deny
+// everything) -- and the group-edit form's comma-joined text encoding
+// cannot represent the difference. The ceiling does not catch this either:
+// the admin:* branch of grantCeilingAllows covers any requested constraint
+// set, so before this guard a blank entry was written straight through.
+func TestGrantCeiling_RejectsBlankConstraintEntries(t *testing.T) {
+	ctx := context.Background()
+
+	blank := []struct {
+		name       string
+		dimension  string
+		constraint APIPermissionConstraint
+		position   int
+	}{
+		{"empty account id", "accounts", APIPermissionConstraint{Accounts: []string{""}}, 0},
+		{"whitespace account id beside a real one", "accounts", APIPermissionConstraint{Accounts: []string{"acct-1", "  "}}, 1},
+		{"empty provider", "providers", APIPermissionConstraint{Providers: []string{""}}, 0},
+		{"tab-only service", "services", APIPermissionConstraint{Services: []string{"\t"}}, 0},
+		{"empty region beside a real one", "regions", APIPermissionConstraint{Regions: []string{"us-east-1", ""}}, 1},
+	}
+
+	for _, tc := range blank {
+		perm := APIPermission{Action: ActionView, Resource: ResourcePlans, Constraints: &tc.constraint}
+
+		t.Run("update/"+tc.name, func(t *testing.T) {
+			mockStore := new(MockStore)
+			t.Cleanup(func() { mockStore.AssertExpectations(t) })
+			svc := newCeilingService(t, mockStore)
+
+			stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+			// Permissive downstream stubs, same reasoning as the blank
+			// action/resource test above: with them, removing the guard makes
+			// the write SUCCEED (admin:* covers any constraint set) and the
+			// assertions below catch it, rather than the test passing by
+			// accident on a missing-stub panic.
+			stubActorPermissionsMaybe(ctx, mockStore, adminOnly)
+			mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Maybe()
+
+			result, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID, updateReqWith(perm))
+
+			require.Error(t, err)
+			assert.Nil(t, result)
+			assert.ErrorIs(t, err, ErrInvalidPermission)
+			// The refusal names the offending entry, the dimension AND the
+			// position within it, so the client can find the value without
+			// guessing. Asserting the position matters because two of these
+			// cases put the blank at index 1: reporting the permission index
+			// where the value index belongs would otherwise go unnoticed.
+			assert.Contains(t, err.Error(), "entry 0")
+			assert.Contains(t, err.Error(), tc.dimension)
+			assert.Contains(t, err.Error(), fmt.Sprintf("at position %d", tc.position))
+			mockStore.AssertNotCalled(t, "UpdateGroup", mock.Anything, mock.Anything)
+		})
+
+		t.Run("create/"+tc.name, func(t *testing.T) {
+			mockStore := new(MockStore)
+			t.Cleanup(func() { mockStore.AssertExpectations(t) })
+			svc := newCeilingService(t, mockStore)
+
+			stubActorPermissionsMaybe(ctx, mockStore, adminOnly)
+			mockStore.On("CreateGroup", ctx, mock.AnythingOfType("*auth.Group")).Return(nil).Maybe()
+
+			_, err := svc.CreateGroupAPI(ctx, ceilingActorID, APICreateGroupRequest{
+				Name:        "Team",
+				Permissions: []APIPermission{perm},
+			})
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrInvalidPermission)
+			assert.Contains(t, err.Error(), tc.dimension)
+			mockStore.AssertNotCalled(t, "CreateGroup", mock.Anything, mock.Anything)
+		})
+	}
+
+	// Negative controls: the guard must not refuse the ordinary constrained
+	// permissions this endpoint exists to write.
+	accepted := []struct {
+		name       string
+		constraint APIPermissionConstraint
+		expect     PermissionConstraints
+	}{
+		{
+			"a populated multi-value list on every dimension",
+			APIPermissionConstraint{
+				Accounts:  []string{"acct-1", "acct-2"},
+				Providers: []string{"aws", "azure"},
+				Services:  []string{"ec2"},
+				Regions:   []string{"us-east-1", "us-west-2"},
+				MaxAmount: 5000,
+			},
+			PermissionConstraints{
+				AccountIDs:        []string{"acct-1", "acct-2"},
+				Providers:         []string{"aws", "azure"},
+				Services:          []string{"ec2"},
+				Regions:           []string{"us-east-1", "us-west-2"},
+				MaxPurchaseAmount: 5000,
+			},
+		},
+		{
+			// An EMPTY list is "no restriction on this dimension", a
+			// legitimate state, and must not be confused with a blank entry.
+			"an empty list is not a blank entry",
+			APIPermissionConstraint{Accounts: []string{}, Providers: []string{"aws"}},
+			PermissionConstraints{AccountIDs: []string{}, Providers: []string{"aws"}},
+		},
+		{
+			// Blank means empty-after-trimming, not "contains whitespace".
+			// Enforcement compares these exactly, so trimming or refusing
+			// them here would diverge from what the value actually does.
+			"a value containing spaces is not blank",
+			APIPermissionConstraint{Accounts: []string{" acct A "}},
+			PermissionConstraints{AccountIDs: []string{" acct A "}},
+		},
+	}
+
+	for _, tc := range accepted {
+		t.Run("accepted/"+tc.name, func(t *testing.T) {
+			mockStore := new(MockStore)
+			t.Cleanup(func() { mockStore.AssertExpectations(t) })
+			svc := newCeilingService(t, mockStore)
+
+			stubActorPermissions(ctx, mockStore, adminOnly)
+			stubTargetGroup(ctx, mockStore, &Group{ID: ceilingTargetID, Name: "Team"})
+
+			var saved *Group
+			mockStore.On("UpdateGroup", ctx, mock.AnythingOfType("*auth.Group")).
+				Run(func(args mock.Arguments) {
+					g, ok := args.Get(1).(*Group)
+					require.True(t, ok)
+					saved = g
+				}).Return(nil).Once()
+
+			constraint := tc.constraint
+			_, err := svc.UpdateGroupAPI(ctx, ceilingActorID, ceilingTargetID, updateReqWith(
+				APIPermission{Action: ActionView, Resource: ResourcePlans, Constraints: &constraint}))
+
+			require.NoError(t, err)
+			require.NotNil(t, saved)
+			require.Len(t, saved.Permissions, 1)
+			require.NotNil(t, saved.Permissions[0].Constraints)
+			// The constraint reaches the store unchanged: the guard refuses or
+			// passes through, it never normalizes.
+			assert.Equal(t, tc.expect, *saved.Permissions[0].Constraints)
+		})
+	}
 }


### PR DESCRIPTION
## The widening

`PermissionConstraints` (`internal/auth/types.go:52`) carries five dimensions: `AccountIDs`, `Providers`, `Services`, `Regions`, `MaxPurchaseAmount`. They round-trip through the API in full. **The group edit form rendered inputs for four.** There was no input for `accounts`, and `collectPermissions()` never read one back, so every save dropped it.

**That is a widening, not data loss.** `matchStringListConstraints` (`internal/auth/service_group.go:414`) returns true whenever *either* list is empty, so an empty `AccountIDs` means **no restriction on this dimension**. A permission stored as "manage any scheduled purchase, but only in `acct-prod-1`" came back out of a cosmetic rename as "manage any scheduled purchase, **in every cloud account**".

The backend grant ceiling does not catch it: `grantCeilingAllows` short-circuits on the caller's `admin:*`, whose own comment notes that `admin:*` carries no constraints and so covers any requested constraint set.

The same gap **fails closed in the other direction**, which this PR also fixes. A constrained carved-out money verb made its group *uneditable*: the form dropped the fence, `permissionCoveredBy` saw a request whose constraints no longer covered the stored ones, and `checkGrantCeiling` refused the whole write, including a pure rename.

### Fix 1 (`frontend/src/groups/groupModals.ts`, +14)

`addPermission()` renders a `.perm-accounts` input (escaped, like the other three list dimensions) and `collectPermissions()` reads it back, including it in the guard that decides whether to attach a `constraints` object at all. That last part matters for the narrowest form of the bug: when `accounts` was the *only* constraint, `if (providers || services || regions || maxAmount)` never fired and the permission round-tripped **fully unconstrained**.

Label and placeholder name cloud account **IDs**, not names: enforcement builds constraint sets as `AccountIDs: []string{accountID}` from `CloudAccountID` or the `unattributed` sentinel (`internal/api/handler_purchases.go:2229-2237`, `handler_ri_exchange.go:1804-1808`, sentinel at `handler.go:466`). An admin following a name-shaped placeholder would write a fence matching nothing.

## Fix 2: blank constraint entries refused at the boundary (`internal/auth/group_ceiling.go`, +60)

`validateRequestedPermissions` already refuses a blank action or resource, because a blank value is malformed input rather than a request for the wildcard. Constraint entries need the same rule for the same reason:

- an **empty list** means "no restriction" -> allow everything;
- a list holding only `""` is non-empty, so `containsAny` runs and matches nothing -> **deny everything**.

The comma-joined text encoding cannot represent the difference, and the ceiling does not catch it either. `validateConstraintEntries` now rejects any entry in `AccountIDs` / `Providers` / `Services` / `Regions` that is empty after `strings.TrimSpace`, for every client including the API. Closing it at the boundary is why no value-preservation machinery is needed in the UI.

The refusal is specific, not generic: it names the **permission index, the action:resource pair, the dimension** (by `APIPermissionConstraint` JSON tag, so it points at the field the client sent) **and the position** within that list, so an operator with a multi-permission group knows which row to repair. Maps to 400. `MaxPurchaseAmount` is untouched: zero already means "no cap" on both sides.

## Fix 3: the form refuses to save a value it cannot represent

Raised by CodeRabbit on this PR and taken rather than dismissed. Fixes 1 and 2 close the common case, but the comma-separated text encoding is **not injective**, so a stored value could still come back as a different restriction:

| stored | what the form would re-submit |
|---|---|
| `[""]` | **absent** -> deny-everything becomes allow-everything |
| `[","]` | `[]` -> same widening; the entry is not blank, so a per-entry blank check misses it |
| `[" acct A "]` | `["acct A"]` -> a different fence, since enforcement compares exactly |

The backend guard cannot catch any of these: the form filters the value out *before* the request is built, so `validateConstraintEntries` never receives a blank to reject. This PR would otherwise have claimed to close a silent widening while shipping one.

**The row now carries the verdict when it renders, and `saveGroup` refuses while any row carries it**, naming the permission by index and by `action:resource` and naming the constraint list, mirroring the backend refusal's specificity. The group stays uneditable through the form until the value is repaired via the API or in the database. A loud refusal beats a silent widening.

Deliberately *not* done: nothing remembers the loaded value in order to compare it later. The check is a pure function of the permission being rendered, and the only thing recorded is which dimensions are unsafe, on the row itself, so removing the row clears it. Nothing tries to round-trip an unrepresentable string.

Detection is a round trip through `parseConstraintList`, now the **single tokenizer shared with the save path**. Sharing it is the point: if the parser drops or alters a value the detector catches it, and the two cannot drift.

An absent or empty list is **not** flagged: both mean "no restriction on this dimension", both are normal, and refusing them would make ordinary unconstrained groups uneditable.

One consequence worth stating: the detector is broader than blank-only, so it also refuses a value that would merely be re-trimmed, such as `[" acct A "]`. That is legitimate stored data the backend accepts, and enforcement compares it exactly, so letting the form silently rewrite it to `"acct A"` would change the fence.

## What remains, and what does not

**Closed:** the silent widening through the form, in every form it took. A stored blank, a comma-only entry, or a whitespace-padded value now refuses the save instead of quietly dropping the restriction.

**Not closed, deliberately: the stored row itself is still malformed and needs repair.** Detection refuses the edit; it does not fix the data. A group holding such a value is uneditable through the form, and **unduplicatable** as well, since `saveDuplicateGroup` posts `permissions: source.permissions` verbatim and the copy hits the backend 400. The repair path is the API or SQL.

No repair migration ships here. Nothing in the repo produces this data (no seed sets permission constraints at all), so a migration written on speculation against rows we have no evidence exist, on an authorization table, is the wrong trade. Tracked conditionally in #1874, which carries a read-only detection query validated against Postgres 16 with a 9-row fixture. Zero rows means that issue can simply be closed.

## One user-visible behaviour change beyond the fix

A non-admin editor whose own permissions are account-constrained will now correctly get a **403** on edits that previously "succeeded" by silently dropping a fence beyond their own scope. That is `listCovers` working as designed, now that the fence actually reaches it.

## Tests

The regression tests **drive the real save path**: they build the `#group-form` markup from `index.html`, call `setupGroupHandlers()` to install the app's own submit listener, and save by **clicking the submit button**. `#group-form` carries no `novalidate` and `.perm-resource` is `required`, so calling `saveGroup(event)` directly (as the pre-existing tests in this file do) bypasses browser constraint validation and cannot tell whether a fix is on the path an admin actually uses. Confirmed by execution beforehand that jsdom 22.1.0 honours validation on that path.

One test exists purely to pin the harness: it clears the required name input, asserts `form.checkValidity() === false`, clicks Save, and asserts `api.updateGroup` was never called. Without it, a fix that never runs would pass everything else in the block.

**Fail-pre-fix, measured** (revert the source file, run, restore):

| | against `origin/main` | post-fix |
|---|---|---|
| frontend (`group-edit-unrepresentable-permissions.test.ts`) | 11 failed, 16 passed | 27 passed |
| backend (`group_ceiling_validation_test.go`) | 10 of 10 blank-entry subtests fail | 13 passed |

Of the 11 frontend failures, 5 are the refusal tests for fix 3, measured separately against the commit that has fix 1 but not fix 3.

Being precise about *why*, since they do not all fail the same way: the headline preserve test fails on the **payload** (jest diff shows `accounts` missing from what `api.updateGroup` received); five fail on the **missing DOM hook**, because you cannot type into an input that does not exist; five fail because the save was not refused. The remaining tests pass both ways by design and are named as such below.

Six tests pass both ways deliberately, and are guards rather than evidence: the harness pin, the four negative controls that a representable constraint still saves, and the one showing that removing an offending row unblocks the save (which pins that the verdict is row-scoped rather than sticky state).

Three assertions were mutation-checked rather than assumed:

- `clearing one fence removes only that one` clears row 0 and asserts row 1 **keeps** its fence. Clearing both rows (an earlier version) survived the "render the input but never read it back" mutation; the current form dies with the other four.
- The reported `position` is asserted, because two backend cases put the blank at index 1. Hardcoding the reported position to 0 kills exactly those two subtests.
- Flagging the container instead of the row (a plausible slip) kills all five refusal tests.

Backend refusal tests stub `UpdateGroup`/`CreateGroup` permissively (`.Maybe()`), so removing the guard makes the write **succeed** and the assertions catch it, rather than passing by accident on a missing-stub panic. Negative controls cover a populated multi-value list on all five dimensions, an empty list, and a value containing internal whitespace.

## Verification

`go build ./...`, `go test ./...` (33 packages, zero FAIL), `go vet`, `golangci-lint run ./...` at the CI pin **v2.10.1** (exit 0, "0 issues."), `gocyclo -over 10` clean. `tsc --noEmit`, `npm test` (90 suites, 2865 passed), `npm run lint` (0 errors), `npm run build`.

**Someone should eyeball the group edit modal in a browser.** All frontend verification here is jsdom. The new accounts input sits alone on its own `.form-row` above Providers/Services, which with `.form-row { display:flex }` and `label { flex:1 }` renders full-width. That is reasoned from the CSS, not seen. Also unverified: whether any deployment actually stores a populated `constraints.accounts` today. If none does, the frontend half is preventive rather than corrective; the widening is reachable either way, and the uneditable-group half bites regardless.

Closes #1629


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Group permission forms now support Cloud Account ID constraints.
  - Account-scoped permissions are preserved when edited, narrowed, cleared, or expanded.
  - Invalid, unrepresentable permission constraints are identified with specific error details.

- **Bug Fixes**
  - Prevented group permission edits from unintentionally widening account access.
  - Added validation to reject blank or whitespace-only constraint values.
  - Improved handling of account IDs with special characters while preserving their exact values.
  - Prevented saving until invalid permission constraints are corrected or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->