### PR TITLE
feat(mcp): add server.json for the MCP Registry + PR/tag validation CI

### DIFF
--- a/.github/scripts/server-json-validator/package-lock.json
+++ b/.github/scripts/server-json-validator/package-lock.json
@@ -1,0 +1,84 @@
+{
+  "name": "cudly-mcp-server-json-validator",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cudly-mcp-server-json-validator",
+      "dependencies": {
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/.github/scripts/server-json-validator/package.json
+++ b/.github/scripts/server-json-validator/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cudly-mcp-server-json-validator",
+  "private": true,
+  "dependencies": {
+    "ajv": "8.20.0",
+    "ajv-formats": "3.0.1"
+  }
+}

--- a/.github/scripts/server-json-validator/validate.cjs
+++ b/.github/scripts/server-json-validator/validate.cjs
@@ -1,0 +1,22 @@
+const fs = require("fs");
+const Ajv = require("ajv");
+const addFormats = require("ajv-formats");
+
+const [schemaPath, dataPath] = process.argv.slice(2);
+if (!schemaPath || !dataPath) {
+  console.error("usage: node .github/scripts/server-json-validator/validate.cjs <schema.json> <server.json>");
+  process.exit(2);
+}
+
+const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
+const data = JSON.parse(fs.readFileSync(dataPath, "utf8"));
+const ajv = new Ajv({ strict: false, allErrors: true });
+addFormats(ajv);
+
+const valid = ajv.validate(schema, data);
+if (!valid) {
+  console.error(JSON.stringify(ajv.errors, null, 2));
+  process.exit(1);
+}
+
+console.log(`${dataPath} valid`);

--- a/.github/workflows/mcp-server-json.yml
+++ b/.github/workflows/mcp-server-json.yml
@@ -1,10 +1,9 @@
 name: MCP server.json
 
-# Validates server.json (the MCP Registry listing manifest, see
-# docs/plans/mcp/05-store.md Phase B) on every PR that touches it, and gates
-# tag pushes on server.json's version matching the tag -- the registry
-# rejects republishing a version, so a mismatch here must fail loud rather
-# than let release.yml silently publish the wrong metadata.
+# Validates server.json (the MCP Registry listing manifest) on every PR that
+# touches it, and gates tag pushes on server.json's version matching the tag.
+# The registry rejects republishing a version, so a mismatch here must fail
+# loud rather than let release.yml silently publish the wrong metadata.
 
 on:
   pull_request:

--- a/.github/workflows/mcp-server-json.yml
+++ b/.github/workflows/mcp-server-json.yml
@@ -3,7 +3,7 @@ name: MCP server.json
 # Validates server.json (the MCP Registry listing manifest) on every PR that
 # touches it, and gates tag pushes on server.json's version matching the tag.
 # The registry rejects republishing a version, so a mismatch here must fail
-# loud rather than let release.yml silently publish the wrong metadata.
+# loud rather than let release automation publish the wrong metadata.
 
 on:
   pull_request:
@@ -44,7 +44,8 @@ jobs:
             echo "::error::server.json name must be $expected_registry_name"
             exit 1
           fi
-          curl -sSfL "$expected_schema_url" -o /tmp/server.schema.json
+          curl -sSfL --connect-timeout 10 --max-time 30 \
+            "$expected_schema_url" -o /tmp/server.schema.json
 
       - name: Install server.json validator dependencies
         working-directory: .github/scripts/server-json-validator
@@ -72,8 +73,8 @@ jobs:
           server_version=$(jq -r '.version' server.json)
           if [[ "$tag" != "$server_version" ]]; then
             echo "::error::server.json version ($server_version) does not match tag v$tag." \
-                 "Bump server.json's version (and, for the MCPB package entry," \
-                 "packages[].identifier and packages[].fileSha256) in the release PR before tagging -- this never rewrites the file for you."
+                 "Correct server.json.version in the release commit before creating or recreating the tag;" \
+                 "this workflow never rewrites the file."
             exit 1
           fi
           echo "server.json version ($server_version) matches tag v$tag"

--- a/.github/workflows/mcp-server-json.yml
+++ b/.github/workflows/mcp-server-json.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "server.json"
       - ".github/workflows/mcp-server-json.yml"
+      - ".github/scripts/server-json-validator/**"
   push:
     tags: ["v*"]
   workflow_dispatch:
@@ -40,8 +41,12 @@ jobs:
           fi
           curl -sSfL "$expected_schema_url" -o /tmp/server.schema.json
 
+      - name: Install server.json validator dependencies
+        working-directory: .github/scripts/server-json-validator
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
       - name: Validate server.json against the schema
-        run: npx --yes ajv-cli@5 validate -s /tmp/server.schema.json -d server.json --spec=draft7 --strict=false
+        run: node .github/scripts/server-json-validator/validate.cjs /tmp/server.schema.json server.json
 
   assert-version-matches-tag:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/mcp-server-json.yml
+++ b/.github/workflows/mcp-server-json.yml
@@ -34,9 +34,15 @@ jobs:
         run: |
           set -euo pipefail
           expected_schema_url="https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+          expected_registry_name="io.github.LeanerCloud/cudly-mcp"
           if ! jq -e --arg expected "$expected_schema_url" \
             '.["$schema"] | type == "string" and . == $expected' server.json >/dev/null; then
             echo "::error::server.json must declare the official MCP Registry \$schema URL"
+            exit 1
+          fi
+          if ! jq -e --arg expected "$expected_registry_name" \
+            '.name | type == "string" and . == $expected' server.json >/dev/null; then
+            echo "::error::server.json name must be $expected_registry_name"
             exit 1
           fi
           curl -sSfL "$expected_schema_url" -o /tmp/server.schema.json

--- a/.github/workflows/mcp-server-json.yml
+++ b/.github/workflows/mcp-server-json.yml
@@ -32,12 +32,13 @@ jobs:
       - name: Fetch the MCP Registry server.json schema
         run: |
           set -euo pipefail
-          schema_url=$(jq -r '.["$schema"]' server.json)
-          if [[ -z "$schema_url" || "$schema_url" == "null" ]]; then
-            echo "::error::server.json is missing a \$schema field"
+          expected_schema_url="https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+          if ! jq -e --arg expected "$expected_schema_url" \
+            '.["$schema"] | type == "string" and . == $expected' server.json >/dev/null; then
+            echo "::error::server.json must declare the official MCP Registry \$schema URL"
             exit 1
           fi
-          curl -sSfL "$schema_url" -o /tmp/server.schema.json
+          curl -sSfL "$expected_schema_url" -o /tmp/server.schema.json
 
       - name: Validate server.json against the schema
         run: npx --yes ajv-cli@5 validate -s /tmp/server.schema.json -d server.json --spec=draft7 --strict=false

--- a/.github/workflows/mcp-server-json.yml
+++ b/.github/workflows/mcp-server-json.yml
@@ -1,0 +1,68 @@
+name: MCP server.json
+
+# Validates server.json (the MCP Registry listing manifest, see
+# docs/plans/mcp/05-store.md Phase B) on every PR that touches it, and gates
+# tag pushes on server.json's version matching the tag -- the registry
+# rejects republishing a version, so a mismatch here must fail loud rather
+# than let release.yml silently publish the wrong metadata.
+
+on:
+  pull_request:
+    paths:
+      - "server.json"
+      - ".github/workflows/mcp-server-json.yml"
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-schema:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Fetch the MCP Registry server.json schema
+        run: |
+          set -euo pipefail
+          schema_url=$(jq -r '.["$schema"]' server.json)
+          if [[ -z "$schema_url" || "$schema_url" == "null" ]]; then
+            echo "::error::server.json is missing a \$schema field"
+            exit 1
+          fi
+          curl -sSfL "$schema_url" -o /tmp/server.schema.json
+
+      - name: Validate server.json against the schema
+        run: npx --yes ajv-cli@5 validate -s /tmp/server.schema.json -d server.json --spec=draft7 --strict=false
+
+  assert-version-matches-tag:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: validate-schema
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Assert server.json version matches the pushed tag
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF#refs/tags/v}"
+          server_version=$(jq -r '.version' server.json)
+          if [[ "$tag" != "$server_version" ]]; then
+            echo "::error::server.json version ($server_version) does not match tag v$tag." \
+                 "Bump server.json's version (and, for the MCPB package entry," \
+                 "packages[].identifier and packages[].fileSha256) in the release PR before tagging -- this never rewrites the file for you."
+            exit 1
+          fi
+          echo "server.json version ($server_version) matches tag v$tag"

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.leanercloud/cudly-mcp",
+  "name": "io.github.LeanerCloud/cudly-mcp",
   "description": "Search and buy AWS/Azure/GCP reserved capacity (RIs, Savings Plans, CUDs) via any MCP client.",
   "repository": {
     "url": "https://github.com/LeanerCloud/CUDly",

--- a/server.json
+++ b/server.json
@@ -23,13 +23,6 @@
           "isRequired": false,
           "isSecret": false,
           "format": "string"
-        },
-        {
-          "name": "CUDLY_MCP_AUDIT_LOG",
-          "description": "Overrides the JSONL audit log path for purchase attempts; set to an empty string to disable audit logging. See mcp/README.md for the current default path.",
-          "isRequired": false,
-          "isSecret": false,
-          "format": "filepath"
         }
       ]
     }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.leanercloud/cudly-mcp",
+  "description": "Search and buy AWS/Azure/GCP reserved capacity (RIs, Savings Plans, CUDs) via any MCP client.",
+  "repository": {
+    "url": "https://github.com/LeanerCloud/CUDly",
+    "source": "github"
+  },
+  "version": "0.1.0",
+  "websiteUrl": "https://cudly.io/mcp/",
+  "packages": [
+    {
+      "registryType": "mcpb",
+      "identifier": "https://github.com/LeanerCloud/CUDly/releases/download/v0.1.0/cudly-mcp-full.mcpb",
+      "fileSha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "CUDLY_MCP_ENABLE_REAL_PURCHASES",
+          "description": "Set to 1 (or true) to let purchase tools execute real, money-spending purchases. Unset (the default) refuses every dry_run=false call before any provider or credential is touched -- see mcp/README.md 'Safety model'.",
+          "isRequired": false,
+          "isSecret": false,
+          "format": "string"
+        },
+        {
+          "name": "CUDLY_MCP_AUDIT_LOG",
+          "description": "Overrides the JSONL audit log path for purchase attempts; set to an empty string to disable audit logging. See mcp/README.md for the current default path.",
+          "isRequired": false,
+          "isSecret": false,
+          "format": "filepath"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add the root `server.json` MCP Registry manifest under the canonical GitHub OIDC namespace `io.github.LeanerCloud/cudly-mcp`. It documents the MCP package and the real-purchase enablement variable. The checked-in package URL and zero digest remain source-template placeholders; #1893 owns artifact construction, hashing, runner-local manifest patching, and registry publication.
- Add `.github/workflows/mcp-server-json.yml` to require the exact pinned registry schema URL and canonical registry identity before network access, validate the manifest with AJV 8.20.0 plus `ajv-formats` 3.0.1, and require `server.json.version` to match a pushed `v*` tag.
- Keep validator dependencies in a private, committed lockfile-backed package. GitHub-hosted runners already provide Node; the workflow installs the pinned dependencies with `npm ci --ignore-scripts --no-audit --no-fund`.

Part of #1890. #1891 is merged, and this branch is rebased onto its merge commit. #1893 remains the follow-up for the macOS/Linux release binaries, MCPB bundle, release artifact verification, and publication workflow.

## Scope boundaries

- This PR validates the source manifest. It does not build, download, hash, or verify a published MCPB artifact.
- macOS and Linux remain equally supported application platforms. Linux is the deployment target and the CI runner used for this platform-neutral JSON check. Windows support is not in scope.

## Verification

- [x] Three independent staged reviews for each new atomic commit, with no actionables or nitpicks
- [x] Three consecutive post-rebase verification passes on exact head
- [x] Fresh `npm ci` from the committed lockfile and `npm audit --omit=dev`: zero vulnerabilities
- [x] Official pinned schema accepts the committed manifest
- [x] Malformed `websiteUrl` is rejected by URI format validation
- [x] Canonical registry identity passes; lowercase, missing, null, non-string, and wrong values fail
- [x] Matching tag version passes and a mismatched tag fails
- [x] `actionlint .github/workflows/mcp-server-json.yml`
- [x] `uvx zizmor .github/workflows/mcp-server-json.yml`: zero unsuppressed findings
- [x] `go build ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an MCP server manifest with repository and website details, release artifact metadata, transport settings, and an optional control for enabling real purchases.

- **Quality Improvements**
  - Added automated manifest validation for pull requests and manual checks.
  - Added safeguards to ensure release versions match pushed tags.
  - Validation provides clear errors and enforces schema and formatting requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->