### PR TITLE
fix(frontend): re-price purchase modal rows and stop submitting skipped fan-out buckets

### DIFF
--- a/frontend/src/__tests__/purchase-execution-toast.test.ts
+++ b/frontend/src/__tests__/purchase-execution-toast.test.ts
@@ -804,7 +804,7 @@ describe('handleFanOutExecute — fan-out path', () => {
 describe('handleExecutePurchase — double-submit guard (#644)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (recs.getFanOutBuckets as jest.Mock).mockReturnValue([]);
+    (recs.getFanOutBuckets as jest.Mock).mockReturnValue(null);
     (recs.getPurchaseModalRecommendations as jest.Mock).mockReturnValue([buildMinimalRec()]);
     (plans.closePurchaseModal as jest.Mock).mockImplementation(() => undefined);
   });

--- a/frontend/src/__tests__/purchase-modal-submit.test.ts
+++ b/frontend/src/__tests__/purchase-modal-submit.test.ts
@@ -556,4 +556,48 @@ describe('Issue #1904: fan-out modal skips incompatible buckets', () => {
 
     expect(api.executePurchase).not.toHaveBeenCalled();
   });
+  // Regression for the double-scale CodeRabbit found on #2071. loadedCellVariants
+  // pushes `rec` itself when the loaded list no longer holds its id, and rec is
+  // already scaled, so re-scaling halved count and cost a second time. Uses a
+  // count of 4 deliberately: at count 2 the second scale floors to zero units
+  // and pricedCellVariant returns null, so the row is left alone and the test
+  // would pass with or without the guard.
+  test('T11 the fallback row is not re-scaled when the loaded list is replaced during open', async () => {
+    const rec: LocalRecommendation = {
+      id: 'x-1-all', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+      region: 'us-east-1', resource_type: 'm5.xlarge', count: 4, term: 1,
+      payment: 'all-upfront', upfront_cost: 24000, monthly_cost: 0, savings: 1400,
+    };
+    (localStorage.getItem as jest.Mock).mockReturnValue(JSON.stringify({ capacity: 50 }));
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: [rec], regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue([rec]);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue([rec]);
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['x-1-all']));
+    // A reload landing during openPurchaseModal's override fetch replaces the
+    // loaded list; the override matches the rec's own payment, so the seed
+    // path resolves to the fallback push, which is `rec` itself.
+    (api.listAccountServiceOverrides as jest.Mock).mockImplementation(async () => {
+      (state.getRecommendations as jest.Mock).mockReturnValue([]);
+      return [{ id: 'ovr-1', account_id: 'a1', provider: 'aws', service: 'ec2', payment: 'all-upfront' }];
+    });
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+
+    expect(getPurchaseModalRecommendations()[0]).toMatchObject({
+      id: 'x-1-all', count: 2, recommended_count: 4, upfront_cost: 12000,
+    });
+
+    (document.getElementById('execute-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+
+    expect(api.executePurchase).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({
+        id: 'x-1-all', count: 2, recommended_count: 4, upfront_cost: 12000,
+      })]),
+      50,
+      undefined,
+    );
+  });
 });

--- a/frontend/src/__tests__/purchase-modal-submit.test.ts
+++ b/frontend/src/__tests__/purchase-modal-submit.test.ts
@@ -144,10 +144,11 @@ jest.mock('../toast', () => ({
 
 // ── imports ───────────────────────────────────────────────────────────────────
 
-import { setupEventListeners } from '../app';
+import { handleExecutePurchase, setupEventListeners } from '../app';
 import * as api from '../api';
 import * as state from '../state';
 import { showToast } from '../toast';
+import { confirmDialog } from '../confirmDialog';
 import {
   openPurchaseModal,
   getPurchaseModalRecommendations,
@@ -194,6 +195,17 @@ function buildRows(): LocalRecommendation[] {
 /** Drains the microtask queue enough for the async handlers under test to settle. */
 async function flush(): Promise<void> {
   for (let i = 0; i < 6; i++) await Promise.resolve();
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
 }
 
 // ── DOM / mock scaffolding ────────────────────────────────────────────────────
@@ -438,6 +450,61 @@ describe('Issue #1903: purchase modal re-prices on Term/Payment change', () => {
 
     expect(document.querySelector('.direct-execute-warning')?.textContent).toContain('12,000.00');
   });
+
+  test('busy single purchase stays disabled while its request is pending', async () => {
+    const request = deferred<Awaited<ReturnType<typeof api.executePurchase>>>();
+    (api.executePurchase as jest.Mock).mockReturnValue(request.promise);
+    const rows = buildRows();
+    await openPurchaseModal([rows[0]!]);
+
+    const executeBtn = document.getElementById('execute-purchase-btn') as HTMLButtonElement;
+    executeBtn.click();
+    await flush();
+    expect(api.executePurchase).toHaveBeenCalledTimes(1);
+
+    const termSelect = document.querySelector<HTMLSelectElement>('.purchase-row-term')!;
+    termSelect.value = '1';
+    termSelect.dispatchEvent(new Event('change'));
+    const include = document.querySelector<HTMLInputElement>('.purchase-modal-row-include')!;
+    include.checked = false;
+    include.dispatchEvent(new Event('change'));
+    include.checked = true;
+    include.dispatchEvent(new Event('change'));
+
+    expect(executeBtn.disabled).toBe(true);
+    executeBtn.click();
+    await flush();
+    expect(api.executePurchase).toHaveBeenCalledTimes(1);
+
+    request.resolve({
+      execution_id: 'exec-single',
+      status: 'pending',
+      email_sent: true,
+      approval_recipient: 'approver@example.com',
+    });
+    await flush();
+    expect(executeBtn.dataset['submitting']).toBeUndefined();
+  });
+
+  test('confirmation cancel restores normal single-purchase submission', async () => {
+    (confirmDialog as jest.Mock)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const rows = buildRows();
+    await openPurchaseModal([rows[0]!]);
+
+    const executeBtn = document.getElementById('execute-purchase-btn') as HTMLButtonElement;
+    executeBtn.click();
+    await flush();
+
+    expect(api.executePurchase).not.toHaveBeenCalled();
+    expect(executeBtn.dataset['submitting']).toBeUndefined();
+    expect(executeBtn.disabled).toBe(false);
+
+    executeBtn.click();
+    await flush();
+    expect(api.executePurchase).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ── #1904: fan-out modal skips incompatible buckets ──────────────────────────
@@ -599,5 +666,79 @@ describe('Issue #1904: fan-out modal skips incompatible buckets', () => {
       50,
       undefined,
     );
+  });
+
+  test('busy fan-out stays disabled while its requests are pending', async () => {
+    const requests = [
+      deferred<Awaited<ReturnType<typeof api.executePurchase>>>(),
+      deferred<Awaited<ReturnType<typeof api.executePurchase>>>(),
+    ];
+    (api.executePurchase as jest.Mock)
+      .mockReturnValueOnce(requests[0]!.promise)
+      .mockReturnValueOnce(requests[1]!.promise);
+    const rows = buildFanOutRows();
+    (api.getConfig as jest.Mock).mockResolvedValue({ global: { default_payment: 'partial-upfront' } });
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {}, recommendations: rows, regions: [],
+    });
+    (state.getRecommendations as jest.Mock).mockReturnValue(rows);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(rows);
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['ec2-1', 'rds-3']));
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+    const executeBtn = document.getElementById('execute-purchase-btn') as HTMLButtonElement;
+    executeBtn.click();
+    await flush();
+    expect(api.executePurchase).toHaveBeenCalledTimes(2);
+
+    const paymentSelect = document.querySelector<HTMLSelectElement>('.fanout-bucket-payment')!;
+    paymentSelect.value = 'partial-upfront';
+    paymentSelect.dispatchEvent(new Event('change'));
+
+    expect(executeBtn.disabled).toBe(true);
+    executeBtn.click();
+    await flush();
+    expect(api.executePurchase).toHaveBeenCalledTimes(2);
+
+    for (const [i, request] of requests.entries()) {
+      request.resolve({
+        execution_id: `exec-fanout-${i}`,
+        status: 'pending',
+        email_sent: true,
+        approval_recipient: 'approver@example.com',
+      });
+    }
+    await flush();
+    expect(executeBtn.dataset['submitting']).toBeUndefined();
+  });
+
+  test('fan-out clears submitting state when result processing throws', async () => {
+    const rows = buildFanOutRows();
+    (api.getConfig as jest.Mock).mockResolvedValue({ global: { default_payment: 'partial-upfront' } });
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {}, recommendations: rows, regions: [],
+    });
+    (state.getRecommendations as jest.Mock).mockReturnValue(rows);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(rows);
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['ec2-1', 'rds-3']));
+    (api.executePurchase as jest.Mock)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        execution_id: 'exec-valid',
+        status: 'pending',
+        email_sent: true,
+      });
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+    const executeBtn = document.getElementById('execute-purchase-btn') as HTMLButtonElement;
+    await expect(handleExecutePurchase()).rejects.toThrow(TypeError);
+
+    expect(api.executePurchase).toHaveBeenCalledTimes(2);
+    expect(executeBtn.dataset['submitting']).toBeUndefined();
+    expect(executeBtn.disabled).toBe(false);
   });
 });

--- a/frontend/src/__tests__/purchase-modal-submit.test.ts
+++ b/frontend/src/__tests__/purchase-modal-submit.test.ts
@@ -1,0 +1,440 @@
+/**
+ * Issue #1903 / #1904: the purchase modal's Term and Payment selects must
+ * re-price the row (not just relabel it), and the fan-out modal must never
+ * submit a bucket it told the user would be skipped.
+ *
+ * These tests drive the REAL app.ts + recommendations.ts modules end to end
+ * and assert on the actual request body handed to api.executePurchase — the
+ * body the backend prices, records, and emails from (see
+ * internal/api/handler_purchases.go: validateAndTotalRecommendations /
+ * recTotalCommitment trust the submitted amounts verbatim). Asserting on an
+ * intermediate helper instead of this body would not prove the fix.
+ */
+
+// ── mocks (must precede imports) ─────────────────────────────────────────────
+
+jest.mock('../api', () => ({
+  initAuth: jest.fn(),
+  isAuthenticated: jest.fn(),
+  getCurrentUser: jest.fn(),
+  executePurchase: jest.fn(),
+  getRecommendations: jest.fn(),
+  getConfig: jest.fn().mockResolvedValue({ global: {} }),
+  listAccountsMinimal: jest.fn().mockResolvedValue([]),
+  listAccountServiceOverrides: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../api/recommendations', () => ({
+  getRecommendationsFreshness: jest.fn().mockResolvedValue({
+    last_collected_at: new Date().toISOString(),
+    last_collection_error: null,
+  }),
+  refreshRecommendations: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../state', () => ({
+  getCurrentProvider: jest.fn().mockReturnValue('all'),
+  setCurrentProvider: jest.fn(),
+  getCurrentAccountIDs: jest.fn().mockReturnValue([]),
+  setCurrentAccountIDs: jest.fn(),
+  getRecommendations: jest.fn().mockReturnValue([]),
+  getRecommendationByID: jest.fn().mockReturnValue(undefined),
+  setRecommendations: jest.fn(),
+  getSelectedRecommendationIDs: jest.fn().mockReturnValue(new Set()),
+  clearSelectedRecommendations: jest.fn(),
+  addSelectedRecommendation: jest.fn(),
+  removeSelectedRecommendation: jest.fn(),
+  getRecommendationsSort: jest.fn().mockReturnValue({ column: 'savings', direction: 'desc' }),
+  setRecommendationsSort: jest.fn(),
+  getRecommendationsColumnFilters: jest.fn().mockReturnValue({}),
+  setRecommendationsColumnFilter: jest.fn(),
+  clearAllRecommendationsColumnFilters: jest.fn(),
+  getVisibleRecommendations: jest.fn().mockReturnValue([]),
+  setVisibleRecommendations: jest.fn(),
+  getCostPeriod: jest.fn().mockReturnValue('monthly'),
+  setCostPeriod: jest.fn(),
+  getHiddenColumns: jest.fn().mockReturnValue(new Set()),
+  setHiddenColumns: jest.fn(),
+  getCurrentUser: jest.fn(),
+  // setupRecommendationsHandlers (real — ../recommendations is NOT mocked in
+  // this file) subscribes to both on module init via app.ts's
+  // setupEventListeners().
+  subscribeProvider: jest.fn().mockReturnValue(() => {}),
+  subscribeAccount: jest.fn().mockReturnValue(() => {}),
+}));
+
+jest.mock('../auth', () => ({
+  showLoginModal: jest.fn(),
+  updateUserUI: jest.fn(),
+}));
+
+jest.mock('../dashboard', () => ({
+  loadDashboard: jest.fn().mockResolvedValue(undefined),
+  setupDashboardHandlers: jest.fn(),
+}));
+
+jest.mock('../navigation', () => ({
+  switchTab: jest.fn(),
+  applyTabFromPath: jest.fn().mockReturnValue('dashboard'),
+  initRouter: jest.fn(),
+  switchSettingsSubTab: jest.fn(),
+  getSettingsSubTabFromPath: jest.fn().mockReturnValue('general'),
+}));
+
+// NOTE: ../recommendations is intentionally NOT mocked — this file exercises
+// the real openPurchaseModal / getFanOutBuckets / loadRecommendations.
+
+jest.mock('../plans', () => ({
+  savePlan: jest.fn(),
+  setupPlanHandlers: jest.fn(),
+  closePlanModal: jest.fn(),
+  openNewPlanModal: jest.fn(),
+  closePurchaseModal: jest.fn(),
+}));
+
+jest.mock('../settings', () => ({
+  saveGlobalSettings: jest.fn(),
+  setupSettingsHandlers: jest.fn(),
+  resetSettings: jest.fn(),
+}));
+
+jest.mock('../riexchange', () => ({
+  setupRIExchangeHandlers: jest.fn(),
+  saveAutomationSettings: jest.fn(),
+}));
+
+jest.mock('../users', () => ({
+  setupUserHandlers: jest.fn(),
+}));
+
+jest.mock('../apikeys', () => ({
+  initApiKeys: jest.fn(),
+}));
+
+jest.mock('../history', () => ({
+  loadHistory: jest.fn(),
+  setupHistoryHandlers: jest.fn(),
+}));
+
+jest.mock('../modules/savings-history', () => ({
+  initSavingsHistory: jest.fn(),
+}));
+
+jest.mock('../purchases-deeplink', () => ({
+  handlePurchaseDeeplink: jest.fn(),
+}));
+
+jest.mock('../modal', () => ({
+  openModal: jest.fn(),
+  closeModal: jest.fn(),
+}));
+
+jest.mock('../confirmDialog', () => ({
+  confirmDialog: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../archera', () => ({
+  handleArcheraDeeplink: jest.fn(),
+  openArcheraOfferModal: jest.fn(),
+}));
+
+jest.mock('../toast', () => ({
+  showToast: jest.fn(),
+}));
+
+// ── imports ───────────────────────────────────────────────────────────────────
+
+import { setupEventListeners } from '../app';
+import * as api from '../api';
+import * as state from '../state';
+import { showToast } from '../toast';
+import {
+  openPurchaseModal,
+  getPurchaseModalRecommendations,
+  clearPurchaseModalRecommendations,
+  clearFanOutBuckets,
+  loadRecommendations,
+} from '../recommendations';
+import { formatCurrency } from '../utils';
+import { ADMINISTRATORS_GROUP_ID, PURCHASER_GROUP_ID } from '../permissions';
+import type { LocalRecommendation } from '../types';
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+// One AWS EC2 cell fanned out into its four (term, payment) variants — the
+// same shape providers/aws/recommendations/client.go produces for a single
+// physical resource. Every #1903 test reads from a fresh copy of this list
+// via buildRows() so no test can leak a mutation into another.
+function buildRows(): LocalRecommendation[] {
+  return [
+    {
+      id: 'v-3-all', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+      region: 'us-east-1', resource_type: 'm5.large', count: 2, term: 3,
+      payment: 'all-upfront', upfront_cost: 36000, monthly_cost: 0, savings: 900,
+    },
+    {
+      id: 'v-3-partial', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+      region: 'us-east-1', resource_type: 'm5.large', count: 2, term: 3,
+      payment: 'partial-upfront', upfront_cost: 18000, monthly_cost: 300, savings: 850,
+    },
+    {
+      id: 'v-1-all', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+      region: 'us-east-1', resource_type: 'm5.large', count: 2, term: 1,
+      payment: 'all-upfront', upfront_cost: 12000, monthly_cost: 0, savings: 700,
+    },
+    {
+      id: 'v-1-no', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+      region: 'us-east-1', resource_type: 'm5.large', count: 1, term: 1,
+      payment: 'no-upfront', upfront_cost: 0, monthly_cost: 800, savings: 500,
+    },
+  ];
+}
+
+/** Drains the microtask queue enough for the async handlers under test to settle. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 6; i++) await Promise.resolve();
+}
+
+// ── DOM / mock scaffolding ────────────────────────────────────────────────────
+
+beforeEach(() => {
+  document.body.replaceChildren();
+
+  const opportunitiesTab = document.createElement('div');
+  opportunitiesTab.id = 'opportunities-tab';
+  opportunitiesTab.className = 'tab-content active';
+  const summaryEl = document.createElement('div');
+  summaryEl.id = 'recommendations-summary';
+  const listEl = document.createElement('div');
+  listEl.id = 'recommendations-list';
+  opportunitiesTab.appendChild(summaryEl);
+  opportunitiesTab.appendChild(listEl);
+  document.body.appendChild(opportunitiesTab);
+
+  const purchaseModal = document.createElement('div');
+  purchaseModal.id = 'purchase-modal';
+  purchaseModal.className = 'hidden';
+  const purchaseDetails = document.createElement('div');
+  purchaseDetails.id = 'purchase-details';
+  purchaseModal.appendChild(purchaseDetails);
+  document.body.appendChild(purchaseModal);
+
+  const executeBtn = document.createElement('button');
+  executeBtn.id = 'execute-purchase-btn';
+  document.body.appendChild(executeBtn);
+
+  setupEventListeners();
+
+  jest.clearAllMocks();
+  clearPurchaseModalRecommendations();
+  clearFanOutBuckets();
+
+  // loadBulkPurchaseState() (setup.ts's localStorage mock defaults getItem to
+  // null) only reads cachedGlobalDefaultPayment when a raw value is present —
+  // otherwise it falls back to the hardcoded 'all-upfront' default and never
+  // consults GlobalConfig. Seed a truthy (capacity-only) value so the
+  // bulk-purchase toolbar picks up the mocked getConfig() default_payment;
+  // tests that need a specific capacity override this per-test.
+  (localStorage.getItem as jest.Mock).mockReturnValue('{}');
+  (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([]);
+  (api.getConfig as jest.Mock).mockResolvedValue({ global: {} });
+  (api.executePurchase as jest.Mock).mockResolvedValue({
+    execution_id: 'exec-aaaaaaaa',
+    email_sent: true,
+    approval_recipient: 'approver@example.com',
+  });
+  (state.getCurrentUser as jest.Mock).mockReturnValue({
+    id: 'u-admin', email: 'admin@example.com', groups: [ADMINISTRATORS_GROUP_ID, PURCHASER_GROUP_ID],
+  });
+  // Every #1903 test needs the full loaded cell so pricedCellVariant /
+  // cellTermOptions / cellPaymentOptions can find the sibling rows.
+  (state.getRecommendations as jest.Mock).mockReturnValue(buildRows());
+});
+
+// ── #1903: purchase modal re-prices on Term/Payment change ───────────────────
+
+describe('Issue #1903: purchase modal re-prices on Term/Payment change', () => {
+  test('T1 term change re-prices the submitted body', async () => {
+    const rows = buildRows();
+    const v3all = rows.find((r) => r.id === 'v-3-all')!;
+
+    await openPurchaseModal([v3all]);
+
+    const termSelect = document.querySelector<HTMLSelectElement>('.purchase-row-term')!;
+    termSelect.value = '1';
+    termSelect.dispatchEvent(new Event('change'));
+
+    const tr = document.querySelector<HTMLTableRowElement>('.purchase-modal-table tbody tr')!;
+    expect(tr.cells[5]!.textContent).toBe(formatCurrency(12000));
+    expect(tr.cells[6]!.textContent).toBe(formatCurrency(0));
+    expect(tr.cells[7]!.textContent).toBe(formatCurrency(700));
+    expect(document.getElementById('purchase-modal-total-upfront')?.textContent).toContain(formatCurrency(12000));
+
+    (document.getElementById('execute-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+
+    expect(api.executePurchase).toHaveBeenCalledTimes(1);
+    const body = (api.executePurchase as jest.Mock).mock.calls[0]![0] as Array<Record<string, unknown>>;
+    expect(body[0]).toMatchObject({
+      id: 'v-1-all', term: 1, payment: 'all-upfront', upfront_cost: 12000, monthly_cost: 0, savings: 700,
+    });
+  });
+
+  test('T2 payment change re-prices the submitted body', async () => {
+    const rows = buildRows();
+    const v1all = rows.find((r) => r.id === 'v-1-all')!;
+
+    await openPurchaseModal([v1all]);
+
+    const paymentSelect = document.querySelector<HTMLSelectElement>('.purchase-row-payment')!;
+    paymentSelect.value = 'no-upfront';
+    paymentSelect.dispatchEvent(new Event('change'));
+
+    (document.getElementById('execute-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+
+    expect(api.executePurchase).toHaveBeenCalledTimes(1);
+    const body = (api.executePurchase as jest.Mock).mock.calls[0]![0] as Array<Record<string, unknown>>;
+    expect(body[0]).toMatchObject({
+      id: 'v-1-no', term: 1, payment: 'no-upfront', upfront_cost: 0, monthly_cost: 800, count: 1,
+    });
+  });
+
+  test('T3 options are only priced variants', async () => {
+    const rows = buildRows();
+    const v3all = rows.find((r) => r.id === 'v-3-all')!;
+
+    await openPurchaseModal([v3all]);
+
+    const termSelect = document.querySelector<HTMLSelectElement>('.purchase-row-term')!;
+    const paymentSelect = document.querySelector<HTMLSelectElement>('.purchase-row-payment')!;
+    expect(Array.from(termSelect.options).map((o) => o.value)).toEqual(['1', '3']);
+    expect(Array.from(paymentSelect.options).map((o) => o.value)).toEqual(['all-upfront', 'partial-upfront']);
+
+    // Azure cell with a single loaded variant.
+    const azureRec: LocalRecommendation = {
+      id: 'az-1', provider: 'azure', cloud_account_id: 'a2', service: 'compute',
+      region: 'eastus', resource_type: 'Standard_D2s_v3', count: 1, term: 3,
+      payment: 'upfront', upfront_cost: 500, savings: 100,
+    };
+    (state.getRecommendations as jest.Mock).mockReturnValue([azureRec]);
+    clearPurchaseModalRecommendations();
+
+    await openPurchaseModal([azureRec]);
+
+    const termSelect2 = document.querySelector<HTMLSelectElement>('.purchase-row-term')!;
+    const paymentSelect2 = document.querySelector<HTMLSelectElement>('.purchase-row-payment')!;
+    expect(Array.from(termSelect2.options).map((o) => o.value)).toEqual(['3']);
+    expect(Array.from(paymentSelect2.options).map((o) => o.value)).toEqual(['all-upfront']);
+  });
+
+  test('T4 capacity scaling survives a swap (bulk path)', async () => {
+    const rows = buildRows();
+    (localStorage.getItem as jest.Mock).mockReturnValue(JSON.stringify({ capacity: 50 }));
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: rows, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(rows);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(rows);
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['v-3-all']));
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+
+    const tr = document.querySelector<HTMLTableRowElement>('.purchase-modal-table tbody tr')!;
+    expect(tr.cells[4]!.textContent).toBe('1');
+    expect(tr.cells[5]!.textContent).toBe(formatCurrency(18000));
+
+    const termSelect = document.querySelector<HTMLSelectElement>('.purchase-row-term')!;
+    termSelect.value = '1';
+    termSelect.dispatchEvent(new Event('change'));
+
+    const tr2 = document.querySelector<HTMLTableRowElement>('.purchase-modal-table tbody tr')!;
+    expect(tr2.cells[5]!.textContent).toBe(formatCurrency(6000));
+
+    (document.getElementById('execute-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+
+    expect(api.executePurchase).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ id: 'v-1-all', count: 1, recommended_count: 2, upfront_cost: 6000 })]),
+      50,
+      undefined,
+    );
+  });
+
+  test('T5 zero-unit variant is refused and the row keeps its price', async () => {
+    const rows = buildRows();
+    (localStorage.getItem as jest.Mock).mockReturnValue(JSON.stringify({ capacity: 50 }));
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: rows, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(rows);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(rows);
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['v-3-all']));
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+
+    const termSelect = document.querySelector<HTMLSelectElement>('.purchase-row-term')!;
+    termSelect.value = '1';
+    termSelect.dispatchEvent(new Event('change'));
+
+    // The term-change re-render replaced the row — re-query the fresh Payment select.
+    const paymentSelect = document.querySelector<HTMLSelectElement>('.purchase-row-payment')!;
+    paymentSelect.value = 'no-upfront';
+    paymentSelect.dispatchEvent(new Event('change'));
+
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ kind: 'warning' }));
+    expect(paymentSelect.value).toBe('all-upfront');
+
+    (document.getElementById('execute-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+
+    const body = (api.executePurchase as jest.Mock).mock.calls[0]![0] as Array<Record<string, unknown>>;
+    expect(body[0]).toMatchObject({ id: 'v-1-all', upfront_cost: 6000 });
+  });
+
+  test('T6 account override re-prices at open', async () => {
+    const rows = buildRows();
+    const v3all = rows.find((r) => r.id === 'v-3-all')!;
+
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'ovr-1', account_id: 'a1', provider: 'aws', service: 'ec2', payment: 'partial-upfront' },
+    ]);
+    await openPurchaseModal([v3all]);
+
+    const live = getPurchaseModalRecommendations();
+    expect(live[0]).toMatchObject({ id: 'v-3-partial', payment: 'partial-upfront', upfront_cost: 18000 });
+    expect(document.querySelector('.purchase-row-payment-source')).not.toBeNull();
+    expect(document.querySelector<HTMLTableRowElement>('.purchase-modal-table tbody tr')!.cells[5]!.textContent)
+      .toBe(formatCurrency(18000));
+
+    clearPurchaseModalRecommendations();
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'ovr-2', account_id: 'a1', provider: 'aws', service: 'ec2', payment: 'no-upfront' },
+    ]);
+    await openPurchaseModal([v3all]);
+
+    const live2 = getPurchaseModalRecommendations();
+    expect(live2[0]).toMatchObject({ id: 'v-3-all', payment: 'all-upfront', upfront_cost: 36000 });
+    expect(document.querySelector('.purchase-row-payment-source')).toBeNull();
+  });
+
+  test('T7 direct-execute warning follows a term change', async () => {
+    const rows = buildRows();
+    const v3all = rows.find((r) => r.id === 'v-3-all')!;
+
+    await openPurchaseModal([v3all]);
+
+    const directRadio = document.getElementById('execute-mode-direct') as HTMLInputElement;
+    expect(directRadio).not.toBeNull();
+    directRadio.click();
+    directRadio.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(document.querySelector('.direct-execute-warning')?.textContent).toContain('36,000.00');
+
+    const termSelect = document.querySelector<HTMLSelectElement>('.purchase-row-term')!;
+    termSelect.value = '1';
+    termSelect.dispatchEvent(new Event('change'));
+
+    expect(document.querySelector('.direct-execute-warning')?.textContent).toContain('12,000.00');
+  });
+});

--- a/frontend/src/__tests__/purchase-modal-submit.test.ts
+++ b/frontend/src/__tests__/purchase-modal-submit.test.ts
@@ -152,6 +152,7 @@ import {
   openPurchaseModal,
   getPurchaseModalRecommendations,
   clearPurchaseModalRecommendations,
+  getFanOutBuckets,
   clearFanOutBuckets,
   loadRecommendations,
 } from '../recommendations';
@@ -436,5 +437,123 @@ describe('Issue #1903: purchase modal re-prices on Term/Payment change', () => {
     termSelect.dispatchEvent(new Event('change'));
 
     expect(document.querySelector('.direct-execute-warning')?.textContent).toContain('12,000.00');
+  });
+});
+
+// ── #1904: fan-out modal skips incompatible buckets ──────────────────────────
+
+describe('Issue #1904: fan-out modal skips incompatible buckets', () => {
+  function buildFanOutRows(): LocalRecommendation[] {
+    return [
+      {
+        id: 'ec2-1', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+        region: 'us-east-1', resource_type: 'm5.large', term: 1, payment: 'no-upfront',
+        count: 1, upfront_cost: 0, monthly_cost: 100, savings: 50,
+      },
+      {
+        id: 'rds-3', provider: 'aws', cloud_account_id: 'a1', service: 'rds',
+        region: 'us-east-1', resource_type: 'db.r5.large', term: 3, payment: undefined,
+        count: 1, upfront_cost: 1000, savings: 200,
+      },
+    ];
+  }
+
+  test('T8 skipped bucket is not submitted and not totalled', async () => {
+    const [ec2Rec, rdsRec] = buildFanOutRows();
+    (api.getConfig as jest.Mock).mockResolvedValue({ global: { default_payment: 'no-upfront' } });
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {}, recommendations: [ec2Rec, rdsRec], regions: [],
+    });
+    (state.getRecommendations as jest.Mock).mockReturnValue([ec2Rec, rdsRec]);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue([ec2Rec, rdsRec]);
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['ec2-1', 'rds-3']));
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+
+    const errorSections = document.querySelectorAll('.fanout-bucket-error');
+    expect(errorSections).toHaveLength(1);
+    expect(errorSections[0]!.textContent).toContain('will be skipped');
+
+    const summaryText = document.getElementById('fanout-summary')!.textContent ?? '';
+    expect(summaryText).toContain('Will send 1 approval email');
+    expect(summaryText).toContain('1 incompatible bucket will be skipped');
+
+    const totalUpfrontLine = Array.from(document.querySelectorAll('#fanout-summary p'))
+      .find((p) => p.textContent?.startsWith('Total upfront'))!;
+    expect(totalUpfrontLine.querySelector('strong')!.textContent).toBe(formatCurrency(0));
+    const totalCommitmentsLine = Array.from(document.querySelectorAll('#fanout-summary p'))
+      .find((p) => p.textContent?.startsWith('Total commitments'))!;
+    expect(totalCommitmentsLine.querySelector('strong')!.textContent).toBe('1');
+
+    (document.getElementById('execute-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+
+    expect(api.executePurchase).toHaveBeenCalledTimes(1);
+    const body = (api.executePurchase as jest.Mock).mock.calls[0]![0] as Array<Record<string, unknown>>;
+    for (const rec of body) {
+      expect(rec['service']).toBe('ec2');
+      expect(rec['id']).not.toBe('rds-3');
+    }
+  });
+
+  test('T9 repairing the bucket un-skips it everywhere', async () => {
+    const [ec2Rec, rdsRec] = buildFanOutRows();
+    (api.getConfig as jest.Mock).mockResolvedValue({ global: { default_payment: 'no-upfront' } });
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {}, recommendations: [ec2Rec, rdsRec], regions: [],
+    });
+    (state.getRecommendations as jest.Mock).mockReturnValue([ec2Rec, rdsRec]);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue([ec2Rec, rdsRec]);
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['ec2-1', 'rds-3']));
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+
+    const rdsSection = Array.from(document.querySelectorAll<HTMLElement>('.fanout-bucket'))
+      .find((s) => s.querySelector('.fanout-bucket-error') != null)!;
+    const rdsPaymentSelect = rdsSection.querySelector<HTMLSelectElement>('.fanout-bucket-payment')!;
+    rdsPaymentSelect.value = 'partial-upfront';
+    rdsPaymentSelect.dispatchEvent(new Event('change'));
+
+    expect(rdsSection.querySelector('.fanout-bucket-ok')).not.toBeNull();
+    const summaryText = document.getElementById('fanout-summary')!.textContent ?? '';
+    expect(summaryText).toContain('Will send 2 approval emails');
+    expect(summaryText).not.toContain('skipped');
+    const totalUpfrontLine = Array.from(document.querySelectorAll('#fanout-summary p'))
+      .find((p) => p.textContent?.startsWith('Total upfront'))!;
+    expect(totalUpfrontLine.querySelector('strong')!.textContent).toBe(formatCurrency(1000));
+
+    (document.getElementById('execute-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+
+    expect(api.executePurchase).toHaveBeenCalledTimes(2);
+  });
+
+  test('T10 nothing submittable disables Execute', async () => {
+    const [, rdsRec] = buildFanOutRows();
+    (api.getConfig as jest.Mock).mockResolvedValue({ global: { default_payment: 'no-upfront' } });
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {}, recommendations: [rdsRec], regions: [],
+    });
+    (state.getRecommendations as jest.Mock).mockReturnValue([rdsRec]);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue([rdsRec]);
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['rds-3']));
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    await flush();
+
+    const executeBtn = document.getElementById('execute-purchase-btn') as HTMLButtonElement;
+    expect(executeBtn.disabled).toBe(true);
+    expect(getFanOutBuckets()).toEqual([]);
+    expect(document.getElementById('fanout-summary')!.textContent).toContain('Will send 0 approval emails');
+
+    executeBtn.click();
+    await flush();
+
+    expect(api.executePurchase).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -3669,6 +3669,12 @@ describe('Issue #111 (iii): per-row Payment seed in openPurchaseModal', () => {
     document.body.appendChild(purchaseModal);
     jest.clearAllMocks();
     (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([]);
+    // Issue #1903: pricedCellVariant/cellTermOptions/cellPaymentOptions read
+    // state.getRecommendations() for the loaded sibling (term, payment) rows.
+    // Reset to empty here so per-test mockReturnValue overrides below don't
+    // leak into sibling describe blocks (clearAllMocks does not reset return
+    // values — see the note above at the #288 execute-mode-toggle suite).
+    (state.getRecommendations as jest.Mock).mockReturnValue([]);
   });
 
   test('(a) single rec with matching override → row Payment seeded from override; source-note rendered', async () => {
@@ -3684,12 +3690,20 @@ describe('Issue #111 (iii): per-row Payment seed in openPurchaseModal', () => {
       service: 'ec2', resource_type: 't3.medium', region: 'us-east-1',
       count: 5, term: 1, payment: 'all-upfront', savings: 100, upfront_cost: 500,
     };
+    // Issue #1903: the override is only honoured when a priced variant for
+    // it was actually loaded.
+    (state.getRecommendations as jest.Mock).mockReturnValue([
+      rec,
+      { ...rec, id: 'rec-1-partial', payment: 'partial-upfront', upfront_cost: 250, monthly_cost: 20 },
+    ]);
 
     await openPurchaseModal([rec]);
 
     const live = getPurchaseModalRecommendations();
     expect(live).toHaveLength(1);
     expect(live[0]!.payment).toBe('partial-upfront');
+    expect(live[0]!.upfront_cost).toBe(250);
+    expect(live[0]!.id).toBe('rec-1-partial');
 
     const select = document.querySelector<HTMLSelectElement>('.purchase-row-payment');
     expect(select).not.toBeNull();
@@ -3760,6 +3774,13 @@ describe('Issue #111 (iii): per-row Payment seed in openPurchaseModal', () => {
       service: 'ec2', resource_type: 't3.medium', region: 'us-east-1',
       count: 5, term: 1, payment: 'all-upfront', savings: 100, upfront_cost: 500,
     };
+    // Issue #1903: the 3yr row Term now offers must be loaded (and thus
+    // priced) — mock the two 3yr variants this cell would have fanned out.
+    (state.getRecommendations as jest.Mock).mockReturnValue([
+      rec,
+      { ...rec, id: 'rec-4-3-all', term: 3, upfront_cost: 1400 },
+      { ...rec, id: 'rec-4-3-partial', term: 3, payment: 'partial-upfront', upfront_cost: 700, monthly_cost: 30 },
+    ]);
 
     await openPurchaseModal([rec]);
 
@@ -3784,6 +3805,10 @@ describe('Issue #111 (iii): per-row Payment seed in openPurchaseModal', () => {
     expect(paymentSelect!.value).toBe(live[0]!.payment);
     const options = Array.from(paymentSelect!.options).map((o) => o.value);
     expect(options.length).toBeGreaterThan(0);
+    // Issue #1903: options are restricted to the priced (loaded) set, and
+    // the swapped-in row carries the priced variant's own price/id.
+    expect(options).toEqual(['all-upfront', 'partial-upfront']);
+    expect(live[0]!.upfront_cost).toBe(1400);
   });
 
   test('(e) user changes Payment dropdown → live state reflects new value (and would round-trip via handleExecutePurchase)', async () => {
@@ -3792,6 +3817,11 @@ describe('Issue #111 (iii): per-row Payment seed in openPurchaseModal', () => {
       service: 'ec2', resource_type: 't3.medium', region: 'us-east-1',
       count: 5, term: 1, payment: 'all-upfront', savings: 100, upfront_cost: 500,
     };
+    // Issue #1903: the no-upfront option must be a loaded (priced) variant.
+    (state.getRecommendations as jest.Mock).mockReturnValue([
+      rec,
+      { ...rec, id: 'rec-5-no', payment: 'no-upfront', upfront_cost: 0, monthly_cost: 60 },
+    ]);
 
     await openPurchaseModal([rec]);
 
@@ -3804,6 +3834,8 @@ describe('Issue #111 (iii): per-row Payment seed in openPurchaseModal', () => {
 
     const live = getPurchaseModalRecommendations();
     expect(live[0]!.payment).toBe('no-upfront');
+    expect(live[0]!.upfront_cost).toBe(0);
+    expect(live[0]!.monthly_cost).toBe(60);
 
     // The mapping in app.ts::handleExecutePurchase reads this value
     // verbatim (`payment: r.payment ?? 'all-upfront'`), so a downstream
@@ -3820,6 +3852,12 @@ describe('Issue #111 (iii): per-row Payment seed in openPurchaseModal', () => {
       service: 'ec2', resource_type: 't3.medium', region: 'us-east-1',
       count: 2, term: 1, payment: 'all-upfront', savings: 50, upfront_cost: 200,
     };
+    // Issue #1903: a 3yr option is only offered when a 3yr variant was
+    // actually loaded for this cell.
+    (state.getRecommendations as jest.Mock).mockReturnValue([
+      rec,
+      { ...rec, id: 'rec-6-3yr', term: 3 },
+    ]);
 
     await openPurchaseModal([rec]);
 

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -309,12 +309,38 @@ function setupButtonHandlers(): void {
 
 }
 
+function setExecutePurchaseSubmitting(
+  executeBtn: HTMLButtonElement | null,
+  submitting: boolean,
+  label: string,
+): void {
+  if (!executeBtn) return;
+
+  executeBtn.textContent = label;
+  if (submitting) {
+    executeBtn.dataset['submitting'] = 'true';
+    executeBtn.disabled = true;
+    executeBtn.title = 'Purchase submission in progress';
+    return;
+  }
+
+  delete executeBtn.dataset['submitting'];
+  const fanOutBuckets = getFanOutBuckets();
+  const unavailable = fanOutBuckets !== null
+    ? fanOutBuckets.length === 0
+    : getPurchaseModalRecommendations().length === 0;
+  executeBtn.disabled = unavailable;
+  executeBtn.title = unavailable
+    ? fanOutBuckets !== null ? 'No compatible buckets to submit' : 'Select at least one purchase'
+    : '';
+}
+
 /**
  * Handle execute purchase button click. Routes to the single-bucket
  * path when getPurchaseModalRecommendations has content, or to the
  * multi-bucket fan-out path when the fan-out modal set buckets.
  */
-async function handleExecutePurchase(): Promise<void> {
+export async function handleExecutePurchase(): Promise<void> {
   const fanOutBuckets = getFanOutBuckets();
   if (fanOutBuckets && fanOutBuckets.length > 0) {
     await handleFanOutExecute(fanOutBuckets);
@@ -338,10 +364,7 @@ async function handleExecutePurchase(): Promise<void> {
   // mint a duplicate pending execution (#644). The button is re-enabled on
   // cancel below and in the finally block once the request settles.
   const executeBtn = document.getElementById('execute-purchase-btn') as HTMLButtonElement | null;
-  if (executeBtn) {
-    executeBtn.disabled = true;
-    executeBtn.textContent = 'Sending...';
-  }
+  setExecutePurchaseSubmitting(executeBtn, true, 'Sending...');
 
   const defaultBtnLabel = isDirect ? 'Execute Purchase Now' : 'Send for Approval';
 
@@ -364,10 +387,7 @@ async function handleExecutePurchase(): Promise<void> {
       });
 
   if (!ok) {
-    if (executeBtn) {
-      executeBtn.disabled = false;
-      executeBtn.textContent = defaultBtnLabel;
-    }
+    setExecutePurchaseSubmitting(executeBtn, false, defaultBtnLabel);
     return;
   }
 
@@ -460,10 +480,7 @@ async function handleExecutePurchase(): Promise<void> {
     const verb = isDirect ? 'execute' : 'send for approval';
     showToast({ message: `Failed to ${verb} purchase: ${err.message}`, kind: 'error' });
   } finally {
-    if (executeBtn) {
-      executeBtn.disabled = false;
-      executeBtn.textContent = defaultBtnLabel;
-    }
+    setExecutePurchaseSubmitting(executeBtn, false, defaultBtnLabel);
   }
 }
 
@@ -495,10 +512,7 @@ async function handleFanOutExecute(buckets: FanOutBucket[]): Promise<void> {
   // double-click can't fan out a second wave of duplicate executions (#644).
   // Re-enabled on cancel below and after the calls settle at the end.
   const executeBtn = document.getElementById('execute-purchase-btn') as HTMLButtonElement | null;
-  if (executeBtn) {
-    executeBtn.disabled = true;
-    executeBtn.textContent = `Sending 0/${buckets.length}…`;
-  }
+  setExecutePurchaseSubmitting(executeBtn, true, `Sending 0/${buckets.length}…`);
 
   // Same approval-required default as the single-purchase path: each
   // bucket POSTs a request that triggers an approval email; the actual
@@ -510,13 +524,18 @@ async function handleFanOutExecute(buckets: FanOutBucket[]): Promise<void> {
     destructive: false,
   });
   if (!ok) {
-    if (executeBtn) {
-      executeBtn.disabled = false;
-      executeBtn.textContent = 'Send for Approval';
-    }
+    setExecutePurchaseSubmitting(executeBtn, false, 'Send for Approval');
     return;
   }
 
+  try {
+    await submitFanOutBuckets(buckets);
+  } finally {
+    setExecutePurchaseSubmitting(executeBtn, false, 'Send for Approval');
+  }
+}
+
+async function submitFanOutBuckets(buckets: FanOutBucket[]): Promise<void> {
   // Fire all POSTs in parallel via allSettled so one failure doesn't
   // cascade. Each bucket's recs are already scaled by its capacity %;
   // the POST body records capacity_percent for audit. Spread the full
@@ -646,11 +665,6 @@ async function handleFanOutExecute(buckets: FanOutBucket[]): Promise<void> {
   }
 
   await loadDashboard();
-
-  if (executeBtn) {
-    executeBtn.disabled = false;
-    executeBtn.textContent = 'Send for Approval';
-  }
 }
 
 /**

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -4388,8 +4388,11 @@ function renderFanOutSummary(summary: HTMLElement, buckets: FanOutBucket[]): voi
 
   const executeBtn = document.getElementById('execute-purchase-btn') as HTMLButtonElement | null;
   if (executeBtn) {
-    executeBtn.disabled = submittable.length === 0;
-    executeBtn.title = submittable.length === 0 ? 'No compatible buckets to submit' : '';
+    const submitting = executeBtn.dataset['submitting'] === 'true';
+    executeBtn.disabled = submitting || submittable.length === 0;
+    executeBtn.title = submitting
+      ? 'Purchase submission in progress'
+      : submittable.length === 0 ? 'No compatible buckets to submit' : '';
   }
 }
 
@@ -5021,7 +5024,7 @@ function renderDirectExecuteWarning(): void {
   icon.textContent = 'Warning: ';
   directWarning.appendChild(icon);
   const text = document.createTextNode(
-    `This will charge $${totalUpfront.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} upfront immediately. ` +
+    `This will charge ${formatCurrency(totalUpfront, '$', 2)} upfront immediately. ` +
     'This bypasses the approval step. AWS allows cancellation within 24 hours via the Account & Billing console.',
   );
   directWarning.appendChild(text);
@@ -5390,8 +5393,11 @@ function updatePurchaseModalTotals(selectAllCb: HTMLInputElement): void {
   const executeBtn = document.getElementById('execute-purchase-btn') as HTMLButtonElement | null;
   if (executeBtn) {
     const noneSelected = checkedPurchaseIndices.size === 0;
-    executeBtn.disabled = noneSelected;
-    executeBtn.title = noneSelected ? 'Select at least one purchase' : '';
+    const submitting = executeBtn.dataset['submitting'] === 'true';
+    executeBtn.disabled = submitting || noneSelected;
+    executeBtn.title = submitting
+      ? 'Purchase submission in progress'
+      : noneSelected ? 'Select at least one purchase' : '';
   }
 
   // Sync select-all checkbox indeterminate/checked/unchecked state.

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -39,6 +39,11 @@ export type { ParsedNumericFilter } from './lib/column-filters';
 
 // Module state for current purchase modal recommendations
 let currentPurchaseRecommendations: LocalRecommendation[] = [];
+// Capacity % the modal's recommendations were scaled at (issue #1903). Used
+// by pricedCellVariant to re-scale a sibling variant swapped in on a
+// Term/Payment change so the row keeps the same capacity as the rest of the
+// modal. Reset to 100 on modal close.
+let currentPurchaseCapacityPercent = 100;
 // Tracks which row indices in currentPurchaseRecommendations the user
 // has kept included (checked). Initialised to all indices on modal open;
 // toggled by per-row checkboxes and the select-all header checkbox.
@@ -229,6 +234,7 @@ export function clearPurchaseModalRecommendations(): void {
   currentPurchaseRecommendations = [];
   checkedPurchaseIndices = new Set();
   checkedPurchaseModalInitialised = false;
+  currentPurchaseCapacityPercent = 100;
 }
 
 /**
@@ -932,6 +938,52 @@ export function groupRecsByCell(recs: readonly LocalRecommendation[]): Map<strin
     }
   }
   return groups;
+}
+
+// Every loaded (term, payment) row of rec's cell, plus rec itself when the
+// loaded set lacks it (modal opened on a stale or test-supplied list).
+// Reads state.getRecommendations() (not getVisibleRecommendations) so a
+// column filter that hides a sibling term/payment row can never make the
+// purchase modal think a priced variant doesn't exist (issue #1903).
+function loadedCellVariants(rec: LocalRecommendation): LocalRecommendation[] {
+  const key = cellKey(rec);
+  const variants = (state.getRecommendations() as unknown as LocalRecommendation[])
+    .filter((v) => cellKey(v) === key);
+  if (!variants.some((v) => v.id === rec.id)) variants.push(rec);
+  return sortVariantsInCell(variants);
+}
+
+// The scaled variant the modal would submit for (term, payment), or null when
+// no such row was loaded or it scales to zero units at the modal's capacity.
+function pricedCellVariant(rec: LocalRecommendation, term: 1 | 3, payment: BulkPurchasePayment): LocalRecommendation | null {
+  const v = loadedCellVariants(rec).find((c) => c.term === term && normalizeBulkPayment(c.payment) === payment);
+  return v ? scaleRecForCapacity(v, currentPurchaseCapacityPercent) : null;
+}
+
+// Distinct terms actually loaded for rec's cell, ascending. Used to build
+// the purchase modal's Term <select> so it never offers a term the API
+// didn't price (issue #1903).
+function cellTermOptions(rec: LocalRecommendation): Array<1 | 3> {
+  const terms = new Set<1 | 3>();
+  for (const v of loadedCellVariants(rec)) {
+    if (v.term === 1 || v.term === 3) terms.add(v.term);
+  }
+  return Array.from(terms).sort((a, b) => a - b);
+}
+
+// Payment options for rec's cell at `term`, restricted to combinations that
+// were actually loaded (and thus priced) — the intersection of the compat
+// table's order with the loaded set (issue #1903).
+function cellPaymentOptions(rec: LocalRecommendation, term: 1 | 3): BulkPurchasePayment[] {
+  const loaded = new Set(
+    loadedCellVariants(rec)
+      .filter((v) => v.term === term)
+      .map((v) => normalizeBulkPayment(v.payment))
+      .filter((p): p is BulkPurchasePayment => p !== null),
+  );
+  return paymentOptionsFor(rec.provider as CompatProvider, rec.service, term).filter((p) =>
+    loaded.has(p as BulkPurchasePayment),
+  ) as BulkPurchasePayment[];
 }
 
 // issue #135: SP plan-type row grouping helpers.
@@ -3906,6 +3958,28 @@ async function openCreatePlanFromBottomBox(snapshot: LocalRecommendation[]): Pro
   openCreatePlanModal(snapshot as unknown as readonly api.Recommendation[]);
 }
 
+// Scale one rec's count-dependent fields (count, upfront_cost, monthly_cost,
+// savings) to a capacity %, flooring the unit count. Returns null when the
+// scaled count floors to 0 — the row contributes nothing at this capacity.
+// Extracted from handleBulkPurchaseClick's scaling loop (issue #1903) so
+// pricedCellVariant can apply the same scaling to a sibling variant swapped
+// in on a Term/Payment change.
+function scaleRecForCapacity(r: LocalRecommendation, capacityPercent: number): LocalRecommendation | null {
+  const newCount = Math.floor((r.count * capacityPercent) / 100);
+  if (newCount <= 0) return null;
+  const ratio = r.count > 0 ? newCount / r.count : 1;
+  return {
+    ...r,
+    count: newCount,
+    // Carry the pre-scaling count so the backend can verify the
+    // capacity_percent it records against the scaled count (#647).
+    recommended_count: r.count,
+    upfront_cost: r.upfront_cost * ratio,
+    monthly_cost: r.monthly_cost != null ? r.monthly_cost * ratio : null,
+    savings: r.savings * ratio,
+  };
+}
+
 function handleBulkPurchaseClick(recommendations: LocalRecommendation[]): void {
   const tb = loadBulkPurchaseState();
   if (recommendations.length === 0) {
@@ -3916,19 +3990,8 @@ function handleBulkPurchaseClick(recommendations: LocalRecommendation[]): void {
   // Scale by capacity %; drop rows whose scaled count floors to 0.
   const scaled: LocalRecommendation[] = [];
   for (const r of recommendations) {
-    const newCount = Math.floor((r.count * tb.capacity) / 100);
-    if (newCount <= 0) continue;
-    const ratio = r.count > 0 ? newCount / r.count : 1;
-    scaled.push({
-      ...r,
-      count: newCount,
-      // Carry the pre-scaling count so the backend can verify the
-      // capacity_percent it records against the scaled count (#647).
-      recommended_count: r.count,
-      upfront_cost: r.upfront_cost * ratio,
-      monthly_cost: r.monthly_cost != null ? r.monthly_cost * ratio : null,
-      savings: r.savings * ratio,
-    });
+    const s = scaleRecForCapacity(r, tb.capacity);
+    if (s) scaled.push(s);
   }
   if (scaled.length === 0) {
     showToast({
@@ -3992,7 +4055,7 @@ function handleBulkPurchaseClick(recommendations: LocalRecommendation[]): void {
   // (wired in app.ts) picks up the recs via getPurchaseModalRecommendations.
   // openPurchaseModal is async (issue #111 (iii): per-rec override
   // prefetch); fire-and-forget — the modal is the user's surface.
-  void openPurchaseModal(scaled);
+  void openPurchaseModal(scaled, tb.capacity);
 }
 
 // FanOutBucket groups one batch of recs under a single (provider,
@@ -4849,7 +4912,7 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
 function resolvePerRecPaymentSeed(
   rec: LocalRecommendation,
   overridesByAccount: Map<string, AccountServiceOverride[]>,
-): { payment: CompatPayment; source: 'override' | 'rec' | 'fallback' } {
+): { payment: CompatPayment; source: 'override' | 'rec' | 'fallback'; variant?: LocalRecommendation } {
   const provider = rec.provider as CompatProvider;
   const term = rec.term as 1 | 3;
 
@@ -4859,12 +4922,13 @@ function resolvePerRecPaymentSeed(
       const match = overrides.find(
         (o) => o.provider === provider && o.service === rec.service,
       );
-      if (
-        match
-        && match.payment
-        && isPaymentSupported(provider, rec.service, term, match.payment as CompatPayment)
-      ) {
-        return { payment: match.payment as CompatPayment, source: 'override' };
+      // Issue #1903: an override is only honoured when a priced variant for
+      // it was actually loaded — otherwise the override would relabel this
+      // row's payment without the matching price.
+      const overridePayment = normalizeBulkPayment(match?.payment);
+      if (overridePayment && isPaymentSupported(provider, rec.service, term, overridePayment)) {
+        const variant = pricedCellVariant(rec, term, overridePayment);
+        if (variant) return { payment: overridePayment, source: 'override', variant };
       }
     }
   }
@@ -4883,6 +4947,33 @@ function resolvePerRecPaymentSeed(
     ? cachedGlobalDefaultPayment
     : (options[0] ?? 'all-upfront') as CompatPayment;
   return { payment: preferred, source: 'fallback' };
+}
+
+// renderDirectExecuteWarning rebuilds the "this will charge $X upfront
+// immediately" callout from the currently checked rows. It is a money total
+// in the same modal as the per-row cost cells (issue #1903), so it must
+// follow both a checkbox toggle (updatePurchaseModalTotals, pre-existing
+// gap) and a Term/Payment re-price, not only the radio's own change event.
+// No-ops when the callout isn't in the DOM (no direct-execute permission).
+function renderDirectExecuteWarning(): void {
+  const directWarning = document.querySelector<HTMLElement>('#purchase-details .direct-execute-warning');
+  if (!directWarning) return;
+  directWarning.hidden = currentExecuteMode !== 'direct';
+  if (currentExecuteMode !== 'direct') return;
+  let totalUpfront = 0;
+  for (const idx of checkedPurchaseIndices) {
+    const r = currentPurchaseRecommendations[idx];
+    if (r) totalUpfront += r.upfront_cost;
+  }
+  while (directWarning.firstChild) directWarning.removeChild(directWarning.firstChild);
+  const icon = document.createElement('strong');
+  icon.textContent = 'Warning: ';
+  directWarning.appendChild(icon);
+  const text = document.createTextNode(
+    `This will charge $${totalUpfront.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} upfront immediately. ` +
+    'This bypasses the approval step. AWS allows cancellation within 24 hours via the Account & Billing console.',
+  );
+  directWarning.appendChild(text);
 }
 
 /**
@@ -4917,7 +5008,8 @@ function resolvePerRecPaymentSeed(
  * `openFanOutModal`. Errors swallowed: the rec-payment fallback always
  * works, so a transient API blip shouldn't block the modal.
  */
-export async function openPurchaseModal(recommendations: LocalRecommendation[]): Promise<void> {
+export async function openPurchaseModal(recommendations: LocalRecommendation[], capacityPercent = 100): Promise<void> {
+  currentPurchaseCapacityPercent = capacityPercent;
   currentPurchaseRecommendations = [...recommendations];
   // Initialise all indices as checked (issue #320: all selected by default).
   checkedPurchaseIndices = new Set(currentPurchaseRecommendations.map((_, i) => i));
@@ -4943,7 +5035,10 @@ export async function openPurchaseModal(recommendations: LocalRecommendation[]):
   // the time the modal opens.
   const seeds = currentPurchaseRecommendations.map((r) => resolvePerRecPaymentSeed(r, overridesByAccount));
   for (let i = 0; i < currentPurchaseRecommendations.length; i++) {
-    currentPurchaseRecommendations[i]!.payment = seeds[i]!.payment;
+    const seed = seeds[i]!;
+    currentPurchaseRecommendations[i] = seed.variant
+      ? { ...seed.variant, payment: seed.payment }
+      : { ...currentPurchaseRecommendations[i]!, payment: seed.payment };
   }
 
   while (container.firstChild) container.removeChild(container.firstChild);
@@ -5012,24 +5107,7 @@ export async function openPurchaseModal(recommendations: LocalRecommendation[]):
     // Wire radio changes to update state + show/hide warning.
     const updateExecuteMode = (): void => {
       currentExecuteMode = directRadio.checked ? 'direct' : '';
-      directWarning.hidden = currentExecuteMode !== 'direct';
-      if (currentExecuteMode === 'direct') {
-        // Compute total upfront from currently checked rows for the warning.
-        let totalUpfront = 0;
-        for (const idx of checkedPurchaseIndices) {
-          const r = currentPurchaseRecommendations[idx];
-          if (r) totalUpfront += r.upfront_cost;
-        }
-        while (directWarning.firstChild) directWarning.removeChild(directWarning.firstChild);
-        const icon = document.createElement('strong');
-        icon.textContent = 'Warning: ';
-        directWarning.appendChild(icon);
-        const text = document.createTextNode(
-          `This will charge $${totalUpfront.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} upfront immediately. ` +
-          'This bypasses the approval step. AWS allows cancellation within 24 hours via the Account & Billing console.',
-        );
-        directWarning.appendChild(text);
-      }
+      renderDirectExecuteWarning();
       // Update the submit button label to reflect the selected mode.
       const executeBtn = document.getElementById('execute-purchase-btn') as HTMLButtonElement | null;
       if (executeBtn) {
@@ -5278,6 +5356,11 @@ function updatePurchaseModalTotals(selectAllCb: HTMLInputElement): void {
     selectAllCb.checked = false;
     selectAllCb.indeterminate = true;
   }
+
+  // Issue #1903: the direct-execute warning's dollar total is derived from
+  // checkedPurchaseIndices too, so it must refresh on every checkbox toggle,
+  // not only when the radio itself changes.
+  renderDirectExecuteWarning();
 }
 
 // renderPurchaseModalRow builds one editable <tr> for the per-row
@@ -5364,13 +5447,12 @@ function renderPurchaseModalRow(idx: number, paymentSource: 'override' | 'rec' |
   effPctTd.appendChild(document.createTextNode(pct !== null ? pct.toFixed(1) + '%' : '—'));
   tr.appendChild(effPctTd);
 
-  // Term select (col 9). AWS/Azure/GCP commitments universally support 1y and 3y;
-  // on change we rederive Payment options for the new term and pick a
-  // still-valid value if the current one becomes unsupported.
+  // Term select (col 9). Options are the terms actually loaded for this
+  // cell (issue #1903) — an unpriced term is never offered.
   const termCell = document.createElement('td');
   const termSelect = document.createElement('select');
   termSelect.className = 'purchase-row-term';
-  for (const t of [1, 3]) {
+  for (const t of cellTermOptions(rec)) {
     const opt = document.createElement('option');
     opt.value = String(t);
     opt.textContent = formatTerm(t);
@@ -5380,13 +5462,13 @@ function renderPurchaseModalRow(idx: number, paymentSource: 'override' | 'rec' |
   termCell.appendChild(termSelect);
   tr.appendChild(termCell);
 
-  // Payment select (col 10). Options come from paymentOptionsFor (already
-  // filtered to supported values for this provider/service/term cell),
-  // so the user can never pick an unsupported combo through the UI.
+  // Payment select (col 10). Options are restricted to the (term, payment)
+  // combinations actually loaded for this cell (issue #1903), so the user
+  // can never pick a combo the API never priced.
   const paymentCell = document.createElement('td');
   const paymentSelect = document.createElement('select');
   paymentSelect.className = 'purchase-row-payment';
-  rebuildPaymentOptions(paymentSelect, rec.provider as CompatProvider, rec.service, rec.term as 1 | 3, (rec.payment ?? '') as CompatPayment);
+  rebuildPaymentOptions(paymentSelect, cellPaymentOptions(rec, rec.term as 1 | 3), (rec.payment ?? '') as BulkPurchasePayment | '');
   paymentCell.appendChild(paymentSelect);
   if (paymentSource === 'override') {
     const sourceNote = document.createElement('span');
@@ -5409,46 +5491,64 @@ function renderPurchaseModalRow(idx: number, paymentSource: 'override' | 'rec' |
     if (selectAllCb) updatePurchaseModalTotals(selectAllCb);
   });
 
+  // Issue #1903: swap in the loaded sibling variant for the selected
+  // (term, payment) and re-render the whole row so the cost cells, the
+  // Include checkbox, and both selects stay derived from one source. Term
+  // and Payment changes both funnel through this so neither can leave the
+  // row's price stale.
+  const applyVariantChange = (focusSelector: string): void => {
+    const term = parseInt(termSelect.value, 10) === 3 ? 3 : 1;
+    const payment = paymentSelect.value as BulkPurchasePayment;
+    const live = currentPurchaseRecommendations[idx];
+    if (!live) return;
+    const variant = pricedCellVariant(live, term, payment);
+    if (!variant) {
+      // Reachable: a sibling variant with a smaller count can floor to 0 at
+      // the modal's capacity. Keep the priced rec and put the selects back.
+      showToast({
+        message: `No priced ${formatTerm(term)} / ${payment} option for this row at ${currentPurchaseCapacityPercent}% capacity.`,
+        kind: 'warning',
+      });
+      termSelect.value = String(live.term);
+      rebuildPaymentOptions(paymentSelect, cellPaymentOptions(live, live.term as 1 | 3), (live.payment ?? '') as BulkPurchasePayment | '');
+      return;
+    }
+    currentPurchaseRecommendations[idx] = { ...variant, payment };
+    const fresh = renderPurchaseModalRow(idx, paymentSource);
+    tr.replaceWith(fresh);
+    fresh.querySelector<HTMLSelectElement>(focusSelector)?.focus();
+    const selectAllCb = document.getElementById('purchase-modal-select-all') as HTMLInputElement | null;
+    if (selectAllCb) updatePurchaseModalTotals(selectAllCb);
+  };
+
   termSelect.addEventListener('change', () => {
     const live = currentPurchaseRecommendations[idx];
     if (!live) return;
     const newTerm = parseInt(termSelect.value, 10) === 3 ? 3 : 1;
-    live.term = newTerm;
-    // Rebuild this row's payment options for the new term; if current
-    // payment is no longer supported, pick the first valid option and
-    // mirror back to live state.
-    rebuildPaymentOptions(
-      paymentSelect,
-      live.provider as CompatProvider,
-      live.service,
-      newTerm,
-      (live.payment ?? '') as CompatPayment,
-    );
-    live.payment = paymentSelect.value;
+    // Rebuild this row's payment options for the new term before applying —
+    // applyVariantChange reads paymentSelect.value, so it must already
+    // reflect the new term's loaded options.
+    rebuildPaymentOptions(paymentSelect, cellPaymentOptions(live, newTerm), (live.payment ?? '') as BulkPurchasePayment | '');
+    applyVariantChange('.purchase-row-term');
   });
 
-  paymentSelect.addEventListener('change', () => {
-    const live = currentPurchaseRecommendations[idx];
-    if (!live) return;
-    live.payment = paymentSelect.value;
-  });
+  paymentSelect.addEventListener('change', () => applyVariantChange('.purchase-row-payment'));
 
   return tr;
 }
 
-// rebuildPaymentOptions clears and re-populates a <select> with the
-// supported Payment options for a (provider, service, term) cell.
-// If `desired` is in the new option set, it stays selected; otherwise
-// the first option wins and the select's `.value` reflects that.
+// rebuildPaymentOptions clears and re-populates a <select> with the given
+// Payment options. If `desired` is in the new option set, it stays
+// selected; otherwise the first option wins and the select's `.value`
+// reflects that. Issue #1903: options are passed in by the caller
+// (cellPaymentOptions — loaded variants only) rather than derived here from
+// the full compat table, so an unpriced combination can never be offered.
 function rebuildPaymentOptions(
   select: HTMLSelectElement,
-  provider: CompatProvider,
-  service: string,
-  term: 1 | 3,
-  desired: CompatPayment | '',
+  options: readonly BulkPurchasePayment[],
+  desired: BulkPurchasePayment | '',
 ): void {
   while (select.firstChild) select.removeChild(select.firstChild);
-  const options = paymentOptionsFor(provider, service, term);
   let matched = false;
   for (const opt of options) {
     const o = document.createElement('option');

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -957,7 +957,13 @@ function loadedCellVariants(rec: LocalRecommendation): LocalRecommendation[] {
 // no such row was loaded or it scales to zero units at the modal's capacity.
 function pricedCellVariant(rec: LocalRecommendation, term: 1 | 3, payment: BulkPurchasePayment): LocalRecommendation | null {
   const v = loadedCellVariants(rec).find((c) => c.term === term && normalizeBulkPayment(c.payment) === payment);
-  return v ? scaleRecForCapacity(v, currentPurchaseCapacityPercent) : null;
+  if (!v) return null;
+  // `rec` reached the modal already scaled to currentPurchaseCapacityPercent:
+  // openPurchaseModal's only caller passes handleBulkPurchaseClick's scaled
+  // rows. Only the rows read from state.getRecommendations() are unscaled, so
+  // re-scaling the fallback push would halve count and cost a second time.
+  if (v === rec) return v;
+  return scaleRecForCapacity(v, currentPurchaseCapacityPercent);
 }
 
 // Distinct terms actually loaded for rec's cell, ascending. Used to build

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -4111,9 +4111,16 @@ export interface FanOutBucket {
 // the modal closes.
 let currentFanOutBuckets: FanOutBucket[] | null = null;
 
+// The renderer promises "This bucket will be skipped" from exactly this
+// check (renderFanOutBucketSection); submit and totals must agree with it
+// (issue #1904) so a bucket the UI marks skipped is never posted.
+function isSubmittableBucket(b: FanOutBucket): boolean {
+  return isBucketPaymentCompatible(b.recs, b.payment);
+}
+
 export function getFanOutBuckets(): FanOutBucket[] | null {
   if (!currentFanOutBuckets) return null;
-  return currentFanOutBuckets.map((b) => ({
+  return currentFanOutBuckets.filter(isSubmittableBucket).map((b) => ({
     ...b,
     // Deep-copy the per-rec map so callers can't mutate module state.
     perRecPayments: b.perRecPayments ? new Map(b.perRecPayments) : undefined,
@@ -4321,17 +4328,43 @@ async function openFanOutModal(
   while (container.firstChild) container.removeChild(container.firstChild);
 
   const summary = document.createElement('div');
+  summary.id = 'fanout-summary';
   summary.className = 'form-section fanout-summary';
+  renderFanOutSummary(summary, buckets);
+  container.appendChild(summary);
+
+  for (const b of buckets) {
+    container.appendChild(renderFanOutBucketSection(b));
+  }
+
+  openModal(modal);
+}
+
+// renderFanOutSummary rebuilds the fan-out modal's header — title, email
+// count, skipped-bucket note, and totals — from the submittable subset
+// (issue #1904), so what the user sees here matches exactly what
+// getFanOutBuckets() returns to app.ts on submit. Also disables the
+// Execute button when nothing is submittable.
+function renderFanOutSummary(summary: HTMLElement, buckets: FanOutBucket[]): void {
+  while (summary.firstChild) summary.removeChild(summary.firstChild);
+
+  const submittable = buckets.filter(isSubmittableBucket);
+  const skipped = buckets.length - submittable.length;
+
   const summaryTitle = document.createElement('h3');
   summaryTitle.textContent = `Bulk purchase — ${buckets.length} bucket${buckets.length === 1 ? '' : 's'}`;
   summary.appendChild(summaryTitle);
 
   const emailNote = document.createElement('p');
   emailNote.className = 'fanout-email-note';
-  emailNote.textContent = `Will send ${buckets.length} approval email${buckets.length === 1 ? '' : 's'} — one per bucket.`;
+  let emailText = `Will send ${submittable.length} approval email${submittable.length === 1 ? '' : 's'} — one per bucket.`;
+  if (skipped > 0) {
+    emailText += ` ${skipped} incompatible bucket${skipped === 1 ? '' : 's'} will be skipped.`;
+  }
+  emailNote.textContent = emailText;
   summary.appendChild(emailNote);
 
-  const totals = computeFanOutTotals(buckets);
+  const totals = computeFanOutTotals(submittable);
   const totalLine = (label: string, value: string, cls = ''): HTMLParagraphElement => {
     const p = document.createElement('p');
     const strong = document.createElement('strong');
@@ -4346,13 +4379,23 @@ async function openFanOutModal(
   summary.appendChild(totalLine('Total commitments', String(totals.totalCount)));
   summary.appendChild(totalLine('Total upfront', formatCurrency(totals.totalUpfront)));
   summary.appendChild(totalLine(`Total savings ${periodSuffix(fanOutPeriod)}`, formatCostForPeriod(totals.totalSavings, fanOutPeriod), 'savings'));
-  container.appendChild(summary);
 
-  for (const b of buckets) {
-    container.appendChild(renderFanOutBucketSection(b));
+  const executeBtn = document.getElementById('execute-purchase-btn') as HTMLButtonElement | null;
+  if (executeBtn) {
+    executeBtn.disabled = submittable.length === 0;
+    executeBtn.title = submittable.length === 0 ? 'No compatible buckets to submit' : '';
   }
+}
 
-  openModal(modal);
+// refreshFanOutSummary re-renders #fanout-summary from currentFanOutBuckets.
+// Called after a bucket's Payment change so a user who repairs a skipped
+// bucket sees the email count, skipped note, and totals follow immediately
+// (issue #1904) rather than only on the next modal open.
+function refreshFanOutSummary(): void {
+  if (!currentFanOutBuckets) return;
+  const summary = document.getElementById('fanout-summary');
+  if (!summary) return;
+  renderFanOutSummary(summary, currentFanOutBuckets);
 }
 
 function computeFanOutTotals(buckets: FanOutBucket[]): { totalCount: number; totalUpfront: number; totalSavings: number } {
@@ -4437,6 +4480,10 @@ function renderFanOutBucketSection(b: FanOutBucket): HTMLElement {
     }
     b.payment = next;
     renderStatus();
+    // Issue #1904: a payment fix here can move this bucket in or out of the
+    // submittable set, so the header's email count, skipped note, totals,
+    // and Execute-enabled state must follow immediately.
+    refreshFanOutSummary();
     // Re-sync any visible per-rec selects whose ids are NOT explicit
     // overrides: those rows follow the bucket default, so their displayed
     // value must track the new bucket payment. Rows with an explicit

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -4431,11 +4431,9 @@ function renderFanOutBucketSection(b: FanOutBucket): HTMLElement {
 
   const status = document.createElement('p');
   const renderStatus = (): void => {
-    // For mixed-SP buckets check compatibility per rec — every rec must
-    // be supported. For non-SP buckets every rec shares b.service so a
-    // single check is equivalent. The shared helper keeps this in sync
-    // with the same check at handleBulkPurchaseClick.
-    const compat = isBucketPaymentCompatible(b.recs, b.payment);
+    // Same predicate the submit filter and the header totals use, so the
+    // "will be skipped" label cannot disagree with what actually submits.
+    const compat = isSubmittableBucket(b);
     status.className = compat ? 'fanout-bucket-ok' : 'fanout-bucket-error';
     status.textContent = compat
       ? `${b.capacityPercent}% capacity · ${b.term}yr · ${b.payment}`


### PR DESCRIPTION
## What

Closes #1903 and #1904.

- Term and Payment edits select the loaded, priced sibling and update row costs, totals, warnings and the submitted recommendation together.
- Selection preserves capacity and stable purchase identity. Legacy payments resolve to actual priced rows or are explicitly excluded. A viable alternate payment remains available when another variant scales to zero.
- Incompatible fan-out buckets are excluded from both totals and submitted requests.
- Modal edits cannot re-enable Execute during submission. Cancellation and request cleanup restore availability from the current valid selection.

## Candidate and scope

Published HEAD: `23b6dc27422b18471057b6c12cd66507af12a852`.
Base: `5405fd1e90dffdb701a46d4b93868b947e1fbf05` (#2090).

The backend already reprices from stored recommendations following #2073. This PR fixes the frontend display and selection contract alongside that protection; it does not claim the backend trusts client prices. The account-scope guard from #2072 remains intact.

## Verification

Native macOS, Node 22.23.2, existing dependencies and shared npm cache:

- Focused regression run: 3 suites, 468 tests passed.
- Full Jest: 91 suites, 2,944 tests passed, 1 skipped.
- Typecheck passed; lint passed with 0 errors and 125 existing warnings.
- Full npm audit: 0 vulnerabilities.
- Production webpack build passed with its existing entrypoint-size warning. Bundle, TypeScript output and declarations were directed outside the worktree.
- Normal commit hooks passed without scanner exceptions, allowlist changes or bypasses. The exact decorative comments falsely flagged by #2030 were reduced to bare comments; comment-stripped transpilation was byte-identical.
- [Fresh-context independent Astra final-HEAD review](https://github.com/LeanerCloud/CUDly/pull/2071#issuecomment-5669185772): NO CONFIRMED FINDINGS across all five committed files.

The full suite/build ran on the candidate implementation before the final comment-only test cleanup; focused checks were repeated. The committed production sources were independently matched byte-for-byte to the browser bundle's source maps. This distinguishes implementation verification from a claim that every command ran after the commit object existed.

### Real Chrome, intercepted local API

Chrome 152 on macOS exercised the production bundle at the final HEAD: 14 scenarios passed, 13 purchase POSTs captured, 43 screenshots and 43 accessibility snapshots. Scenarios cover repricing and serialized payloads, identity exclusion, missing/empty/invalid legacy payments, mixed excluded rows, capacity-preserving alternate payments and repeated swaps, all-zero restoration, pending-edit protection, and fan-out submissions/skips.

Skipped-bucket edge cases deliberately injected unsupported RDS options; these are defensive fixtures, not naturally selectable choices. API requests were intercepted at loopback, nonlocal requests and WebSockets blocked, and the server independently rejected mutations. No application page errors or nonlocal requests were observed. No real purchase, authentication, email, cloud integration or deployment is claimed.

Production app SHA256: `fa135c0f09d21883b5e78bce62e9fcb3fbcf75980a9d407737565f6ea5d70805`.

Durable local reports:
- `~/.claude/projects/CUDly/recovery/pr2071-local-verification-20260914.txt`
- `~/.claude/projects/CUDly/recovery/pr2071-browser-7nJIx4/report.json`
- `~/.claude/projects/CUDly/recovery/pr2071-browser-7nJIx4/verification.txt`

Earlier September 11 temporary artifacts are no longer available. The September 14 evidence above supersedes their availability claims; the reason those old temporary files disappeared is unknown.

### Merge outcome

Merged normally on September 14 at 19:38:05 UTC as `596680d0350fb4f324120bde1fa338e66c62ee51`. All six exact-head CI workflows passed. The serialized full CodeRabbit retry covered all five files against the exact base and final HEAD with zero actionable findings; historical findings received inline dispositions before merge. The merged tree is byte-identical to the reviewed candidate.

[Complete merge-gate record](https://github.com/LeanerCloud/CUDly/pull/2071#issuecomment-5669740698). [Independent baseline-fail/final-pass scenario proof](https://github.com/LeanerCloud/CUDly/pull/2071#issuecomment-5669478097).

Post-merge workflows are being monitored separately. Linux verification stays in CI. Windows is unsupported.

## Follow-ups

- #2070: fan-out Payment edits need variant repricing.
- #2086: broader stale/Escape/cross-mode modal lifecycle.
- #2087 and #1865: separately scoped test/module decomposition.
- #2088: bulk request grouping by cloud account.
- #2091: backend stored identity needs service-detail selectors.
- #1635: existing capacity scaling leaves the on-demand denominator unscaled.
- #2030: repair the inverted custom secret-scanner pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Purchase options now show only available, correctly priced variants.
  - Variant selection accurately preserves service details, terms, payment methods, capacity, and submitted costs.
  - Legacy payment options now resolve to compatible capacity-scaled variants.
  - Invalid or unavailable options are excluded from totals and submissions, with skipped groups clearly reported.
  - Approval totals and direct-execution warnings reflect current selections.
  - Execution is disabled when no purchase groups can be submitted.
  - Purchase controls remain locked during submission to prevent duplicate requests.
  - Purchase controls and status messages reset correctly after completion or errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



