### PR TITLE
feat(mcp): add GoReleaser + release workflow + MCPB bundle for cudly-mcp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,219 @@
+name: Release cudly-mcp
+
+# Triggered by pushing a v* tag (see mcp/README.md and
+# docs/plans/mcp/05-store.md Phase B4). This workflow is machinery only as
+# added: no tag has been created and nothing has been published by the PR
+# that introduces this file. The pipeline was instead verified locally --
+# `goreleaser release --snapshot --clean --skip=publish` for the build, and
+# `npx @anthropic-ai/mcpb pack mcpb` against locally staged placeholder
+# binaries for the bundle step -- see that PR's description for the exact
+# commands and output.
+#
+# Pipeline: consistency gate (server.json and mcpb/manifest.json versions
+# both match the tag -- fails loud, never silently rewrites either file) ->
+# test -> GoReleaser (raw darwin/linux, amd64/arm64 binaries, GitHub
+# Release) -> MCPB pack (full edition, all tools) uploaded as an extra
+# release asset -> mcp-publisher publish to the MCP Registry via GitHub
+# OIDC (no long-lived registry secret).
+#
+# The tag-version check here deliberately duplicates
+# .github/workflows/mcp-server-json.yml's own check rather than calling it
+# via workflow_call, so the two workflows stay independently triggerable,
+# reviewable, and mergeable (they land as separate PRs).
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+env:
+  MCPB_CLI_VERSION: "2.1.2" # @anthropic-ai/mcpb on npm; pinned, never @latest
+
+jobs:
+  consistency-gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Assert server.json and mcpb/manifest.json versions match the pushed tag
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF#refs/tags/v}"
+
+          server_version=$(jq -r '.version' server.json)
+          if [[ "$tag" != "$server_version" ]]; then
+            echo "::error::server.json version ($server_version) does not match tag v$tag." \
+                 "Bump server.json's version (and packages[].identifier/fileSha256 for the MCPB entry) in the release PR before tagging."
+            exit 1
+          fi
+
+          manifest_version=$(jq -r '.version' mcpb/manifest.json)
+          if [[ "$tag" != "$manifest_version" ]]; then
+            echo "::error::mcpb/manifest.json version ($manifest_version) does not match tag v$tag."
+            exit 1
+          fi
+
+          echo "server.json and mcpb/manifest.json both match tag v$tag"
+
+  test:
+    needs: consistency-gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          # This workflow only runs off a v* tag push, so its runtime cache
+          # would be a persistent, cross-run artifact reachable by anything
+          # that can push a tag -- disable it rather than risk poisoning a
+          # release build's module cache.
+          cache: false
+
+      - name: Test the MCP server
+        run: go test ./mcp/... ./cmd/cudly-mcp/...
+
+  goreleaser:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub Release and upload its binaries
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0 # GoReleaser needs full history/tags for its changelog and git-state checks
+          persist-credentials: false
+
+      - id: tag
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          # This workflow only runs off a v* tag push, so its runtime cache
+          # would be a persistent, cross-run artifact reachable by anything
+          # that can push a tag -- disable it rather than risk poisoning a
+          # release build's module cache.
+          cache: false
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  mcpb:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # upload the .mcpb bundle as an extra release asset
+    outputs:
+      sha256: ${{ steps.pack.outputs.sha256 }}
+      asset_url: ${{ steps.pack.outputs.asset_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download this release's GoReleaser binaries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.goreleaser.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/cudly-mcp-bin
+          # --repo omitted: gh infers it from this checkout's git remote.
+          gh release download "$RELEASE_TAG" \
+            --pattern 'cudly-mcp_*' --dir /tmp/cudly-mcp-bin
+
+      - name: Verify downloaded binaries against GoReleaser's own checksums
+        run: |
+          set -euo pipefail
+          cd /tmp/cudly-mcp-bin
+          sha256sum -c cudly-mcp_checksums.txt
+
+      - name: Stage per-platform binaries into the MCPB bundle layout
+        run: |
+          set -euo pipefail
+          for combo in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64; do
+            dir="mcpb/server/${combo/_/-}"
+            mkdir -p "$dir"
+            install -m 0755 "/tmp/cudly-mcp-bin/cudly-mcp_${combo}" "$dir/cudly-mcp"
+          done
+
+      - name: Pack the MCPB bundle (full edition -- all tools)
+        run: npx --yes "@anthropic-ai/mcpb@${MCPB_CLI_VERSION}" pack mcpb cudly-mcp-full.mcpb
+
+      - name: Upload the MCPB bundle to the GitHub Release
+        id: pack
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.goreleaser.outputs.tag }}
+          REPO_SLUG: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          sha=$(sha256sum cudly-mcp-full.mcpb | cut -d' ' -f1)
+          # --repo omitted: gh infers it from this checkout's git remote.
+          gh release upload "$RELEASE_TAG" cudly-mcp-full.mcpb --clobber
+          echo "sha256=$sha" >> "$GITHUB_OUTPUT"
+          echo "asset_url=https://github.com/${REPO_SLUG}/releases/download/${RELEASE_TAG}/cudly-mcp-full.mcpb" >> "$GITHUB_OUTPUT"
+
+  publish-registry:
+    needs: mcpb
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # GitHub OIDC auth to the MCP Registry -- no long-lived secret
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      # server.json in git carries a placeholder fileSha256/identifier (see
+      # its own comment history) until a real release exists to hash; patch
+      # in the values this run just produced before publishing. This never
+      # writes back to the repository -- only the ephemeral runner's checkout.
+      - name: Patch server.json with this release's MCPB asset
+        env:
+          MCPB_SHA256: ${{ needs.mcpb.outputs.sha256 }}
+          MCPB_ASSET_URL: ${{ needs.mcpb.outputs.asset_url }}
+        run: |
+          set -euo pipefail
+          jq --arg sha "$MCPB_SHA256" \
+             --arg url "$MCPB_ASSET_URL" \
+             '.packages[0].fileSha256 = $sha | .packages[0].identifier = $url' \
+             server.json > server.json.tmp
+          mv server.json.tmp server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Authenticate to the MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to the MCP Registry
+        run: ./mcp-publisher publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,18 @@ name: Release cudly-mcp
 # .github/workflows/mcp-server-json.yml's own check rather than calling it
 # via workflow_call, so the two workflows stay independently triggerable,
 # reviewable, and mergeable (they land as separate PRs).
+#
+# SECURITY: this is the first tag-triggered workflow in this repo, and its
+# publishing jobs (goreleaser, mcpb, publish-registry) hold `contents: write`
+# / `id-token: write`. They are bound to the `release` environment below, but
+# per #1660's finding (which this repeats for tags, not environments): an
+# `environment:` binding alone is NOT a reviewer gate until protection rules
+# are configured out-of-band, and GitHub auto-creates a referenced
+# environment bare (no reviewers) on first use. Nothing today also restricts
+# who can push a `v*` tag -- the repo has a branch ruleset
+# (protect-default-branch) but no tag ruleset. Tracked in #1896: configuring
+# required reviewers on `release` and adding a `v*` tag-protection ruleset
+# are both repo-admin actions outside what this workflow file can enforce.
 
 on:
   push:
@@ -89,6 +101,7 @@ jobs:
   goreleaser:
     needs: test
     runs-on: ubuntu-latest
+    environment: release # see the SECURITY note above and #1896
     permissions:
       contents: write # create the GitHub Release and upload its binaries
     outputs:
@@ -125,6 +138,7 @@ jobs:
   mcpb:
     needs: goreleaser
     runs-on: ubuntu-latest
+    environment: release # see the SECURITY note above and #1896
     permissions:
       contents: write # upload the .mcpb bundle as an extra release asset
     outputs:
@@ -162,8 +176,12 @@ jobs:
             install -m 0755 "/tmp/cudly-mcp-bin/cudly-mcp_${combo}" "$dir/cudly-mcp"
           done
 
+      # Packed under $RUNNER_TEMP, not the checkout root: this is a scratch
+      # release artifact, not source, and every step below in this same job
+      # can reach it by the same literal path (no cross-job propagation --
+      # $GITHUB_ENV isn't needed within a single job).
       - name: Pack the MCPB bundle (full edition -- all tools)
-        run: npx --yes "@anthropic-ai/mcpb@${MCPB_CLI_VERSION}" pack mcpb cudly-mcp-full.mcpb
+        run: npx --yes "@anthropic-ai/mcpb@${MCPB_CLI_VERSION}" pack mcpb "$RUNNER_TEMP/cudly-mcp-full.mcpb"
 
       - name: Upload the MCPB bundle to the GitHub Release
         id: pack
@@ -173,15 +191,17 @@ jobs:
           REPO_SLUG: ${{ github.repository }}
         run: |
           set -euo pipefail
-          sha=$(sha256sum cudly-mcp-full.mcpb | cut -d' ' -f1)
+          bundle="$RUNNER_TEMP/cudly-mcp-full.mcpb"
+          sha=$(sha256sum "$bundle" | cut -d' ' -f1)
           # --repo omitted: gh infers it from this checkout's git remote.
-          gh release upload "$RELEASE_TAG" cudly-mcp-full.mcpb --clobber
+          gh release upload "$RELEASE_TAG" "$bundle" --clobber
           echo "sha256=$sha" >> "$GITHUB_OUTPUT"
           echo "asset_url=https://github.com/${REPO_SLUG}/releases/download/${RELEASE_TAG}/cudly-mcp-full.mcpb" >> "$GITHUB_OUTPUT"
 
   publish-registry:
     needs: mcpb
     runs-on: ubuntu-latest
+    environment: release # see the SECURITY note above and #1896
     permissions:
       id-token: write # GitHub OIDC auth to the MCP Registry -- no long-lived secret
       contents: read
@@ -194,18 +214,23 @@ jobs:
       # server.json in git carries a placeholder fileSha256/identifier (see
       # its own comment history) until a real release exists to hash; patch
       # in the values this run just produced before publishing. This never
-      # writes back to the repository -- only the ephemeral runner's checkout.
+      # writes back to the repository -- only the ephemeral runner's checkout
+      # -- and the final `server.json` intentionally stays at the checkout
+      # root: mcp-publisher publish reads ./server.json from the working
+      # directory by default. Only the scratch intermediate file lives under
+      # $RUNNER_TEMP.
       - name: Patch server.json with this release's MCPB asset
         env:
           MCPB_SHA256: ${{ needs.mcpb.outputs.sha256 }}
           MCPB_ASSET_URL: ${{ needs.mcpb.outputs.asset_url }}
         run: |
           set -euo pipefail
+          patched="$RUNNER_TEMP/server.json.tmp"
           jq --arg sha "$MCPB_SHA256" \
              --arg url "$MCPB_ASSET_URL" \
              '.packages[0].fileSha256 = $sha | .packages[0].identifier = $url' \
-             server.json > server.json.tmp
-          mv server.json.tmp server.json
+             server.json > "$patched"
+          mv "$patched" server.json
 
       - name: Install mcp-publisher
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,14 @@ docs/generated/
 
 # Graphify knowledge graph output — regenerated locally, not committed
 graphify-out/
+
+# MCPB bundle staging: release.yml stages GoReleaser's per-platform
+# cudly-mcp binaries into mcpb/server/<os>-<arch>/ before packing (see
+# .github/workflows/release.yml). Only the two launch scripts are checked
+# in; the binaries are release artifacts, never source.
+mcpb/server/*/cudly-mcp
+mcpb/server/*/cudly-mcp.exe
+*.mcpb
+
+# GoReleaser's local output directory (see .goreleaser.yml)
+/dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,50 @@
+# GoReleaser config for cmd/cudly-mcp (see mcp/README.md and
+# docs/plans/mcp/05-store.md Phase B4). This repo hosts several independent
+# tools under one module; this config -- and the v* tag trigger in
+# .github/workflows/release.yml -- is scoped to cudly-mcp only. There is
+# nothing else in this repo's release surface yet.
+version: 2
+
+project_name: cudly-mcp
+
+builds:
+  - id: cudly-mcp
+    main: ./cmd/cudly-mcp
+    binary: cudly-mcp
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.Version={{ .Version }}
+
+# formats: ["binary"] skips compression and uploads the raw per-platform
+# executables directly to the GitHub Release -- release.yml's MCPB pack step
+# reads them straight out of dist/ (no download/extract round trip needed).
+archives:
+  - id: cudly-mcp
+    ids: [cudly-mcp]
+    formats: [binary]
+    name_template: "cudly-mcp_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "cudly-mcp_checksums.txt"
+  algorithm: sha256
+
+# Per-tag release notes: the default changelog would pull in every commit
+# since the last tag across this repo's unrelated tools, most of which have
+# nothing to do with cudly-mcp. Disabled rather than misleading.
+changelog:
+  disable: true
+
+release:
+  github:
+    owner: LeanerCloud
+    name: CUDly
+  # release.yml also uploads the MCPB bundle(s) as extra release assets
+  # after this step runs; GoReleaser only produces the raw binaries here.
+  mode: append

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,54 @@
+{
+  "manifest_version": "0.3",
+  "name": "cudly-mcp",
+  "version": "0.1.0",
+  "description": "Search and buy AWS/Azure/GCP reserved capacity (RIs, Savings Plans, CUDs) from Claude Desktop.",
+  "author": {
+    "name": "LeanerCloud",
+    "url": "https://cudly.io"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LeanerCloud/CUDly"
+  },
+  "license": "OSL-3.0",
+  "server": {
+    "type": "binary",
+    "entry_point": "server/linux-launch.sh",
+    "mcp_config": {
+      "command": "${__dirname}/server/linux-launch.sh",
+      "args": [],
+      "env": {
+        "CUDLY_MCP_ENABLE_REAL_PURCHASES": "${user_config.enable_real_purchases}"
+      },
+      "platform_overrides": {
+        "darwin": {
+          "command": "${__dirname}/server/darwin-launch.sh",
+          "args": [],
+          "env": {
+            "CUDLY_MCP_ENABLE_REAL_PURCHASES": "${user_config.enable_real_purchases}"
+          }
+        },
+        "linux": {
+          "command": "${__dirname}/server/linux-launch.sh",
+          "args": [],
+          "env": {
+            "CUDLY_MCP_ENABLE_REAL_PURCHASES": "${user_config.enable_real_purchases}"
+          }
+        }
+      }
+    }
+  },
+  "user_config": {
+    "enable_real_purchases": {
+      "type": "boolean",
+      "title": "Enable real purchases",
+      "description": "DANGER: turns on cudly-mcp's ability to execute REAL, money-spending cloud purchases (AWS Reserved Instances, Savings Plans, Azure Reservations, GCP CUDs) when a client explicitly requests dry_run=false and confirm=true. Leave this off until you have exercised the dry-run path and are ready to let it spend real money.",
+      "default": false,
+      "required": false
+    }
+  },
+  "privacy_policies": [
+    "https://cudly.io/privacy"
+  ]
+}

--- a/mcpb/server/darwin-launch.sh
+++ b/mcpb/server/darwin-launch.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Selects the right arch-specific cudly-mcp binary at launch. The MCPB
+# manifest format's platform_overrides differentiate by OS only (darwin,
+# linux, win32) -- there is no architecture-level template variable -- so
+# each OS gets one of these tiny wrapper scripts to bridge the gap between
+# a single bundled command and the amd64/arm64 binaries GoReleaser produces.
+set -eu
+
+dir=$(cd "$(dirname "$0")" && pwd)
+arch=$(uname -m)
+
+case "$arch" in
+  arm64) bin="$dir/darwin-arm64/cudly-mcp" ;;
+  x86_64) bin="$dir/darwin-amd64/cudly-mcp" ;;
+  *)
+    echo "cudly-mcp: unsupported macOS architecture: $arch" >&2
+    exit 1
+    ;;
+esac
+
+exec "$bin" "$@"

--- a/mcpb/server/linux-launch.sh
+++ b/mcpb/server/linux-launch.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Selects the right arch-specific cudly-mcp binary at launch. See
+# darwin-launch.sh for why this exists: MCPB's platform_overrides
+# differentiate by OS only, not architecture.
+set -eu
+
+dir=$(cd "$(dirname "$0")" && pwd)
+arch=$(uname -m)
+
+case "$arch" in
+  aarch64|arm64) bin="$dir/linux-arm64/cudly-mcp" ;;
+  x86_64) bin="$dir/linux-amd64/cudly-mcp" ;;
+  *)
+    echo "cudly-mcp: unsupported Linux architecture: $arch" >&2
+    exit 1
+    ;;
+esac
+
+exec "$bin" "$@"


### PR DESCRIPTION
## Summary
- `.goreleaser.yml`: builds static (`CGO_ENABLED=0`) `darwin`/`linux`, `amd64`/`arm64` binaries of `cmd/cudly-mcp` with the version ldflag, uploaded raw (`formats: [binary]`, no compression) so the MCPB pack step can consume them directly out of the GitHub Release.
- `.github/workflows/release.yml`, on a `v*` tag push: **consistency gate** (`server.json` and `mcpb/manifest.json` versions both match the tag -- fails loud, never silently rewrites either file) -> `go test ./mcp/... ./cmd/cudly-mcp/...` -> **GoReleaser** -> **MCPB pack** (full edition, all 11 tools) uploaded as an extra release asset -> **`mcp-publisher publish`** to the MCP Registry via GitHub OIDC (no long-lived registry secret). `actionlint` and `zizmor` are both clean (fixed two zizmor findings along the way -- see "MCPB/CI surprises" below).
- `mcpb/manifest.json`: the Claude Desktop extension manifest. `server.type: "binary"`, a `user_config.enable_real_purchases` boolean (default `false`, deliberately scary description) mapped to `CUDLY_MCP_ENABLE_REAL_PURCHASES` via `${user_config...}`, and a **placeholder** `privacy_policies: ["https://cudly.io/privacy"]` entry -- **that page does not exist yet and must exist before any directory submission**; this bundle is self-distributed via GitHub Releases only, no directory submission is part of this PR or planned by it.
- `mcpb/server/{darwin,linux}-launch.sh`: MCPB's `platform_overrides` differentiate by OS only, not CPU architecture (confirmed against the spec -- see below), so each OS gets a tiny wrapper that picks the right `amd64`/`arm64` binary via `uname -m` at launch. The binaries themselves are staged into `mcpb/server/<os>-<arch>/` by `release.yml`, never committed (new `.gitignore` entries).
- **Full edition only** (all 13 tools, once the sibling annotations/audit-log PRs land) -- a read-only "directory edition" MCPB (search/catalog only) is a documented follow-up, not part of this PR.

## Cross-PR dependencies (why this branch alone won't run yet)
This branch was cut from the same `origin/main` commit as two sibling store-readiness PRs, so `release.yml` references two files/symbols that don't exist on `main` until those merge:
- `server.json` (added by #1892) -- `release.yml`'s consistency gate reads it.
- The exported `Version` symbol in `cmd/cudly-mcp/main.go` that `.goreleaser.yml`'s ldflag targets (renamed by #1891, from lowercase `version`).

I verified the actual mechanism works by temporarily cherry-picking #1891's commit into this worktree, confirming the ldflag injection end-to-end (see Test plan), then reverting the cherry-pick before committing here -- this branch's diff is clean of that PR's changes. Since real tags are only ever cut from `main` (after all three PRs have merged), this is a merge-order dependency, not a bug in this PR.

Part of #1890 (store/distribution readiness) -- closes it once merged alongside #1891 and #1892.

## MCPB / registry surprises worth flagging
- `platform_overrides` nests **inside** `mcp_config`, not as a sibling key of it under `server` -- my first draft got this wrong and `mcpb validate` caught it immediately.
- No architecture-level `platform_overrides` or template variable exists (confirmed against `modelcontextprotocol/mcpb`'s `MANIFEST.md`) -- solved with the per-OS launcher scripts above rather than shipping 4 separate `.mcpb` files.
- `zizmor` flagged `actions/setup-go`'s default-on caching as a cache-poisoning risk on a tag-triggered (artifact-publishing) workflow -- fixed with explicit `cache: false` on both uses. It also flagged `${{ needs.*.outputs.* }}` interpolated directly into `run:` blocks as (low-confidence) template injection -- routed through `env:` everywhere, and dropped `--repo` from `gh release` calls entirely (it infers the repo from the checkout's git remote) rather than interpolating `github.repository`.
- `server.json`'s `packages[0].fileSha256`/`identifier` are placeholders in git (64 zeros, a `v0.1.0` URL) until a real release exists to hash -- `release.yml`'s `publish-registry` job patches both in the ephemeral runner's checkout right before calling `mcp-publisher publish`, never committing back.

## Test plan
- [x] `goreleaser check` -- config valid
- [x] `goreleaser release --snapshot --clean --skip=publish` -- builds all 4 binaries successfully
- [x] `npx @anthropic-ai/mcpb validate mcpb/manifest.json` -- passes
- [x] `npx @anthropic-ai/mcpb pack mcpb` against the real (non-snapshot) GoReleaser output -- produces a valid bundle; verified `sha256sum -c` against GoReleaser's own checksums file first
- [x] Unpacked the packed bundle and launched `server/darwin-launch.sh` through a real MCP client (`gosdk.CommandTransport`): reports the injected version and lists all 11 tools correctly
- [x] `actionlint .github/workflows/release.yml` -- clean
- [x] `uvx zizmor .github/workflows/release.yml` -- 0 findings (default persona); only informational/low findings under `--persona pedantic` (job naming, concurrency groups), consistent with this repo's existing workflow style
- [x] `go build ./...` unaffected (no Go source changes in this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added downloadable MCPB packages for macOS and Linux.
  - Added support for Apple Silicon, Intel, and ARM64 systems.
  - Added configuration for enabling real purchases through the MCP server.
  - Added package metadata, launch configuration, and privacy policy information.
  - Added SHA-256 checksums for downloaded binaries.

- **Release Improvements**
  - Releases can now automatically build, package, and publish platform-specific binaries and MCP Registry metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->