### PR TITLE
fix(frontend): move the topbar controls into the drawer below 768px

### DIFF
--- a/frontend/src/__tests__/mobile-nav.test.ts
+++ b/frontend/src/__tests__/mobile-nav.test.ts
@@ -5,21 +5,37 @@
  * aria-expanded toggle, focus management, body scroll-lock class.
  */
 
-import { setupMobileNav } from '../app';
+import { setupMobileNav, syncHeaderPlacement } from '../app';
 
 function buildDOM(): void {
   document.body.innerHTML = `
-    <button type="button" class="hamburger" id="hamburger-btn"
-      aria-label="Open navigation menu"
-      aria-controls="sidebar"
-      aria-expanded="false">
-    </button>
+    <header class="app-topbar">
+      <button type="button" class="hamburger" id="hamburger-btn"
+        aria-label="Open navigation menu"
+        aria-controls="sidebar"
+        aria-expanded="false">
+      </button>
+      <div class="app-topbar-brand"><h1>CUDly</h1></div>
+      <div id="topbar-filters" class="app-topbar-filters" aria-label="Global filters"></div>
+      <div id="user-info">
+        <span id="user-email-display"></span>
+        <span id="user-role-display" class="role-badge"></span>
+        <a href="/docs/" target="_blank" class="header-link">API Docs</a>
+        <a id="feedback-link" href="#" class="header-link feedback-link">Feedback</a>
+        <button id="logout-btn">Logout</button>
+      </div>
+    </header>
     <div class="sidebar-overlay" id="sidebar-overlay" aria-hidden="true"></div>
     <aside id="sidebar" aria-label="Primary navigation" aria-hidden="true">
       <a class="tab-btn" href="/home" data-tab="home">Home</a>
       <a class="tab-btn" href="/plans" data-tab="plans">Plans</a>
+      <div class="app-sidebar-extras" id="sidebar-extras"></div>
     </aside>
   `;
+}
+
+function hamburgerBtn(): HTMLButtonElement {
+  return document.getElementById('hamburger-btn') as HTMLButtonElement;
 }
 
 describe('setupMobileNav', () => {
@@ -149,5 +165,82 @@ describe('setupMobileNav', () => {
   test('no-op when sidebar element is missing from DOM', () => {
     document.getElementById('sidebar')!.remove();
     expect(() => setupMobileNav()).not.toThrow();
+  });
+});
+
+/**
+ * Placement of the topbar controls (issue #1779).
+ *
+ * These assert DOM parentage only. Whether the relocated controls are
+ * visible, on-screen and large enough to tap is a layout question jsdom
+ * cannot answer -- tests-e2e/mobile-header-drawer.spec.ts measures that in
+ * a real browser at a 390px viewport.
+ */
+describe('syncHeaderPlacement', () => {
+  beforeEach(buildDOM);
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  const projected = (): HTMLElement[] => [
+    document.getElementById('topbar-filters')!,
+    document.getElementById('user-info')!,
+  ];
+
+  function parentIds(): (string | undefined)[] {
+    return projected().map(el => el.parentElement?.id);
+  }
+
+  test('narrow moves the filters and the account actions into the drawer slot', () => {
+    syncHeaderPlacement(true);
+    expect(parentIds()).toEqual(['sidebar-extras', 'sidebar-extras']);
+  });
+
+  test('widening restores both to the topbar, in header order', () => {
+    syncHeaderPlacement(true);
+    syncHeaderPlacement(false);
+
+    const topbar = document.querySelector<HTMLElement>('.app-topbar')!;
+    expect(projected().every(el => el.parentElement === topbar)).toBe(true);
+    const ids = Array.from(topbar.children).map(el => el.id).filter(Boolean);
+    expect(ids.indexOf('topbar-filters')).toBeLessThan(ids.indexOf('user-info'));
+  });
+
+  test('repeated narrow calls do not re-append the same nodes', () => {
+    syncHeaderPlacement(true);
+    const marker = document.createElement('span');
+    projected()[0]!.appendChild(marker);
+    // A redundant appendChild would tear the subtree out and back in,
+    // dropping focus and closing any open chip popover.
+    syncHeaderPlacement(true);
+    expect(marker.isConnected).toBe(true);
+    expect(document.getElementById('sidebar-extras')!.children).toHaveLength(2);
+  });
+
+  test('no-op when the drawer slot is absent', () => {
+    const topbar = document.querySelector<HTMLElement>('.app-topbar')!;
+    document.getElementById('sidebar-extras')!.remove();
+    expect(() => syncHeaderPlacement(true)).not.toThrow();
+    expect(projected().every(el => el.parentElement === topbar)).toBe(true);
+  });
+
+  test('clicking an account action in the drawer closes it', () => {
+    setupMobileNav();
+    syncHeaderPlacement(true);
+    hamburgerBtn().click();
+    document.getElementById('logout-btn')!.dispatchEvent(
+      new MouseEvent('click', { button: 0, bubbles: true }),
+    );
+    expect(document.body.classList.contains('sidebar-open')).toBe(false);
+  });
+
+  test('using a filter chip in the drawer leaves it open', () => {
+    setupMobileNav();
+    syncHeaderPlacement(true);
+    hamburgerBtn().click();
+    const chip = document.createElement('button');
+    document.getElementById('topbar-filters')!.appendChild(chip);
+    chip.dispatchEvent(new MouseEvent('click', { button: 0, bubbles: true }));
+    expect(document.body.classList.contains('sidebar-open')).toBe(true);
   });
 });

--- a/frontend/src/__tests__/responsive.test.ts
+++ b/frontend/src/__tests__/responsive.test.ts
@@ -42,6 +42,18 @@ describe('responsive.css nav wrap rules', () => {
   });
 
   /**
+   * On the lazy `([\s\S]*?)\n}` capture used here and below: it does reach
+   * the end of the 768px block, despite looking like it would stop at the
+   * first nested rule. Every rule inside the block is indented, so the
+   * block's own closing brace is the only `}` at column zero and `\n}` can
+   * only anchor there. Measured against a brace-matched extraction: the true
+   * body is 5260 characters, the capture is 5259, the whole difference being
+   * the trailing newline the pattern consumes.
+   *
+   * This holds only while the stylesheet stays formatted that way. A nested
+   * rule closed at column zero would truncate the capture and these
+   * assertions would start passing or failing for the wrong reason.
+   *
    * Issue #10 wrapped #user-info at ≤768px to stop it overflowing the
    * header. That never worked: the topbar is a fixed --cudly-topbar-h box,
    * so the extra rows painted over the page content instead (issue #1779).

--- a/frontend/src/__tests__/responsive.test.ts
+++ b/frontend/src/__tests__/responsive.test.ts
@@ -41,10 +41,41 @@ describe('responsive.css nav wrap rules', () => {
     expect(tabsRule?.[0] ?? '').not.toMatch(/overflow-x/);
   });
 
-  it('wraps #user-info inside the ≤768px block so header children do not overflow', () => {
+  /**
+   * Issue #10 wrapped #user-info at ≤768px to stop it overflowing the
+   * header. That never worked: the topbar is a fixed --cudly-topbar-h box,
+   * so the extra rows painted over the page content instead (issue #1779).
+   * The regions are relocated into the drawer now, and the topbar copies
+   * are laid out away rather than left to paint behind the content.
+   *
+   * Source-text assertions only -- whether the relocated controls are
+   * actually visible and tappable is measured in a real browser by
+   * tests-e2e/mobile-header-drawer.spec.ts.
+   */
+  it('takes #user-info and #topbar-filters out of the topbar at ≤768px', () => {
     const match = css.match(/@media\s*\(max-width:\s*768px\)\s*{([\s\S]*?)\n}/);
     expect(match).not.toBeNull();
     const body = match?.[1] ?? '';
-    expect(body).toMatch(/#user-info\s*{[\s\S]*?flex-wrap:\s*wrap/);
+    expect(body).toMatch(
+      /\.app-topbar\s*>\s*#topbar-filters,\s*\.app-topbar\s*>\s*#user-info\s*{[\s\S]*?display:\s*none/,
+    );
+  });
+
+  it('styles both regions for the drawer slot at ≤768px', () => {
+    const match = css.match(/@media\s*\(max-width:\s*768px\)\s*{([\s\S]*?)\n}/);
+    expect(match).not.toBeNull();
+    const body = match?.[1] ?? '';
+    expect(body).toMatch(/\.app-sidebar-extras\s*{[\s\S]*?display:\s*flex/);
+    expect(body).toMatch(/\.app-sidebar-extras #topbar-filters/);
+    expect(body).toMatch(/\.app-sidebar-extras #user-info/);
+  });
+
+  it('does not stack the topbar into a column at ≤768px', () => {
+    const match = css.match(/@media\s*\(max-width:\s*768px\)\s*{([\s\S]*?)\n}/);
+    expect(match).not.toBeNull();
+    const body = match?.[1] ?? '';
+    // The `header { flex-direction: column }` rule was the overflow source.
+    expect(body).not.toMatch(/(^|\n)\s*header\s*{/);
+    expect(body).toMatch(/\.app-topbar\s*{[\s\S]*?justify-content:\s*flex-start/);
   });
 });

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -82,6 +82,25 @@ if (typeof globalThis.structuredClone === 'undefined') {
   }) as typeof structuredClone;
 }
 
+// jsdom evaluates no CSS media queries and so ships no window.matchMedia,
+// which setupMobileNav() calls to decide where the topbar controls live.
+// Stub it as never-matching: jsdom has no viewport width to honour, so the
+// desktop branch is the only honest default. The narrow branch is asserted
+// by calling syncHeaderPlacement directly, and measured for real in the
+// Playwright suite, which has actual layout.
+if (typeof window.matchMedia !== 'function') {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(() => false),
+  })) as unknown as typeof window.matchMedia;
+}
+
 // Mock alert and confirm
 global.alert = jest.fn();
 global.confirm = jest.fn(() => true);

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -699,13 +699,19 @@ export function syncHeaderPlacement(isNarrow: boolean): void {
  *
  * Open:  body.classList.add('sidebar-open')
  *        hamburger aria-expanded="true"
- *        sidebar aria-hidden="false"
+ *        sidebar aria-hidden="false", inert cleared
  *        Focus first focusable link in the sidebar
  *
  * Close: body.classList.remove('sidebar-open')
  *        hamburger aria-expanded="false"
- *        sidebar aria-hidden="true"
+ *        sidebar aria-hidden="true", inert set
  *        Return focus to the hamburger button
+ *
+ * A closed drawer needs both attributes and they always move together.
+ * aria-hidden takes it out of the accessibility tree; inert takes it out of
+ * sequential keyboard navigation, which neither aria-hidden nor the
+ * off-screen transform affects. With only the first, tabbing walks into
+ * controls that are invisible and expose no accessible name.
  *
  * Crossing the breakpoint in either direction is a third transition, neither
  * an open nor a close: see applyBreakpointState.
@@ -722,6 +728,9 @@ export function setupMobileNav(): void {
     document.body.classList.add('sidebar-open');
     hamburger!.setAttribute('aria-expanded', 'true');
     sidebar!.setAttribute('aria-hidden', 'false');
+    // Before the focus below, not after: focus into an inert subtree is
+    // dropped silently and the caret would land on <body>.
+    sidebar!.removeAttribute('inert');
     if (overlay) overlay.setAttribute('aria-hidden', 'false');
 
     // Focus the first focusable element in the sidebar
@@ -735,6 +744,7 @@ export function setupMobileNav(): void {
     document.body.classList.remove('sidebar-open');
     hamburger!.setAttribute('aria-expanded', 'false');
     sidebar!.setAttribute('aria-hidden', 'true');
+    sidebar!.setAttribute('inert', '');
     if (overlay) overlay.setAttribute('aria-hidden', 'true');
     hamburger!.focus();
   }
@@ -744,11 +754,11 @@ export function setupMobileNav(): void {
    * Runs on load and on every crossing, neither of which the user asked for,
    * so unlike openDrawer and closeDrawer it moves focus only to rescue it.
    *
-   * Whether the sidebar belongs in the accessibility tree is what the two
-   * widths disagree about. Above the breakpoint it is the permanently
-   * visible navigation and must stay in it; below, it is a drawer parked
-   * off-screen holding the controls syncHeaderPlacement moves into it, and
-   * everything in there has to leave the tree with it.
+   * Whether the sidebar is reachable at all is what the two widths disagree
+   * about. Above the breakpoint it is the permanently visible navigation and
+   * must stay both in the accessibility tree and in the tab order; below, it
+   * is a drawer parked off-screen holding the controls syncHeaderPlacement
+   * moves into it, and everything in there has to leave both with it.
    *
    * The narrow branch can never be hiding an open drawer: the only crossing
    * that reaches it comes from the desktop side, where nothing opens one.
@@ -762,13 +772,16 @@ export function setupMobileNav(): void {
 
     if (!isNarrow) {
       sidebar!.removeAttribute('aria-hidden');
+      sidebar!.removeAttribute('inert');
       return;
     }
     // Focus survives the crossing when it was already on a sidebar link, and
     // hiding the subtree under it strands the caret where no screen reader
-    // can follow.
+    // can follow. Chromium does not blur it for us when inert lands, so this
+    // has to run first.
     if (sidebar!.contains(document.activeElement)) hamburger!.focus();
     sidebar!.setAttribute('aria-hidden', 'true');
+    sidebar!.setAttribute('inert', '');
   }
 
   hamburger.addEventListener('click', () => {

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -707,8 +707,8 @@ export function syncHeaderPlacement(isNarrow: boolean): void {
  *        sidebar aria-hidden="true"
  *        Return focus to the hamburger button
  *
- * Widening past the breakpoint is a third transition, not a close: see
- * releaseDrawerForDesktop.
+ * Crossing the breakpoint in either direction is a third transition, neither
+ * an open nor a close: see applyBreakpointState.
  *
  * Sidebar links also close the drawer (they navigate within the SPA).
  */
@@ -740,20 +740,35 @@ export function setupMobileNav(): void {
   }
 
   /**
-   * Tear the drawer state down on the way past the breakpoint. Above it the
-   * sidebar is the permanently visible navigation, so this differs from
-   * closeDrawer in two ways: it leaves the sidebar in the accessibility tree
-   * rather than marking it aria-hidden, and it moves no focus, because the
-   * hamburger it would focus is display:none at this width.
+   * Put the drawer into the closed state the current breakpoint calls for.
+   * Runs on load and on every crossing, neither of which the user asked for,
+   * so unlike openDrawer and closeDrawer it moves focus only to rescue it.
    *
-   * Unconditional, so a drawer that was closed while narrow does not carry
-   * its aria-hidden across either.
+   * Whether the sidebar belongs in the accessibility tree is what the two
+   * widths disagree about. Above the breakpoint it is the permanently
+   * visible navigation and must stay in it; below, it is a drawer parked
+   * off-screen holding the controls syncHeaderPlacement moves into it, and
+   * everything in there has to leave the tree with it.
+   *
+   * The narrow branch can never be hiding an open drawer: the only crossing
+   * that reaches it comes from the desktop side, where nothing opens one.
    */
-  function releaseDrawerForDesktop(): void {
+  function applyBreakpointState(isNarrow: boolean): void {
+    // body.sidebar-open sets overflow:hidden outside the media query, so a
+    // drawer open across a resize would lock scrolling with no drawer left.
     document.body.classList.remove('sidebar-open');
     hamburger!.setAttribute('aria-expanded', 'false');
-    sidebar!.removeAttribute('aria-hidden');
     if (overlay) overlay.setAttribute('aria-hidden', 'true');
+
+    if (!isNarrow) {
+      sidebar!.removeAttribute('aria-hidden');
+      return;
+    }
+    // Focus survives the crossing when it was already on a sidebar link, and
+    // hiding the subtree under it strands the caret where no screen reader
+    // can follow.
+    if (sidebar!.contains(document.activeElement)) hamburger!.focus();
+    sidebar!.setAttribute('aria-hidden', 'true');
   }
 
   hamburger.addEventListener('click', () => {
@@ -782,11 +797,10 @@ export function setupMobileNav(): void {
   // the breakpoint. Listeners are bound once here, never per relocation.
   const mediaQuery = window.matchMedia(MOBILE_NAV_QUERY);
   syncHeaderPlacement(mediaQuery.matches);
+  applyBreakpointState(mediaQuery.matches);
   mediaQuery.addEventListener('change', event => {
     syncHeaderPlacement(event.matches);
-    // Without this the drawer's scroll lock stays on <body> with no visible
-    // drawer and no hamburger to dismiss it.
-    if (!event.matches) releaseDrawerForDesktop();
+    applyBreakpointState(event.matches);
   });
 
   // Account actions inside the drawer navigate or end the session, so they

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -654,6 +654,45 @@ async function handleFanOutExecute(buckets: FanOutBucket[]): Promise<void> {
 }
 
 /**
+ * Drawer breakpoint. Must stay in lockstep with the `max-width: 768px` block
+ * in styles/responsive.css, which lays these same regions out of the topbar.
+ */
+const MOBILE_NAV_QUERY = '(max-width: 768px)';
+
+/**
+ * Topbar regions with no room in the topbar below the breakpoint, listed in
+ * the order they appear in the header so restoring them re-appends correctly.
+ */
+const DRAWER_PROJECTED_IDS = ['topbar-filters', 'user-info'] as const;
+
+/**
+ * Move the global filter chips and the account actions between the topbar
+ * and the drawer (issue #1779). Relocation rather than duplication: the
+ * chips and the logout/profile handlers are bound to these exact nodes, and
+ * moving a node keeps its listeners and state.
+ *
+ * Idempotent, and a no-op when either endpoint is absent.
+ */
+export function syncHeaderPlacement(isNarrow: boolean): void {
+  const topbar = document.querySelector<HTMLElement>('.app-topbar');
+  const extras = document.getElementById('sidebar-extras');
+  if (!topbar || !extras) return;
+
+  const target = isNarrow ? extras : topbar;
+  const elements = DRAWER_PROJECTED_IDS
+    .map(id => document.getElementById(id))
+    .filter((el): el is HTMLElement => el !== null);
+
+  // Re-append all of them whenever any one is misplaced, so the restored
+  // header keeps DRAWER_PROJECTED_IDS order. Appending an element that is
+  // already in place would tear its subtree out and back in, dropping focus
+  // and closing an open chip popover, so the whole pass is skipped instead.
+  const misplaced = elements.some(el => el.parentElement !== target);
+  if (!misplaced) return;
+  for (const el of elements) target.appendChild(el);
+}
+
+/**
  * Wire the mobile navigation drawer (hamburger button + overlay + Escape).
  *
  * Activates below 768px (CSS hides the hamburger above that breakpoint).
@@ -717,6 +756,30 @@ export function setupMobileNav(): void {
       e.preventDefault();
       closeDrawer();
     }
+  });
+
+  // Projected topbar controls: place them for the current width, then follow
+  // the breakpoint. Listeners are bound once here, never per relocation.
+  const mediaQuery = window.matchMedia(MOBILE_NAV_QUERY);
+  syncHeaderPlacement(mediaQuery.matches);
+  mediaQuery.addEventListener('change', event => {
+    syncHeaderPlacement(event.matches);
+    // Widening past the breakpoint leaves the drawer's scroll lock on <body>
+    // with no visible drawer and no hamburger to dismiss it.
+    if (!event.matches && document.body.classList.contains('sidebar-open')) {
+      closeDrawer();
+    }
+  });
+
+  // Account actions inside the drawer navigate or end the session, so they
+  // close it. Delegated from the slot, which outlives every relocation; the
+  // filter chips are deliberately excluded so picking a filter keeps the
+  // drawer open for the next one.
+  const extras = document.getElementById('sidebar-extras');
+  extras?.addEventListener('click', (e: MouseEvent) => {
+    const target = e.target as HTMLElement | null;
+    if (!target?.closest('#user-info a, #user-info button')) return;
+    if (document.body.classList.contains('sidebar-open')) closeDrawer();
   });
 
   // Clicking any sidebar link closes the drawer (SPA navigation)

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -707,6 +707,9 @@ export function syncHeaderPlacement(isNarrow: boolean): void {
  *        sidebar aria-hidden="true"
  *        Return focus to the hamburger button
  *
+ * Widening past the breakpoint is a third transition, not a close: see
+ * releaseDrawerForDesktop.
+ *
  * Sidebar links also close the drawer (they navigate within the SPA).
  */
 export function setupMobileNav(): void {
@@ -734,6 +737,23 @@ export function setupMobileNav(): void {
     sidebar!.setAttribute('aria-hidden', 'true');
     if (overlay) overlay.setAttribute('aria-hidden', 'true');
     hamburger!.focus();
+  }
+
+  /**
+   * Tear the drawer state down on the way past the breakpoint. Above it the
+   * sidebar is the permanently visible navigation, so this differs from
+   * closeDrawer in two ways: it leaves the sidebar in the accessibility tree
+   * rather than marking it aria-hidden, and it moves no focus, because the
+   * hamburger it would focus is display:none at this width.
+   *
+   * Unconditional, so a drawer that was closed while narrow does not carry
+   * its aria-hidden across either.
+   */
+  function releaseDrawerForDesktop(): void {
+    document.body.classList.remove('sidebar-open');
+    hamburger!.setAttribute('aria-expanded', 'false');
+    sidebar!.removeAttribute('aria-hidden');
+    if (overlay) overlay.setAttribute('aria-hidden', 'true');
   }
 
   hamburger.addEventListener('click', () => {
@@ -764,11 +784,9 @@ export function setupMobileNav(): void {
   syncHeaderPlacement(mediaQuery.matches);
   mediaQuery.addEventListener('change', event => {
     syncHeaderPlacement(event.matches);
-    // Widening past the breakpoint leaves the drawer's scroll lock on <body>
-    // with no visible drawer and no hamburger to dismiss it.
-    if (!event.matches && document.body.classList.contains('sidebar-open')) {
-      closeDrawer();
-    }
+    // Without this the drawer's scroll lock stays on <body> with no visible
+    // drawer and no hamburger to dismiss it.
+    if (!event.matches) releaseDrawerForDesktop();
   });
 
   // Account actions inside the drawer navigate or end the session, so they

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -87,6 +87,13 @@
                         <span class="sidebar-label">Admin</span>
                     </a>
                 </nav>
+                <!-- Drawer slot for the topbar controls. Below the drawer
+                     breakpoint the topbar has no room for the filter chips
+                     and the account actions, so app.ts:setupMobileNav()
+                     relocates #topbar-filters and #user-info in here, and
+                     back out again above it (issue #1779). Empty on
+                     desktop. -->
+                <div class="app-sidebar-extras" id="sidebar-extras"></div>
             </aside>
             <main class="app-main" id="main-content">
             <!-- Home Tab. Provider/Account filters live in the topbar

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -165,6 +165,13 @@
     text-overflow: ellipsis;
 }
 
+/* Drawer slot for the relocated topbar controls (issue #1779). Empty and
+ * inert on desktop, where those controls stay in the topbar; the mobile
+ * rules live alongside the drawer block in responsive.css. */
+.app-sidebar-extras {
+    display: none;
+}
+
 .app-main {
     flex: 1;
     padding: var(--cudly-sp-5);

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -113,11 +113,6 @@ body.sidebar-open {
     overflow: hidden;
 }
 @media (max-width: 768px) {
-    header {
-        flex-direction: column;
-        gap: 1rem;
-    }
-
     .controls-bar {
         flex-direction: column;
     }
@@ -145,11 +140,6 @@ body.sidebar-open {
         white-space: nowrap;
     }
 
-    #user-info {
-        flex-wrap: wrap;
-        justify-content: center;
-    }
-
     .form-row {
         flex-direction: column;
     }
@@ -174,14 +164,27 @@ body.sidebar-open {
         grid-template-columns: 1fr 1fr;
     }
 
-    /* Topbar: show hamburger, wrap filter chips to prevent overflow */
     .hamburger {
         display: inline-flex;
     }
 
-    .app-topbar-filters {
-        flex-wrap: wrap;
-        row-gap: var(--cudly-sp-2);
+    /* Topbar: hamburger + brand only, on one row (issue #1779).
+     *
+     * The topbar is a fixed --cudly-topbar-h box. It used to also carry the
+     * filter chips and the account actions, stacked by a
+     * `header { flex-direction: column }` rule, so every row past the first
+     * overflowed past the gradient and painted its white text straight onto
+     * the page content below. Both regions move into the drawer instead
+     * (app.ts:syncHeaderPlacement); laying them out away here covers the
+     * moment before that script has run. */
+    .app-topbar {
+        justify-content: flex-start;
+        gap: var(--cudly-sp-2);
+    }
+
+    .app-topbar > #topbar-filters,
+    .app-topbar > #user-info {
+        display: none;
     }
 
     /* Sidebar: off-screen by default; slides in when .sidebar-open is on <body> */
@@ -222,6 +225,86 @@ body.sidebar-open {
 
     body.sidebar-open .app-sidebar {
         transform: translateX(0);
+    }
+
+    /* Drawer footer holding the relocated topbar controls (issue #1779).
+     * Pinned to the bottom of the rail so the filter chips open their
+     * popover upwards (chip-select flips when the trigger sits low in the
+     * viewport) instead of off the bottom edge. */
+    .app-sidebar-extras {
+        display: flex;
+        flex-direction: column;
+        gap: var(--cudly-sp-3);
+        margin-top: auto;
+        padding-top: var(--cudly-sp-3);
+        padding-bottom: max(var(--cudly-sp-3), env(safe-area-inset-bottom));
+        border-top: 1px solid var(--cudly-border);
+    }
+
+    .app-sidebar-extras #topbar-filters,
+    .app-sidebar-extras #user-info {
+        flex-direction: column;
+        align-items: stretch;
+        gap: var(--cudly-sp-2);
+        margin: 0;
+    }
+
+    /* Chips fill the rail and clip long account labels rather than
+     * overflowing it; the popover is capped to the rail width for the
+     * same reason. */
+    .app-sidebar-extras .chip-select {
+        width: 100%;
+        min-height: 44px;
+        justify-content: space-between;
+    }
+
+    .app-sidebar-extras .chip-select-value {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .app-sidebar-extras .chip-select-menu {
+        min-width: 0;
+        max-width: 100%;
+        width: 100%;
+    }
+
+    /* A long address has only the rail's width to sit in. */
+    .app-sidebar-extras #user-email-display {
+        overflow-wrap: anywhere;
+    }
+
+    /* The rules below re-colour #user-info, which is authored for the blue
+     * topbar gradient and so invisible on the drawer's light surface. */
+    .app-sidebar-extras .role-badge {
+        align-self: flex-start;
+        margin-left: 0;
+        background: var(--cudly-info-bg);
+        color: var(--cudly-primary);
+    }
+
+    /* Zero the topbar's horizontal padding so the links start on the same
+     * left edge as the chips and the email above them. */
+    .app-sidebar-extras .header-link,
+    .app-sidebar-extras #logout-btn {
+        display: flex;
+        align-items: center;
+        min-height: 44px;
+        padding-left: 0;
+        padding-right: 0;
+        color: var(--cudly-text);
+    }
+
+    .app-sidebar-extras #logout-btn,
+    .app-sidebar-extras #logout-btn:hover {
+        justify-content: center;
+        border-color: var(--cudly-border-strong);
+    }
+
+    .app-sidebar-extras .header-link:hover,
+    .app-sidebar-extras #logout-btn:hover {
+        background: var(--cudly-surface-muted);
     }
 }
 

--- a/frontend/tests-e2e/mobile-header-drawer.spec.ts
+++ b/frontend/tests-e2e/mobile-header-drawer.spec.ts
@@ -59,6 +59,33 @@ const DRAWER_CONTROLS: Record<string, string> = {
   'Account chip': '#sidebar button[aria-label="Account"]',
 };
 
+type AriaRole = Parameters<Page['getByRole']>[0];
+
+/**
+ * What a screen reader must not find while the drawer is closed and must
+ * find once it is open: the drawer itself, its navigation, and the account
+ * action this PR moved into it. Role queries match only nodes present in the
+ * accessibility tree, which is what an aria-hidden ancestor removes them
+ * from; the CSS locators elsewhere in this file cannot see that.
+ */
+const ACCESSIBLE_DRAWER_CONTENT: ReadonlyArray<readonly [AriaRole, string]> = [
+  ['complementary', 'Primary navigation'],
+  ['tablist', 'Main navigation'],
+  ['button', 'Logout'],
+];
+
+/** True when the caret sits in a subtree no screen reader will follow. */
+async function focusIsInsideHiddenSubtree(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    let node: Element | null = document.activeElement;
+    while (node) {
+      if (node.getAttribute('aria-hidden') === 'true') return true;
+      node = node.parentElement;
+    }
+    return false;
+  });
+}
+
 /** The subset that is tappable and so bound by the 44x44 minimum. */
 const TAPPABLE = [
   'API Docs link',
@@ -286,5 +313,81 @@ test.describe('phone viewport', () => {
     await page.setViewportSize(DESKTOP);
     await expect(page.locator('#sidebar')).not.toHaveAttribute('aria-hidden', 'true');
     await expect(page.getByRole('complementary', { name: 'Primary navigation' })).toHaveCount(1);
+  });
+
+  /**
+   * The mirror of the widening defect. A closed drawer is parked off-screen
+   * by a CSS transform, which hides it from sight but not from assistive
+   * technology, and this file moves the account controls into it. Without an
+   * aria-hidden a screen-reader user reaches Logout, the identity block and
+   * both filter chips inside a drawer that is closed.
+   */
+  test('a closed drawer is out of the accessibility tree on a narrow load', async ({ page }) => {
+    await openApp(page);
+
+    await expect(page.locator('#sidebar')).toHaveAttribute('aria-hidden', 'true');
+    for (const [role, name] of ACCESSIBLE_DRAWER_CONTENT) {
+      await expect(page.getByRole(role, { name }), `${name} is out of reach`).toHaveCount(0);
+    }
+
+    // Still reachable once it is actually open, rather than hidden for good.
+    await openDrawer(page);
+    for (const [role, name] of ACCESSIBLE_DRAWER_CONTENT) {
+      await expect(page.getByRole(role, { name }), `${name} is reachable`).toHaveCount(1);
+    }
+  });
+});
+
+test.describe('desktop viewport', () => {
+  test.use({ viewport: DESKTOP });
+
+  test('narrowing hides the drawer it moves the controls into', async ({ page }) => {
+    await openApp(page);
+    // Exposed on the desktop side, which is the whole point of the widening
+    // fix above, so the assertions below are a real transition.
+    await expect(page.getByRole('complementary', { name: 'Primary navigation' })).toHaveCount(1);
+
+    await page.setViewportSize(PHONE);
+    await expect(page.locator('#sidebar #user-info')).toHaveCount(1);
+
+    await expect(page.locator('#sidebar')).toHaveAttribute('aria-hidden', 'true');
+    for (const [role, name] of ACCESSIBLE_DRAWER_CONTENT) {
+      await expect(page.getByRole(role, { name }), `${name} is out of reach`).toHaveCount(0);
+    }
+  });
+
+  /**
+   * Focus on a sidebar link survives the crossing: the nav is not one of the
+   * relocated regions, so nothing detaches the focused node. Hiding the
+   * sidebar under it would leave the caret in a subtree screen readers no
+   * longer expose, so it has to be handed to the visible hamburger first.
+   */
+  test('narrowing moves focus off a sidebar link onto the hamburger', async ({ page }) => {
+    await openApp(page);
+    await page.locator('#sidebar .tab-btn').first().focus();
+    await expect(page.locator('#sidebar .tab-btn').first()).toBeFocused();
+
+    await page.setViewportSize(PHONE);
+    await expect(page.locator('#sidebar')).toHaveAttribute('aria-hidden', 'true');
+
+    await expect(page.locator('#hamburger-btn')).toBeFocused();
+    expect(await focusIsInsideHiddenSubtree(page), 'focus left inside aria-hidden').toBe(false);
+  });
+
+  /**
+   * The other way focus can be sitting on something the drawer swallows. The
+   * relocation itself detaches the node, so the browser has already blurred
+   * it by the time the drawer is hidden; the invariant that matters is the
+   * same either way.
+   */
+  test('narrowing does not strand focus on a relocated control', async ({ page }) => {
+    await openApp(page);
+    await page.locator('#logout-btn').focus();
+    await expect(page.locator('#logout-btn')).toBeFocused();
+
+    await page.setViewportSize(PHONE);
+    await expect(page.locator('#sidebar')).toHaveAttribute('aria-hidden', 'true');
+
+    expect(await focusIsInsideHiddenSubtree(page), 'focus left inside aria-hidden').toBe(false);
   });
 });

--- a/frontend/tests-e2e/mobile-header-drawer.spec.ts
+++ b/frontend/tests-e2e/mobile-header-drawer.spec.ts
@@ -1,0 +1,230 @@
+/**
+ * Mobile topbar / drawer layout at a phone viewport (issue #1779).
+ *
+ * The reported failure is that below the drawer breakpoint the CUDly logo,
+ * the signed-in email, the admin badge, API Docs, Feedback, Logout and the
+ * Provider / Account filter chips paint as faint text over the page content
+ * and cannot be used. The markup was always correct: the topbar is a fixed
+ * --cudly-topbar-h box, and a `header { flex-direction: column }` rule
+ * stacked those regions inside it, so every row past the first overflowed
+ * past the gradient and landed on the content below in white-on-white.
+ *
+ * That is invisible to jsdom, which resolves no stylesheets into layout: a
+ * jest assertion that "the header is hidden on mobile" passes whether or not
+ * anything was fixed. Every assertion below therefore measures what Chromium
+ * actually paints -- bounding boxes against the topbar and the viewport --
+ * rather than what the DOM contains.
+ */
+
+import { test, expect, type Page, type Locator } from '@playwright/test';
+import { mockApi, seedAuth } from './fixtures/recs';
+
+/* iPhone 12/13/14 logical width, the viewport quoted in the report. */
+const PHONE = { width: 390, height: 844 };
+
+/* Apple HIG / WCAG 2.5.8 minimum touch target, enforced repo-wide. */
+const MIN_TOUCH_PX = 44;
+
+interface Box {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  bottom: number;
+  right: number;
+}
+
+async function box(locator: Locator): Promise<Box> {
+  return locator.evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    return { x: r.x, y: r.y, width: r.width, height: r.height, bottom: r.bottom, right: r.right };
+  });
+}
+
+/**
+ * Every control the report names, keyed by the label used in assertion
+ * messages. Scoped to the sidebar so a stray desktop copy cannot satisfy
+ * them. The chips are matched on their aria-label, set by createChipSelect.
+ */
+const DRAWER_CONTROLS: Record<string, string> = {
+  'signed-in email': '#sidebar #user-email-display',
+  'admin badge': '#sidebar #user-role-display',
+  'API Docs link': '#sidebar #user-info a[href="/docs/"]',
+  'Feedback link': '#sidebar #feedback-link',
+  'Logout button': '#sidebar #logout-btn',
+  'Provider chip': '#sidebar button[aria-label="Provider"]',
+  'Account chip': '#sidebar button[aria-label="Account"]',
+};
+
+/** The subset that is tappable and so bound by the 44x44 minimum. */
+const TAPPABLE = [
+  'API Docs link',
+  'Feedback link',
+  'Logout button',
+  'Provider chip',
+  'Account chip',
+] as const;
+
+async function openApp(page: Page): Promise<void> {
+  await seedAuth(page);
+  await mockApi(page);
+  await page.goto('/home');
+  // The account chip is the last thing to mount (it awaits /accounts/list),
+  // so its presence means the topbar controls have finished rendering
+  // wherever they were placed.
+  await expect(page.locator('button[aria-label="Account"]')).toHaveCount(1);
+}
+
+async function openDrawer(page: Page): Promise<void> {
+  await page.locator('#hamburger-btn').click();
+  await expect(page.locator('#hamburger-btn')).toHaveAttribute('aria-expanded', 'true');
+  // Wait out the 0.25s slide-in so boxes are measured at rest, not mid-transform.
+  await expect
+    .poll(async () => (await box(page.locator('#sidebar'))).x, { timeout: 5_000 })
+    .toBeCloseTo(0, 1);
+}
+
+test.describe('phone viewport', () => {
+  test.use({ viewport: PHONE });
+
+  /**
+   * The defect itself. Anything still parented to the topbar must paint
+   * inside it; pre-fix the stacked rows spilled hundreds of pixels below
+   * the topbar's bottom edge and over the page content.
+   */
+  test('nothing in the topbar paints outside it', async ({ page }) => {
+    await openApp(page);
+
+    const topbar = await box(page.locator('.app-topbar'));
+    expect(topbar.height, 'topbar height').toBeGreaterThan(0);
+
+    const overflowing = await page.locator('.app-topbar').evaluate((header, limit) => {
+      const spills: { text: string; bottom: number }[] = [];
+      for (const el of Array.from(header.querySelectorAll('*'))) {
+        const r = el.getBoundingClientRect();
+        if (r.width === 0 && r.height === 0) continue;
+        if (r.bottom > limit + 1) {
+          spills.push({ text: (el.textContent ?? '').trim().slice(0, 40), bottom: r.bottom });
+        }
+      }
+      return spills;
+    }, topbar.bottom);
+
+    expect(overflowing, 'topbar descendants painting below the topbar').toEqual([]);
+
+    // Catches the other shape of the same regression: a topbar that grows to
+    // fit the extra rows rather than overflowing. Compared against the token
+    // the layout declares, not a number copied into this file.
+    const declaredHeight = await page.evaluate(() =>
+      parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue('--cudly-topbar-h'),
+      ),
+    );
+    expect(declaredHeight, '--cudly-topbar-h resolves').toBeGreaterThan(0);
+    expect(topbar.height, 'topbar stays one row tall').toBeCloseTo(declaredHeight, 0);
+  });
+
+  test('the drawer controls are off-screen until the drawer is opened', async ({ page }) => {
+    await openApp(page);
+
+    // Parked off the left edge by the sidebar transform, not merely painted
+    // behind the content where a stray tap could still reach them.
+    for (const [label, selector] of Object.entries(DRAWER_CONTROLS)) {
+      const { right } = await box(page.locator(selector));
+      expect(right, `${label} is off-screen while the drawer is closed`).toBeLessThanOrEqual(0);
+    }
+  });
+
+  test('every header control and both filter chips are reachable in the drawer', async ({ page }) => {
+    await openApp(page);
+    await openDrawer(page);
+
+    for (const [label, selector] of Object.entries(DRAWER_CONTROLS)) {
+      const locator = page.locator(selector);
+      await expect(locator, `${label} is in the drawer`).toHaveCount(1);
+      await expect(locator, `${label} is visible`).toBeVisible();
+
+      const b = await box(locator);
+      expect(b.x, `${label} left edge on-screen`).toBeGreaterThanOrEqual(0);
+      expect(b.right, `${label} right edge on-screen`).toBeLessThanOrEqual(PHONE.width);
+      expect(b.y, `${label} top edge on-screen`).toBeGreaterThanOrEqual(0);
+      expect(b.bottom, `${label} bottom edge on-screen`).toBeLessThanOrEqual(PHONE.height);
+    }
+  });
+
+  test('the admin badge reads admin for an administrator', async ({ page }) => {
+    await openApp(page);
+    await openDrawer(page);
+    await expect(page.locator('#sidebar #user-role-display')).toHaveText('admin');
+    await expect(page.locator('#sidebar #user-email-display')).toHaveText('smoke@example.com');
+  });
+
+  test('drawer controls meet the 44x44 touch minimum', async ({ page }) => {
+    await openApp(page);
+    await openDrawer(page);
+
+    for (const label of TAPPABLE) {
+      const b = await box(page.locator(DRAWER_CONTROLS[label]!));
+      expect(b.width, `${label} hit-target width`).toBeGreaterThanOrEqual(MIN_TOUCH_PX);
+      expect(b.height, `${label} hit-target height`).toBeGreaterThanOrEqual(MIN_TOUCH_PX);
+    }
+  });
+
+  /**
+   * Present and on-screen is not the same as usable: the chips have to open
+   * their popover inside the viewport and actually apply the filter.
+   */
+  test('the Provider chip filters from inside the drawer', async ({ page }) => {
+    await openApp(page);
+    await openDrawer(page);
+
+    const chip = page.locator('#sidebar button[aria-label="Provider"]');
+    await chip.click();
+
+    const menu = page.locator('#sidebar .chip-select-menu:not(.hidden)');
+    await expect(menu).toBeVisible();
+    const menuBox = await box(menu);
+    expect(menuBox.x, 'popover left edge on-screen').toBeGreaterThanOrEqual(0);
+    expect(menuBox.right, 'popover right edge on-screen').toBeLessThanOrEqual(PHONE.width);
+    expect(menuBox.bottom, 'popover bottom edge on-screen').toBeLessThanOrEqual(PHONE.height);
+
+    await menu.getByRole('option', { name: 'AWS', exact: true }).click();
+
+    await expect(chip).toContainText('AWS');
+    await expect.poll(() => new URL(page.url()).searchParams.get('provider')).toBe('aws');
+    // Picking a filter must not dismiss the drawer -- the next chip is
+    // right below it.
+    await expect(page.locator('#hamburger-btn')).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('an account action closes the drawer', async ({ page }) => {
+    await openApp(page);
+    await openDrawer(page);
+
+    await page.locator('#sidebar #feedback-link').click();
+    await expect(page.locator('#hamburger-btn')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  /**
+   * Widening past the breakpoint has to hand the controls back, or a
+   * desktop browser resized down and up again loses its header for good.
+   */
+  test('widening past the breakpoint returns the controls to the topbar', async ({ page }) => {
+    await openApp(page);
+    await expect(page.locator('#sidebar #user-info')).toHaveCount(1);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await expect(page.locator('.app-topbar > #user-info')).toHaveCount(1);
+    await expect(page.locator('.app-topbar > #topbar-filters')).toHaveCount(1);
+
+    for (const selector of ['#logout-btn', '#feedback-link', 'button[aria-label="Account"]']) {
+      await expect(page.locator(selector)).toBeVisible();
+    }
+
+    const topbar = await box(page.locator('.app-topbar'));
+    const userInfo = await box(page.locator('#user-info'));
+    expect(userInfo.bottom, 'user actions paint inside the topbar').toBeLessThanOrEqual(
+      topbar.bottom + 1,
+    );
+  });
+});

--- a/frontend/tests-e2e/mobile-header-drawer.spec.ts
+++ b/frontend/tests-e2e/mobile-header-drawer.spec.ts
@@ -22,6 +22,9 @@ import { mockApi, seedAuth } from './fixtures/recs';
 /* iPhone 12/13/14 logical width, the viewport quoted in the report. */
 const PHONE = { width: 390, height: 844 };
 
+/* Comfortably past the 768px drawer breakpoint. */
+const DESKTOP = { width: 1280, height: 900 };
+
 /* Apple HIG / WCAG 2.5.8 minimum touch target, enforced repo-wide. */
 const MIN_TOUCH_PX = 44;
 
@@ -213,7 +216,7 @@ test.describe('phone viewport', () => {
     await openApp(page);
     await expect(page.locator('#sidebar #user-info')).toHaveCount(1);
 
-    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.setViewportSize(DESKTOP);
     await expect(page.locator('.app-topbar > #user-info')).toHaveCount(1);
     await expect(page.locator('.app-topbar > #topbar-filters')).toHaveCount(1);
 
@@ -226,5 +229,62 @@ test.describe('phone viewport', () => {
     expect(userInfo.bottom, 'user actions paint inside the topbar').toBeLessThanOrEqual(
       topbar.bottom + 1,
     );
+  });
+
+  /**
+   * Widening while the drawer is open must not carry the drawer's closed
+   * state onto the desktop layout. Above the breakpoint #sidebar is the
+   * permanently visible navigation, so marking it aria-hidden removes the
+   * entire nav for screen-reader users while it is plainly on screen, and
+   * handing focus back to the hamburger strands the caret on a control CSS
+   * hides at this width.
+   */
+  test('widening with the drawer open leaves the desktop sidebar exposed', async ({ page }) => {
+    await openApp(page);
+    await openDrawer(page);
+
+    await page.setViewportSize(DESKTOP);
+    await expect(page.locator('.app-topbar > #user-info')).toHaveCount(1);
+
+    const sidebar = page.locator('#sidebar');
+    await expect(sidebar, 'desktop sidebar is painted').toBeVisible();
+    await expect(sidebar, 'desktop sidebar is not marked hidden').not.toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+    // Role queries match only nodes that reach the accessibility tree, so
+    // this fails however the aside came to be excluded from it.
+    await expect(
+      page.getByRole('complementary', { name: 'Primary navigation' }),
+      'desktop sidebar reaches the accessibility tree',
+    ).toHaveCount(1);
+
+    const active = await page.evaluate(() => {
+      const el = document.activeElement as HTMLElement | null;
+      return { id: el?.id ?? '', rendered: (el?.getClientRects().length ?? 0) > 0 };
+    });
+    expect(active.rendered, `focus rests on a rendered element (id "${active.id}")`).toBe(true);
+
+    await expect(page.locator('body'), 'scroll-lock class dropped').not.toHaveClass(
+      /sidebar-open/,
+    );
+    const overflow = await page.evaluate(() => getComputedStyle(document.body).overflow);
+    expect(overflow, 'body scroll released').not.toBe('hidden');
+  });
+
+  /**
+   * The same stale state is reachable without the drawer being open at the
+   * moment of the resize: closing it while narrow is what sets aria-hidden,
+   * and nothing cleared it on the way up.
+   */
+  test('a drawer closed while narrow does not carry aria-hidden to desktop', async ({ page }) => {
+    await openApp(page);
+    await openDrawer(page);
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#sidebar')).toHaveAttribute('aria-hidden', 'true');
+
+    await page.setViewportSize(DESKTOP);
+    await expect(page.locator('#sidebar')).not.toHaveAttribute('aria-hidden', 'true');
+    await expect(page.getByRole('complementary', { name: 'Primary navigation' })).toHaveCount(1);
   });
 });

--- a/frontend/tests-e2e/mobile-header-drawer.spec.ts
+++ b/frontend/tests-e2e/mobile-header-drawer.spec.ts
@@ -74,6 +74,29 @@ const ACCESSIBLE_DRAWER_CONTENT: ReadonlyArray<readonly [AriaRole, string]> = [
   ['button', 'Logout'],
 ];
 
+/**
+ * Presses Tab `presses` times and returns a label for every stop that landed
+ * inside the sidebar. Measured at this viewport with the drawer closed: the
+ * order returns to the skip link after 19 presses, so 25 walks a full cycle
+ * and a little more. An empty result therefore means the drawer is skipped,
+ * not merely further down the order than we looked.
+ */
+const TAB_CYCLE_PRESSES = 25;
+
+async function tabStopsInsideDrawer(page: Page): Promise<string[]> {
+  const stops: string[] = [];
+  for (let i = 0; i < TAB_CYCLE_PRESSES; i++) {
+    await page.keyboard.press('Tab');
+    const stop = await page.evaluate(() => {
+      const el = document.activeElement as HTMLElement | null;
+      if (!el || !document.getElementById('sidebar')?.contains(el)) return null;
+      return el.id || (el.textContent ?? '').trim().slice(0, 30) || el.tagName;
+    });
+    if (stop !== null) stops.push(stop);
+  }
+  return stops;
+}
+
 /** True when the caret sits in a subtree no screen reader will follow. */
 async function focusIsInsideHiddenSubtree(page: Page): Promise<boolean> {
   return page.evaluate(() => {
@@ -313,6 +336,13 @@ test.describe('phone viewport', () => {
     await page.setViewportSize(DESKTOP);
     await expect(page.locator('#sidebar')).not.toHaveAttribute('aria-hidden', 'true');
     await expect(page.getByRole('complementary', { name: 'Primary navigation' })).toHaveCount(1);
+
+    // Keyboard reach has to come back too, and this is the one path that
+    // carries a closed drawer's inert up to the desktop side. Focus into an
+    // inert subtree is dropped, so this lands on <body> if it survived.
+    const firstLink = page.locator('#sidebar .tab-btn').first();
+    await firstLink.focus();
+    await expect(firstLink, 'desktop sidebar is keyboard reachable').toBeFocused();
   });
 
   /**
@@ -335,6 +365,32 @@ test.describe('phone viewport', () => {
     for (const [role, name] of ACCESSIBLE_DRAWER_CONTENT) {
       await expect(page.getByRole(role, { name }), `${name} is reachable`).toHaveCount(1);
     }
+  });
+
+  /**
+   * aria-hidden governs the accessibility tree and nothing else. Neither it
+   * nor the off-screen transform takes the closed drawer's links and buttons
+   * out of sequential keyboard navigation, so without inert a keyboard user
+   * tabs into controls they cannot see, in a subtree that by then exposes no
+   * accessible name. That pairing is the WCAG failure, not just untidiness.
+   */
+  test('the closed drawer is out of the tab order', async ({ page }) => {
+    await openApp(page);
+
+    expect(await tabStopsInsideDrawer(page), 'tab stops inside the closed drawer').toEqual([]);
+
+    // Reachable once open, rather than locked away for good: one Tab from
+    // the hamburger is the first sidebar link.
+    await openDrawer(page);
+    await page.locator('#hamburger-btn').focus();
+    await page.keyboard.press('Tab');
+    await expect(page.locator('#sidebar .tab-btn').first()).toBeFocused();
+
+    // And closing it again puts the drawer back out of reach, which is the
+    // closeDrawer path rather than the breakpoint one.
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#hamburger-btn')).toHaveAttribute('aria-expanded', 'false');
+    expect(await tabStopsInsideDrawer(page), 'tab stops after closing').toEqual([]);
   });
 });
 


### PR DESCRIPTION
At a phone viewport the left nav collapses into a working hamburger drawer, but the topbar does not adapt. `.app-topbar` is a fixed `--cudly-topbar-h` (56px) box, and a `header { flex-direction: column }` rule inside the 768px media block stacked the brand, the Provider/Account filter chips and `#user-info` inside it. Every row past the first overflowed the box and painted its white foreground straight onto the light page content: the signed-in email, the `admin` badge, API Docs, Feedback, Logout and both filter chips read as faint ghost text over the dashboard, and none of them were reachable.

Measured pre-fix at 390x844: eleven topbar descendants painting below the topbar's 56px bottom edge, the lowest at `y=259.56`.

The `#user-info { flex-wrap: wrap }` rule added for issue #10 was a band-aid on this same defect. Wrapping cannot help a fixed-height container, which is why the jest test asserting it stayed green while the page was visibly broken.

## What changed

The two regions move into the **existing** sidebar drawer rather than gaining a second mechanism. `app.ts:syncHeaderPlacement` relocates the `#topbar-filters` and `#user-info` nodes themselves between the topbar and a new `#sidebar-extras` slot, driven by a `matchMedia` listener on the same 768px breakpoint the CSS uses. Moving the nodes rather than copies keeps every `ChipSelectHandle`, the logout binding and all filter state intact. The topbar copies are hidden by direct-child selectors so nothing paints behind content before the script runs.

Inside the drawer the chips fill the rail and truncate long account labels, the popover is capped to rail width, `#user-info` is re-coloured for the light surface, and every action meets the 44x44 touch minimum. That minimum is set unconditionally because the existing `pointer: coarse` block lists `button` but not the bare `<a>` that API Docs and Feedback use. Widening past the breakpoint hands the controls back to the topbar and drops the drawer's body scroll lock.

## How it was verified

jsdom resolves no stylesheets into layout, so jest is structurally incapable of catching a ghosting or overflow defect: `getBoundingClientRect` returns zeros and a "the header is hidden on mobile" assertion passes whether or not anything was fixed. The fix is therefore proven in a real browser.

New `frontend/tests-e2e/mobile-header-drawer.spec.ts`, 8 tests at 390x844 measuring real Chromium geometry. **Pre-fix, with sources reverted and rebuilt: 8/8 failed.** The primary test reported the ghosting as data (the eleven descendants above); the rest timed out waiting for `#sidebar #user-email-display`. **Post-fix: 8/8 passed.**

It asserts that nothing parented to the topbar paints outside it and that its height equals the `--cudly-topbar-h` token read at runtime; that the controls sit at `right <= 0` while the drawer is closed (rather than `toBeHidden`, which a translated element defeats); that all seven are visible and inside the viewport once it opens; that tappables are at least 44x44; that the Provider chip opens an on-screen popover, applies `?provider=aws` and leaves the drawer open; and that widening to 1280 restores the topbar. Also confirmed by eye on the built bundle at 390px.

Full suites: jest 2890 passed, playwright 44 passed, eslint 0 errors (125 pre-existing warnings), `tsc --noEmit` clean, `npm run build` clean.

## Notes for the reviewer

- The issue-#10 jest assertion on `flex-wrap: wrap` is **replaced**, not deleted: three tests now describe the relocation contract. They are source-text assertions only, and say so; whether the relocated controls are actually visible and tappable is measured by the E2E spec.
- A `window.matchMedia` stub was added to the jest setup. jsdom provides none, so every pre-existing `setupMobileNav` test would otherwise throw.
- `docs/ui-ux-review.md`, cited by the issue as the source of finding 2.1, **does not exist in the repo at any commit**, so sibling findings could not be checked. Scope was taken from the issue body alone.

## Deferred

The profile modal opened from the drawer leaves the drawer open behind it (it renders above at `z-index: 1000`, so it is usable), and the 769-900px icon-only sidebar band is untouched. Follow-ups for these and three smaller items (a dead `#user-email` CSS rule, `openDrawer` focusing a `display: none` toggle, the missing UX doc) are in the implementation report and will be filed as issues.

Closes #1779


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved mobile navigation by moving filters and account controls into the drawer on smaller screens.
  - Restored controls to the top bar when the viewport widens.
  - Added accessible drawer styling with touch-friendly controls, safe-area support, spacing, and improved scrolling.
  - Account actions close the drawer, while filter interactions keep it open.

- **Bug Fixes**
  - Improved control placement and ordering across responsive breakpoints.
  - Preserved interactive state, focus, and keyboard accessibility when controls move between the top bar and drawer.
  - Improved drawer behavior during viewport resizing, including scroll locking and accessibility state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->