### PR TITLE
fix(azure): error instead of truncating silently at the pricing page cap

### DIFF
--- a/providers/azure/internal/pricing/retail_prices.go
+++ b/providers/azure/internal/pricing/retail_prices.go
@@ -42,10 +42,15 @@ type Page[T any] struct {
 // service clients use this default.
 const DefaultPageTimeout = 10 * time.Second
 
-// DefaultMaxPages caps the NextPageLink loop. The Azure Retail Prices API
-// paginates at 100 items per page, so 50 pages is 5000 items — more than
-// any realistic SKU/region/term query. The cap is purely a defence against
-// a server bug returning a NextPageLink that never empties.
+// DefaultMaxPages caps the NextPageLink loop. The Retail Prices API
+// (api-version 2023-01-01-preview) pages at about 1,000 items, so 50
+// pages is roughly 50,000 items. The largest filter any client issues
+// (a region-wide service catalogue, cosmosdb/search) measured 1 page on
+// 2026-09-08; the whole Virtual Machines catalogue for one region, which
+// no client requests, measured 16. The cap is a defence against a
+// server bug returning a NextPageLink that never empties. Reaching it
+// with a NextPageLink still pending is an error, never a truncated
+// result (#1963).
 const DefaultMaxPages = 50
 
 // FetchAll walks the Retail Prices API starting at initialURL, appending
@@ -54,7 +59,8 @@ const DefaultMaxPages = 50
 //   - a per-page timeout (pageTimeout) that's independent of the caller's
 //     ctx, so one slow page can't consume the caller's whole budget;
 //   - a max-pages cap (maxPages) against a server bug returning an
-//     infinite NextPageLink chain;
+//     infinite NextPageLink chain; hitting it with pages remaining is
+//     an error, not a truncated result;
 //   - a seen-URL guard against a self-referential NextPageLink.
 //
 // ctx's cancellation still propagates via context.WithTimeout(ctx, ...),
@@ -84,6 +90,9 @@ func FetchAll[T any](ctx context.Context, httpClient HTTPClient, initialURL stri
 		nextURL = page.NextPageLink
 	}
 
+	if nextURL != "" {
+		return nil, fmt.Errorf("pricing API result exceeds the %d-page cap (%d items read, NextPageLink still set)", maxPages, len(all))
+	}
 	return all, nil
 }
 

--- a/providers/azure/internal/pricing/retail_prices_test.go
+++ b/providers/azure/internal/pricing/retail_prices_test.go
@@ -60,6 +60,22 @@ func okJSONResponse(body string) *http.Response {
 	}
 }
 
+// scriptPageChain scripts n pages at https://prices.example/page<letter>,
+// each holding one item named after its letter and linking to the next;
+// the last page has an empty NextPageLink.
+func scriptPageChain(client *fakeHTTPClient, n int) {
+	for i := 0; i < n; i++ {
+		url := "https://prices.example/page" + string(rune('a'+i))
+		next := ""
+		if i < n-1 {
+			next = "https://prices.example/page" + string(rune('a'+i+1))
+		}
+		client.responses[url] = okJSONResponse(
+			`{"Items":[{"name":"` + string(rune('a'+i)) + `"}],"NextPageLink":"` + next + `"}`,
+		)
+	}
+}
+
 // TestFetchAll_MergesPages pins the multi-page walk: page 1 has a non-
 // empty NextPageLink, page 2 has an empty NextPageLink, all items are
 // merged into the returned slice in order.
@@ -94,29 +110,35 @@ func TestFetchAll_RejectsSelfReferentialNextPageLink(t *testing.T) {
 	assert.Contains(t, err.Error(), "self-referential")
 }
 
-// TestFetchAll_HonoursMaxPagesCap covers the defensive cap: if the server
-// returns a genuinely unbounded chain of fresh NextPageLinks, the walker
-// must stop after maxPages instead of running forever.
-func TestFetchAll_HonoursMaxPagesCap(t *testing.T) {
+// TestFetchAll_ErrorsWhenCapReachedWithPagesRemaining is the regression
+// test for #1963: a chain longer than maxPages must produce an error, not
+// the first maxPages pages with a nil error. The walker must still stop
+// fetching at the cap.
+func TestFetchAll_ErrorsWhenCapReachedWithPagesRemaining(t *testing.T) {
 	client := newFakeHTTPClient()
-	for i := 0; i < 10; i++ {
-		url := "https://prices.example/page" + string(rune('a'+i))
-		next := ""
-		if i < 9 {
-			next = "https://prices.example/page" + string(rune('a'+i+1))
-		}
-		client.responses[url] = okJSONResponse(
-			`{"Items":[{"name":"` + string(rune('a'+i)) + `"}],"NextPageLink":"` + next + `"}`,
-		)
-	}
+	scriptPageChain(client, 10)
 
-	// Cap at 3 — walker should read pages a, b, c only.
+	items, err := FetchAll[fakeItem](context.Background(), client, "https://prices.example/pagea", DefaultPageTimeout, 3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "3-page cap")
+	assert.Contains(t, err.Error(), "3 items read")
+	assert.Nil(t, items, "a truncated result must not be returned alongside the error")
+	assert.Len(t, client.calls, 3, "walker must not fetch beyond maxPages")
+}
+
+// TestFetchAll_ExactlyMaxPagesSucceeds pins the boundary: a chain of
+// exactly maxPages pages whose last page has an empty NextPageLink is
+// complete and must not be reported as truncated.
+func TestFetchAll_ExactlyMaxPagesSucceeds(t *testing.T) {
+	client := newFakeHTTPClient()
+	scriptPageChain(client, 3)
+
 	items, err := FetchAll[fakeItem](context.Background(), client, "https://prices.example/pagea", DefaultPageTimeout, 3)
 	require.NoError(t, err)
 	require.Len(t, items, 3)
 	assert.Equal(t, "a", items[0].Name)
 	assert.Equal(t, "c", items[2].Name)
-	assert.Len(t, client.calls, 3, "walker must not fetch beyond maxPages")
+	assert.Len(t, client.calls, 3)
 }
 
 // TestFetchAll_PerPageTimeout proves the per-page timeout is applied

--- a/providers/azure/services/cache/client.go
+++ b/providers/azure/services/cache/client.go
@@ -567,7 +567,7 @@ func (c *CacheClient) getRedisPricing(ctx context.Context, sku, region string, t
 }
 
 // fetchAzurePricing fetches pricing data from Azure Retail Prices API,
-// following NextPageLink until exhausted or the shared safety cap fires.
+// following NextPageLink until exhausted; hitting the shared page cap is an error.
 // Delegates pagination to pricing.FetchAll.
 func (c *CacheClient) fetchAzurePricing(ctx context.Context, serviceName, sku, region string) (*AzureRetailPrice, error) {
 	filter := fmt.Sprintf("serviceName eq '%s' and armRegionName eq '%s' and contains(armSkuName, '%s')",

--- a/providers/azure/services/compute/client.go
+++ b/providers/azure/services/compute/client.go
@@ -728,8 +728,8 @@ func (c *ComputeClient) getVMPricing(ctx context.Context, vmSize, region string,
 }
 
 // fetchAzurePricing fetches pricing data from Azure Retail Prices API,
-// following NextPageLink until exhausted (or the shared safety cap is
-// hit). Delegates the pagination walk to pricing.FetchAll so every
+// following NextPageLink until exhausted (hitting the shared page cap
+// is an error). Delegates the pagination walk to pricing.FetchAll so every
 // service client shares the same per-page timeout, seen-URL guard, and
 // max-pages cap — see providers/azure/internal/pricing for those
 // invariants.

--- a/providers/azure/services/cosmosdb/client.go
+++ b/providers/azure/services/cosmosdb/client.go
@@ -567,7 +567,7 @@ func (c *CosmosDBClient) getCosmosPricing(ctx context.Context, sku, region strin
 }
 
 // fetchAzurePricing fetches pricing data from Azure Retail Prices API,
-// following NextPageLink until exhausted or the shared safety cap fires.
+// following NextPageLink until exhausted; hitting the shared page cap is an error.
 // Delegates pagination to pricing.FetchAll.
 func (c *CosmosDBClient) fetchAzurePricing(ctx context.Context, filter string) (*AzureRetailPrice, error) {
 	baseURL := "https://prices.azure.com/api/retail/prices"

--- a/providers/azure/services/database/client.go
+++ b/providers/azure/services/database/client.go
@@ -586,7 +586,7 @@ func (c *DatabaseClient) getSQLPricing(ctx context.Context, sku, region string, 
 }
 
 // fetchAzurePricing fetches pricing data from Azure Retail Prices API,
-// following NextPageLink until exhausted or the shared safety cap fires.
+// following NextPageLink until exhausted; hitting the shared page cap is an error.
 // Delegates pagination to pricing.FetchAll — see
 // providers/azure/internal/pricing for the per-page timeout, max-pages
 // cap, and seen-URL guard invariants.


### PR DESCRIPTION
## What

Closes #1963.

`pricing.FetchAll` walked the Azure Retail Prices API, stopped at its page cap, and returned the pages collected so far with a **nil error**, so every caller read a truncated price list as a complete one. The self-referential-link guard nine lines above already returned an explicit error for its failure mode; the cap did not. It now does.

## This is a latent-defect fix, and the PR should say so

No filter the code issues reaches page two of the API today, and `GetOfferingDetails`, which every affected call site sits under, has no in-repo production caller. So **no user-facing behaviour changes**. What changes is that hitting the cap becomes an error instead of a silent truncation, which matters the moment either of those facts stops being true.

## The cap stays at 50, and the comment was wrong

The constant's comment claimed the API pages at 100 items. Measured live on 2026-09-08 against api-version `2023-01-01-preview`, it pages at roughly 1,000, so the cap is about 50,000 items rather than 5,000.

| Query the code issues | Pages | Items |
| --- | ---: | ---: |
| Cosmos DB, region-wide, eastus | 1 | 112 |
| Azure Search, region-wide | 1 | 32 |
| Compute, SKU-scoped | 1 | 9 |
| Whole VM catalogue for one region (no client issues this) | 16 | 15,483 |
| Global Cosmos DB | 7 | 6,577 |

Nothing the code issues reaches page two, and the widest plausible shape is 16 pages against a 50-page cap. The cap stays as the runaway-chain defence it was meant to be, the comment is corrected, and the fix is the error alone rather than a number pulled from nowhere.

## Verification

The regression test scripts a paginated response that still carries a page link when the cap is reached. It fails on the base commit with `An error is expected but got nil` and passes after, under `-race`.

`TestFetchAll_ExactlyMaxPagesSucceeds` is a **positive control**, not evidence of the fix: a chain filling exactly the cap with no further link must still succeed, and it passes both before and after. It scripts a 3-page chain against a cap of 3, so it exercises the boundary itself rather than a page short of it.

An independent reviewer ran six mutants of the fix and every one was killed, including an off-by-one on the page count, an inverted condition, a check against the wrong variable, and returning the partial slice alongside the error.

| Check | Result |
| --- | --- |
| `go test -count=1 -race ./...` in `providers/azure` | all 12 packages ok |
| `go vet ./...`, `gofmt -l` | clean |
| `gocyclo -over 10` on the touched file | clean (`FetchAll` 6 to 7) |
| `go build ./...` from the root | exit 0 |

No live reproduction is possible, since no real query reaches the cap. The scripted-server unit test is the scenario.

## Scope

Four service-client doc comments described the cap as a silent stop and are corrected. Those hunks are comment-only. Nothing else is touched.

## Noted while reviewing, not fixed here

`providers/azure/services/managedredis/client.go:355-357` falls through to `upfrontCost = totalCost` on an unknown payment option, where the other six clients fail loud. Pre-existing and out of scope for this PR; filed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Azure pricing retrieval now reports an error when the pagination limit is reached before all pricing results are fetched, preventing incomplete data from being returned silently.
  - Retrieval succeeds when all available pages are completed within the configured limit.
  - Error details identify the page limit and amount of data processed.

- **Documentation**
  - Updated Azure pricing documentation to clarify pagination behavior, page-size expectations, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->