### PR TITLE
fix(mcp): inject build version into cudly-mcp and document Codex CLI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,48 @@ jobs:
             echo "::warning::Coverage is below 80% (current: ${coverage}%)"
           fi
 
+  mcp-build:
+    name: Build MCP (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            binary_format: ELF
+          - os: macos-latest
+            binary_format: Mach-O
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Assert MCP artifact is absent
+        run: test ! -e bin/cudly-mcp
+
+      - name: Build MCP
+        run: make build-mcp VERSION=v0.0.0-version-test
+
+      - name: Assert host-native binary format
+        run: file bin/cudly-mcp | grep -F '${{ matrix.binary_format }}'
+
+      - name: Verify Make-built MCP version
+        env:
+          CUDLY_MCP_TEST_BINARY: ${{ github.workspace }}/bin/cudly-mcp
+        run: go test ./cmd/cudly-mcp -run '^TestBuiltBinaryReportsInjectedVersion$' -count=1
+
+      - name: Assert clean target includes MCP artifact
+        run: make -n clean | grep -Fx 'rm -f cudly bootstrap bin/cudly-server bin/cudly-mcp'
+
   # Integration tests with real PostgreSQL
   integration-tests:
     name: Integration Tests
@@ -1023,6 +1065,7 @@ jobs:
       - lint
       - workflow-lint
       - unit-tests
+      - mcp-build
       - integration-tests
       - docker-build
       - terraform-validate

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ build-lambda:
 # as build-server so a tagged release reports its version in the MCP
 # initialize response instead of "dev" (see cmd/cudly-mcp/main.go).
 build-mcp:
+	mkdir -p bin
 	CGO_ENABLED=0 go build $(LDFLAGS) -o bin/cudly-mcp ./cmd/cudly-mcp
 
 # Run unit tests
@@ -91,7 +92,7 @@ full-test: test-unit test-integration test-coverage
 
 # Clean build artifacts
 clean:
-	rm -f cudly bootstrap bin/cudly-server
+	rm -f cudly bootstrap bin/cudly-server bin/cudly-mcp
 	rm -f coverage.out coverage.html
 	rm -f gosec-report.json trivy-report.json tfsec-report.json
 	go clean

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean test deploy help all build-server build-lambda test-unit test-integration \
+.PHONY: build clean test deploy help all build-server build-lambda build-mcp test-unit test-integration \
         test-coverage full-test security-scan terraform-validate docker-build \
         fmt vet lint complexity complexity-report security-scan-go security-scan-docker \
         security-scan-terraform terraform-fmt terraform-fmt-check iac-arm docker-test pre-commit \
@@ -30,6 +30,7 @@ help: ## Display available targets
 	@echo "  build              - Build the CLI"
 	@echo "  build-server       - Build the unified server"
 	@echo "  build-lambda       - Build for AWS Lambda"
+	@echo "  build-mcp          - Build the MCP server (cmd/cudly-mcp)"
 	@echo "  test               - Run all unit tests"
 	@echo "  test-unit          - Run unit tests only"
 	@echo "  test-integration   - Run integration tests with testcontainers"
@@ -58,6 +59,12 @@ build-server:
 # Build for Lambda (backward compatible)
 build-lambda:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o bootstrap ./cmd/lambda
+
+# Build the MCP server (see mcp/README.md). Uses the same $(LDFLAGS)/$(VERSION)
+# as build-server so a tagged release reports its version in the MCP
+# initialize response instead of "dev" (see cmd/cudly-mcp/main.go).
+build-mcp:
+	CGO_ENABLED=0 go build $(LDFLAGS) -o bin/cudly-mcp ./cmd/cudly-mcp
 
 # Run unit tests
 test: test-unit

--- a/cmd/cudly-mcp/main.go
+++ b/cmd/cudly-mcp/main.go
@@ -20,13 +20,17 @@ import (
 	_ "github.com/LeanerCloud/CUDly/providers/gcp"
 )
 
-// version is overridable at build time via:
+// Version is overridable at build time via:
 //
-//	go build -ldflags "-X main.version=1.2.3" ./cmd/cudly-mcp
-var version = "dev"
+//	go build -ldflags "-X main.Version=1.2.3" ./cmd/cudly-mcp
+//
+// `make build-mcp` sets it from the same $(LDFLAGS)/$(VERSION) the other
+// binaries (build-server, ...) use, so a release build's tag flows through to
+// the MCP initialize response's Implementation.Version.
+var Version = "dev"
 
 func main() {
-	server, err := cudlymcp.NewServer(version)
+	server, err := cudlymcp.NewServer(Version)
 	if err != nil {
 		log.Fatalf("cudly-mcp: failed to build server: %v", err)
 	}

--- a/cmd/cudly-mcp/version_test.go
+++ b/cmd/cudly-mcp/version_test.go
@@ -26,7 +26,13 @@ import (
 )
 
 const (
-	buildTimeout = 2 * time.Minute
+	// buildTimeout must cover a genuinely cold build: the "Unit Tests" CI job
+	// runs this test with a fresh module/build cache for the non-race build
+	// flavor (the preceding `go test -race` step only warms the race-enabled
+	// cache), so this recompiles the full AWS/Azure/GCP SDK dependency tree
+	// from scratch on shared CI hardware. That measured over 2 minutes in CI
+	// (see PR #1891); 5 minutes leaves headroom without masking a real hang.
+	buildTimeout = 5 * time.Minute
 	runTimeout   = 15 * time.Second
 
 	// injectedTestVersion stands in for a release tag; any value distinct

--- a/cmd/cudly-mcp/version_test.go
+++ b/cmd/cudly-mcp/version_test.go
@@ -1,23 +1,12 @@
 package main
 
-// version_test.go is the regression guard for the version-injection mismatch
-// fixed alongside it: the Makefile's shared $(LDFLAGS) has always injected
-// -X main.Version=$(VERSION) (see build-server), but this package used to
-// declare a lowercase `version` var that ldflags cannot address by name, so
-// every release build silently reported "dev" in the MCP initialize
-// response's Implementation.Version. An in-process test against
-// cudlymcp.NewServer cannot catch this: it calls NewServer directly with a
-// Go string, bypassing the ldflags/linker step entirely. Only building the
-// real binary with -ldflags and inspecting what it reports over stdio proves
-// the wiring works end to end, the same way `make build-mcp` and a real
-// release tag do.
+// Linker injection is exercised only by building and running a subprocess.
 
 import (
 	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
@@ -26,82 +15,25 @@ import (
 )
 
 const (
-	// buildTimeout must cover a genuinely cold build: the "Unit Tests" CI job
-	// runs this test with a fresh module/build cache for the non-race build
-	// flavor (the preceding `go test -race` step only warms the race-enabled
-	// cache), so this recompiles the full AWS/Azure/GCP SDK dependency tree
-	// from scratch on shared CI hardware. That measured over 2 minutes in CI
-	// (see PR #1891); 5 minutes leaves headroom without masking a real hang.
-	buildTimeout = 5 * time.Minute
-	runTimeout   = 15 * time.Second
-
-	// injectedTestVersion stands in for a release tag; any value distinct
-	// from the "dev" zero value proves ldflags injection reached the binary.
+	buildTimeout        = 5 * time.Minute
+	runTimeout          = 15 * time.Second
 	injectedTestVersion = "v0.0.0-version-test"
 )
 
-var (
-	buildOnce   sync.Once
-	buildDir    string
-	builtBinary string
-	buildErr    error
-)
-
-// TestMain removes the compiled binary's directory once every test in this
-// package has run; the binary is built once (buildOnce) and shared across
-// tests, so its lifetime is the test binary's, not any single test's.
-func TestMain(m *testing.M) {
-	code := m.Run()
-	if buildDir != "" {
-		_ = os.RemoveAll(buildDir)
-	}
-	os.Exit(code)
-}
-
-// builtVersionedBinary compiles cmd/cudly-mcp once with -X main.Version set,
-// mirroring `make build-mcp`'s ldflags, and returns the path to the
-// executable.
-func builtVersionedBinary(t *testing.T) string {
-	t.Helper()
-	buildOnce.Do(func() {
-		if _, err := exec.LookPath("go"); err != nil {
-			buildErr = err
-			return
-		}
-		dir, err := os.MkdirTemp("", "cudly-mcp-version-test-")
-		if err != nil {
-			buildErr = err
-			return
-		}
-		buildDir = dir
-		binPath := filepath.Join(dir, "cudly-mcp")
-
+func TestBuiltBinaryReportsInjectedVersion(t *testing.T) {
+	binPath := os.Getenv("CUDLY_MCP_TEST_BINARY")
+	if binPath == "" {
+		binPath = filepath.Join(t.TempDir(), "cudly-mcp")
 		ctx, cancel := context.WithTimeout(context.Background(), buildTimeout)
 		defer cancel()
+
 		cmd := exec.CommandContext(ctx, "go", "build",
 			"-ldflags", "-X main.Version="+injectedTestVersion,
 			"-o", binPath, ".")
-		cmd.Dir = "." // this package's directory, cmd/cudly-mcp
-		if out, err := cmd.CombinedOutput(); err != nil {
-			buildErr = err
-			t.Logf("go build output:\n%s", out)
-			return
-		}
-		builtBinary = binPath
-	})
-	if buildErr != nil {
-		t.Fatalf("build cmd/cudly-mcp with version ldflags: %v", buildErr)
+		cmd.Dir = "."
+		out, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "build cmd/cudly-mcp with version ldflags:\n%s", out)
 	}
-	return builtBinary
-}
-
-// TestBuiltBinaryReportsInjectedVersion runs the actual compiled cudly-mcp
-// binary as a subprocess over stdio (the same transport every real MCP
-// client uses) and asserts the MCP initialize handshake's
-// InitializeResult.ServerInfo.Version echoes the ldflags-injected version,
-// not the "dev" fallback in cmd/cudly-mcp/main.go.
-func TestBuiltBinaryReportsInjectedVersion(t *testing.T) {
-	binPath := builtVersionedBinary(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), runTimeout)
 	defer cancel()
@@ -116,5 +48,5 @@ func TestBuiltBinaryReportsInjectedVersion(t *testing.T) {
 	require.NotNil(t, result, "InitializeResult")
 	require.NotNil(t, result.ServerInfo, "InitializeResult.ServerInfo")
 	require.Equal(t, injectedTestVersion, result.ServerInfo.Version,
-		"built binary must report the ldflags-injected version, not the main.Version=\"dev\" fallback")
+		"built binary must report the injected version")
 }

--- a/cmd/cudly-mcp/version_test.go
+++ b/cmd/cudly-mcp/version_test.go
@@ -1,0 +1,114 @@
+package main
+
+// version_test.go is the regression guard for the version-injection mismatch
+// fixed alongside it: the Makefile's shared $(LDFLAGS) has always injected
+// -X main.Version=$(VERSION) (see build-server), but this package used to
+// declare a lowercase `version` var that ldflags cannot address by name, so
+// every release build silently reported "dev" in the MCP initialize
+// response's Implementation.Version. An in-process test against
+// cudlymcp.NewServer cannot catch this: it calls NewServer directly with a
+// Go string, bypassing the ldflags/linker step entirely. Only building the
+// real binary with -ldflags and inspecting what it reports over stdio proves
+// the wiring works end to end, the same way `make build-mcp` and a real
+// release tag do.
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	gosdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	buildTimeout = 2 * time.Minute
+	runTimeout   = 15 * time.Second
+
+	// injectedTestVersion stands in for a release tag; any value distinct
+	// from the "dev" zero value proves ldflags injection reached the binary.
+	injectedTestVersion = "v0.0.0-version-test"
+)
+
+var (
+	buildOnce   sync.Once
+	buildDir    string
+	builtBinary string
+	buildErr    error
+)
+
+// TestMain removes the compiled binary's directory once every test in this
+// package has run; the binary is built once (buildOnce) and shared across
+// tests, so its lifetime is the test binary's, not any single test's.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if buildDir != "" {
+		_ = os.RemoveAll(buildDir)
+	}
+	os.Exit(code)
+}
+
+// builtVersionedBinary compiles cmd/cudly-mcp once with -X main.Version set,
+// mirroring `make build-mcp`'s ldflags, and returns the path to the
+// executable.
+func builtVersionedBinary(t *testing.T) string {
+	t.Helper()
+	buildOnce.Do(func() {
+		if _, err := exec.LookPath("go"); err != nil {
+			buildErr = err
+			return
+		}
+		dir, err := os.MkdirTemp("", "cudly-mcp-version-test-")
+		if err != nil {
+			buildErr = err
+			return
+		}
+		buildDir = dir
+		binPath := filepath.Join(dir, "cudly-mcp")
+
+		ctx, cancel := context.WithTimeout(context.Background(), buildTimeout)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "go", "build",
+			"-ldflags", "-X main.Version="+injectedTestVersion,
+			"-o", binPath, ".")
+		cmd.Dir = "." // this package's directory, cmd/cudly-mcp
+		if out, err := cmd.CombinedOutput(); err != nil {
+			buildErr = err
+			t.Logf("go build output:\n%s", out)
+			return
+		}
+		builtBinary = binPath
+	})
+	if buildErr != nil {
+		t.Fatalf("build cmd/cudly-mcp with version ldflags: %v", buildErr)
+	}
+	return builtBinary
+}
+
+// TestBuiltBinaryReportsInjectedVersion runs the actual compiled cudly-mcp
+// binary as a subprocess over stdio (the same transport every real MCP
+// client uses) and asserts the MCP initialize handshake's
+// InitializeResult.ServerInfo.Version echoes the ldflags-injected version,
+// not the "dev" fallback in cmd/cudly-mcp/main.go.
+func TestBuiltBinaryReportsInjectedVersion(t *testing.T) {
+	binPath := builtVersionedBinary(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), runTimeout)
+	defer cancel()
+
+	transport := &gosdk.CommandTransport{Command: exec.CommandContext(ctx, binPath)}
+	client := gosdk.NewClient(&gosdk.Implementation{Name: "version-test-client"}, nil)
+	session, err := client.Connect(ctx, transport, nil)
+	require.NoError(t, err, "connect to the built binary over stdio")
+	defer session.Close()
+
+	result := session.InitializeResult()
+	require.NotNil(t, result, "InitializeResult")
+	require.NotNil(t, result.ServerInfo, "InitializeResult.ServerInfo")
+	require.Equal(t, injectedTestVersion, result.ServerInfo.Version,
+		"built binary must report the ldflags-injected version, not the main.Version=\"dev\" fallback")
+}

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -84,6 +84,22 @@ Add an entry to your client's MCP server config. For Claude Code, this is `~/.cl
 
 `env` is optional -- omit it entirely to rely on whatever ambient credentials are already active in the shell that launches the client, or set only the provider(s) you actually use.
 
+## Use with OpenAI Codex CLI
+
+Codex CLI reads MCP server definitions from `~/.codex/config.toml` (or a project-scoped `.codex/config.toml`), under a `[mcp_servers.<name>]` table -- same `command`/`args`/`env` shape as Claude Code's `mcpServers` JSON, different file format:
+
+```toml
+[mcp_servers.cudly]
+command = "/absolute/path/to/cudly-mcp"
+args = []
+
+[mcp_servers.cudly.env]
+AWS_PROFILE = "my-aws-profile"
+AZURE_SUBSCRIPTION_ID = "00000000-0000-0000-0000-000000000000"
+```
+
+`CUDLY_MCP_ENABLE_REAL_PURCHASES` is deliberately omitted from this example -- leave it unset until you have exercised the dry-run path against this client and are ready to let it spend money; see [Safety model](#safety-model).
+
 ## Worked example
 
 A typical session searches for a recommendation, previews the purchase, then executes it:

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -86,7 +86,7 @@ Add an entry to your client's MCP server config. For Claude Code, this is `~/.cl
 
 ## Use with OpenAI Codex CLI
 
-Codex CLI reads MCP server definitions from `~/.codex/config.toml` (or a project-scoped `.codex/config.toml`), under a `[mcp_servers.<name>]` table -- same `command`/`args`/`env` shape as Claude Code's `mcpServers` JSON, different file format:
+Codex CLI reads MCP server definitions from `~/.codex/config.toml`, under a `[mcp_servers.<name>]` table -- same `command`/`args`/`env` shape as Claude Code's `mcpServers` JSON, different file format. A project-scoped `.codex/config.toml` works the same way, but only if you have marked that project directory as trusted in Codex CLI -- an untrusted project's `.codex/` layer is silently ignored, so if `cudly` doesn't show up, register it in `~/.codex/config.toml` instead (or trust the project).
 
 ```toml
 [mcp_servers.cudly]


### PR DESCRIPTION
## Summary

- Fix the `main.Version`/`version` ldflags mismatch so release builds report their injected version in the MCP `initialize` response instead of `dev`.
- Add `make build-mcp`, create its ignored output directory safely, and include its artifact in the existing clean target.
- Test the real MCP subprocess over stdio, including the exact Make-produced artifact.
- Gate host-native MCP builds on both macOS (Mach-O) and Linux (ELF), with both matrix legs required by `ci-success`. Windows is not supported.
- Document OpenAI Codex CLI registration and project trust behavior.

Part of #1890. The remaining registry, GoReleaser, and MCPB phases are handled by the sequenced follow-up PRs.

## Verification for `da420367a9bd0dadac3657115befff2c826ae9d9`

- [x] Three consecutive complete local verification passes on the same rebased head and tree.
- [x] macOS: host-native `make build-mcp VERSION=v0.0.0-version-test` produced Mach-O arm64; the exact binary completed the MCP initialize handshake and reported `v0.0.0-version-test`.
- [x] Linux: the digest-pinned Go 1.26.6 Bookworm image produced ELF arm64; the exact binary completed the same handshake and reported the same version.
- [x] `go build ./...` with Go 1.26.6 and `GOWORK=off`.
- [x] Race tests for `./cmd/cudly-mcp` and `./mcp/...`.
- [x] golangci-lint v2.10.1, actionlint, zizmor, `git diff --check`, clean-target dry run, and platform-scope scans.
- [x] Full rebased five-file diff independently reviewed with no actionables or nitpicks.
- [x] Exact-head GitHub Actions green: 28 checks, including required macOS and Linux build legs.
- [x] Substantive CodeRabbit review covers exact head with zero actionables; the sole historical inline thread is resolved and outdated.
