### PR TITLE
sec(iac/aws): drop unconditioned account-wide KMS data-plane grant from deploy role

### DIFF
--- a/terraform/environments/aws/ci-cd-permissions/policy_guard_test.go
+++ b/terraform/environments/aws/ci-cd-permissions/policy_guard_test.go
@@ -1648,12 +1648,37 @@ var kmsDataPlaneActions = []string{
 	"kms:ReEncryptTo",
 }
 
+// actionKeyPresentPattern matches an `Action = ...` or `actions = ...`
+// assignment regardless of whether the value is a literal list/string this
+// test can read. It exists so TestKMSDataPlaneActionsAreNotUnconditionallyGranted
+// can tell "this statement grants nothing" (no Action key at all) apart from
+// "this statement grants something this test cannot read"
+// (`Action = local.something`): actionAssignmentPattern only matches the
+// latter's value shape, so a bare reference produces the exact same zero
+// match count as a statement with no Action key, and only the reference case
+// is a hole worth failing on (#1969).
+var actionKeyPresentPattern = regexp.MustCompile(`(?m)^[ \t]*(?:Action|actions)\s*=`)
+
+// kmsResourceScopingConditionKey is the condition key KMSMutateTaggedOnly
+// (policy_compute.tf) and KMSReadTaggedOnly (policy_compute_b.tf) key their
+// exemption on. A Condition that does not reference it (an unrelated key, or
+// none at all) restricts nothing this guard cares about, so its presence,
+// not merely a Condition's presence, is what earns the exemption below.
+const kmsResourceScopingConditionKey = "aws:ResourceTag/Project"
+
+// kmsGrantIsForResourceConditionKey is required IN ADDITION to
+// kmsResourceScopingConditionKey for kms:CreateGrant specifically: the tag
+// condition scopes which key the grant is created on, not who the grant
+// authorizes, so a CreateGrant gated on the tag alone still lets the deploy
+// role hand the ability to use a CUDly-tagged key to any grantee it names.
+const kmsGrantIsForResourceConditionKey = "kms:GrantIsForAWSResource"
+
 // TestKMSDataPlaneActionsAreNotUnconditionallyGranted is the KMS counterpart of
 // TestBoundaryGatedActionsAreNotUnconditionallyGranted: every deploy-role
 // identity policy in this directory may grant a kmsDataPlaneActions entry only
-// under a Condition. policy_boundary.tf is skipped on purpose: its
-// WorkloadServiceCeiling allows kms:* by design and, being a permissions
-// boundary, grants nothing on its own.
+// under a Condition actually scoped to a CUDly-owned key. policy_boundary.tf
+// is skipped on purpose: its WorkloadServiceCeiling allows kms:* by design
+// and, being a permissions boundary, grants nothing on its own.
 func TestKMSDataPlaneActionsAreNotUnconditionallyGranted(t *testing.T) {
 	scanned := 0
 	for _, f := range append(guardedPolicyFiles(t), iamFile) {
@@ -1667,17 +1692,32 @@ func TestKMSDataPlaneActionsAreNotUnconditionallyGranted(t *testing.T) {
 			}
 			for _, stmt := range stmts {
 				scanned++
-				if !effectIsAllowPattern.MatchString(stmt) || statementConditionBody(stmt) != "" {
+				if !effectIsAllowPattern.MatchString(stmt) {
 					continue
 				}
+
+				if !actionAssignmentPattern.MatchString(stmt) {
+					if actionKeyPresentPattern.MatchString(stmt) {
+						t.Errorf("%s: statement %q has an Action expression this test cannot read (not a literal list or quoted string, e.g. a local or var reference). IAM still grants whatever it resolves to, so a KMS data-plane action behind it is invisible to this guard (#1969). Gate the statement with a Condition scoped to %s, or write Action as literals", f, statementSid(stmt), kmsResourceScopingConditionKey)
+					}
+					continue
+				}
+
 				granted := extractActionListActions(stmt)
 				if n := countActionListStrings(stmt); n != len(granted) {
 					t.Errorf("%s: statement %q has %d Action entries but this test could parse only %d of them; an entry it cannot read is still granted by IAM, so it may be a KMS data-plane grant this guard never sees", f, statementSid(stmt), n, len(granted))
 				}
+
+				condBody := statementConditionBody(stmt)
+				scopedToProject := strings.Contains(condBody, kmsResourceScopingConditionKey)
 				for _, action := range kmsDataPlaneActions {
-					if actionPermitted(granted, action) {
-						t.Errorf("%s: statement %q grants %s with no Condition. Customer managed keys delegate to IAM by default, so this reaches every CMK in the account, not just CUDly's (#1969). Nothing on the deploy path needs it; if a CUDly symmetric key ever does, gate the grant on aws:ResourceTag/Project like KMSMutateTaggedOnly in policy_compute.tf (and CreateGrant additionally on kms:GrantIsForAWSResource)", f, statementSid(stmt), action)
+					if !actionPermitted(granted, action) {
+						continue
 					}
+					if scopedToProject && (action != "kms:CreateGrant" || strings.Contains(condBody, kmsGrantIsForResourceConditionKey)) {
+						continue
+					}
+					t.Errorf("%s: statement %q grants %s without a Condition properly scoped to a CUDly-owned key (needs %s, and for kms:CreateGrant also %s). Customer managed keys delegate to IAM by default, so an unscoped or wrongly-scoped grant reaches every CMK in the account, not just CUDly's (#1969). Nothing on the deploy path needs it; if a CUDly symmetric key ever does, gate it like KMSMutateTaggedOnly in policy_compute.tf", f, statementSid(stmt), action, kmsResourceScopingConditionKey, kmsGrantIsForResourceConditionKey)
 				}
 			}
 		})

--- a/terraform/environments/aws/ci-cd-permissions/policy_guard_test.go
+++ b/terraform/environments/aws/ci-cd-permissions/policy_guard_test.go
@@ -1634,8 +1634,10 @@ func TestPolicyDocumentsUseLiteralActionAndResourceLists(t *testing.T) {
 // and, because customer managed keys carry a default key policy that
 // delegates to IAM, reaches every CMK in the shared account (#1969). A grant
 // gated on aws:ResourceTag/Project, the KMSMutateTaggedOnly convention in
-// policy_compute.tf, or on kms:GrantIsForAWSResource for CreateGrant, still
-// passes this guard if a CUDly symmetric key ever needs one.
+// policy_compute.tf, still passes this guard if a CUDly symmetric key ever
+// needs one; kms:CreateGrant additionally needs kms:GrantIsForAWSResource,
+// since the tag alone scopes which key the grant targets, not who it
+// authorizes.
 var kmsDataPlaneActions = []string{
 	"kms:CreateGrant",
 	"kms:Decrypt",
@@ -1648,30 +1650,40 @@ var kmsDataPlaneActions = []string{
 	"kms:ReEncryptTo",
 }
 
-// actionKeyPresentPattern matches an `Action = ...` or `actions = ...`
-// assignment regardless of whether the value is a literal list/string this
-// test can read. It exists so TestKMSDataPlaneActionsAreNotUnconditionallyGranted
-// can tell "this statement grants nothing" (no Action key at all) apart from
-// "this statement grants something this test cannot read"
-// (`Action = local.something`): actionAssignmentPattern only matches the
-// latter's value shape, so a bare reference produces the exact same zero
-// match count as a statement with no Action key, and only the reference case
-// is a hole worth failing on (#1969).
-var actionKeyPresentPattern = regexp.MustCompile(`(?m)^[ \t]*(?:Action|actions)\s*=`)
+// kmsResourceScopingConditionKey and kmsResourceScopingTagValue are the
+// condition key and value KMSMutateTaggedOnly (policy_compute.tf) and
+// KMSReadTaggedOnly (policy_compute_b.tf) key their exemption on. Both are
+// pinned, not merely the key's presence: a Condition that references the key
+// with an unrelated value, or that inverts it (StringNotEquals), restricts
+// nothing this guard cares about either.
+const (
+	kmsResourceScopingConditionKey = "aws:ResourceTag/Project"
+	kmsResourceScopingTagValue     = "CUDly"
+)
 
-// kmsResourceScopingConditionKey is the condition key KMSMutateTaggedOnly
-// (policy_compute.tf) and KMSReadTaggedOnly (policy_compute_b.tf) key their
-// exemption on. A Condition that does not reference it (an unrelated key, or
-// none at all) restricts nothing this guard cares about, so its presence,
-// not merely a Condition's presence, is what earns the exemption below.
-const kmsResourceScopingConditionKey = "aws:ResourceTag/Project"
-
-// kmsGrantIsForResourceConditionKey is required IN ADDITION to
-// kmsResourceScopingConditionKey for kms:CreateGrant specifically: the tag
-// condition scopes which key the grant is created on, not who the grant
-// authorizes, so a CreateGrant gated on the tag alone still lets the deploy
-// role hand the ability to use a CUDly-tagged key to any grantee it names.
+// kmsGrantIsForResourceConditionKey closes the gap kmsResourceScopingConditionKey
+// leaves open for kms:CreateGrant specifically: the tag condition scopes
+// which key the grant is created ON, not who it authorizes, so CreateGrant
+// additionally needs this Bool condition pinned true, which permits the call
+// only when an AWS service integrated with KMS makes it on the deploy role's
+// behalf, never a direct caller naming an arbitrary grantee.
 const kmsGrantIsForResourceConditionKey = "kms:GrantIsForAWSResource"
+
+// kmsResourceScopingOperatorPattern matches kmsResourceScopingConditionKey in
+// KEY position (quoted, followed by "="), pinned to kmsResourceScopingTagValue
+// case-insensitively (matching the StringEqualsIgnoreCase these statements
+// use, per the tag-casing note in policy_compute.tf). Key position, not a
+// bare Contains, is what stops the key appearing only as a value, or inside a
+// trailing comment (readPolicySource strips only whole-line comments), from
+// earning the exemption; pinning the value is what stops a wrong tag value or
+// an inverted operator from earning it once combined with the operator name
+// check below.
+var kmsResourceScopingOperatorPattern = regexp.MustCompile(`(?i)"` + regexp.QuoteMeta(kmsResourceScopingConditionKey) + `"\s*=\s*"` + regexp.QuoteMeta(kmsResourceScopingTagValue) + `"`)
+
+// kmsGrantIsForResourceTruePattern matches kmsGrantIsForResourceConditionKey
+// in key position pinned to "true": "false" or any other value grants
+// nothing extra and must not earn the exemption.
+var kmsGrantIsForResourceTruePattern = regexp.MustCompile(`"` + regexp.QuoteMeta(kmsGrantIsForResourceConditionKey) + `"\s*=\s*"true"`)
 
 // TestKMSDataPlaneActionsAreNotUnconditionallyGranted is the KMS counterpart of
 // TestBoundaryGatedActionsAreNotUnconditionallyGranted: every deploy-role
@@ -1679,6 +1691,15 @@ const kmsGrantIsForResourceConditionKey = "kms:GrantIsForAWSResource"
 // under a Condition actually scoped to a CUDly-owned key. policy_boundary.tf
 // is skipped on purpose: its WorkloadServiceCeiling allows kms:* by design
 // and, being a permissions boundary, grants nothing on its own.
+//
+// Effect and Action are read the same fail-closed way boundaryAllowedActions
+// reads policy_boundary.tf: a statement not positively identified as a Deny
+// is treated as a grant, NotAction is refused outright because it cannot be
+// expressed as a bounded Action set, and a statement whose Action this test
+// cannot parse into literals is refused rather than silently skipped. A
+// one-line statement and a quoted "Action" key both hide the assignment from
+// actionAssignmentPattern's ^-anchored match the same way a local/var
+// reference does, so all three are the same failure here.
 func TestKMSDataPlaneActionsAreNotUnconditionallyGranted(t *testing.T) {
 	scanned := 0
 	for _, f := range append(guardedPolicyFiles(t), iamFile) {
@@ -1692,14 +1713,15 @@ func TestKMSDataPlaneActionsAreNotUnconditionallyGranted(t *testing.T) {
 			}
 			for _, stmt := range stmts {
 				scanned++
-				if !effectIsAllowPattern.MatchString(stmt) {
+				if statementEffect(stmt) == "Deny" {
 					continue
 				}
-
+				if strings.Contains(stmt, "NotAction") {
+					t.Errorf("%s: statement %q uses NotAction, which grants every action except the ones it names. A KMS data-plane action granted by omission this way is invisible to a guard that can only check a bounded Action set (#1969)", f, statementSid(stmt))
+					continue
+				}
 				if !actionAssignmentPattern.MatchString(stmt) {
-					if actionKeyPresentPattern.MatchString(stmt) {
-						t.Errorf("%s: statement %q has an Action expression this test cannot read (not a literal list or quoted string, e.g. a local or var reference). IAM still grants whatever it resolves to, so a KMS data-plane action behind it is invisible to this guard (#1969). Gate the statement with a Condition scoped to %s, or write Action as literals", f, statementSid(stmt), kmsResourceScopingConditionKey)
-					}
+					t.Errorf("%s: statement %q has no Action list this test can parse (not one attribute per line with a literal list or quoted string, e.g. a one-line statement, a quoted \"Action\" key, or a local/var reference). IAM still grants whatever it resolves to, so a KMS data-plane action behind it is invisible to this guard (#1969)", f, statementSid(stmt))
 					continue
 				}
 
@@ -1709,15 +1731,29 @@ func TestKMSDataPlaneActionsAreNotUnconditionallyGranted(t *testing.T) {
 				}
 
 				condBody := statementConditionBody(stmt)
-				scopedToProject := strings.Contains(condBody, kmsResourceScopingConditionKey)
+				ops := statementConditionOperators(stmt)
+				if opens := len(anyBlockOpenPattern.FindAllString(condBody, -1)); opens != len(ops) {
+					t.Errorf("%s: statement %q has a Condition block opening %d nested objects but this test parsed only %d of them as operators; an operator it cannot see is still ANDed in by IAM, so this guard cannot verify what actually scopes the grant", f, statementSid(stmt), opens, len(ops))
+				}
+
+				scopedToProject, grantIsForResource := false, false
+				for _, op := range ops {
+					switch op.name {
+					case "StringEquals", "StringEqualsIgnoreCase":
+						scopedToProject = scopedToProject || kmsResourceScopingOperatorPattern.MatchString(op.body)
+					case "Bool":
+						grantIsForResource = grantIsForResource || kmsGrantIsForResourceTruePattern.MatchString(op.body)
+					}
+				}
+
 				for _, action := range kmsDataPlaneActions {
 					if !actionPermitted(granted, action) {
 						continue
 					}
-					if scopedToProject && (action != "kms:CreateGrant" || strings.Contains(condBody, kmsGrantIsForResourceConditionKey)) {
+					if scopedToProject && (action != "kms:CreateGrant" || grantIsForResource) {
 						continue
 					}
-					t.Errorf("%s: statement %q grants %s without a Condition properly scoped to a CUDly-owned key (needs %s, and for kms:CreateGrant also %s). Customer managed keys delegate to IAM by default, so an unscoped or wrongly-scoped grant reaches every CMK in the account, not just CUDly's (#1969). Nothing on the deploy path needs it; if a CUDly symmetric key ever does, gate it like KMSMutateTaggedOnly in policy_compute.tf", f, statementSid(stmt), action, kmsResourceScopingConditionKey, kmsGrantIsForResourceConditionKey)
+					t.Errorf("%s: statement %q grants %s without a Condition properly scoped to a CUDly-owned key (needs %s = %q via StringEquals/StringEqualsIgnoreCase, and for kms:CreateGrant also %s = \"true\" via Bool). Customer managed keys delegate to IAM by default, so an unscoped or wrongly-scoped grant reaches every CMK in the account, not just CUDly's (#1969). Nothing on the deploy path needs it; if a CUDly symmetric key ever does, gate it like KMSMutateTaggedOnly in policy_compute.tf", f, statementSid(stmt), action, kmsResourceScopingConditionKey, kmsResourceScopingTagValue, kmsGrantIsForResourceConditionKey)
 				}
 			}
 		})

--- a/terraform/environments/aws/ci-cd-permissions/policy_guard_test.go
+++ b/terraform/environments/aws/ci-cd-permissions/policy_guard_test.go
@@ -1620,3 +1620,69 @@ func TestPolicyDocumentsUseLiteralActionAndResourceLists(t *testing.T) {
 		t.Fatalf("scanned zero statements across %v; this guard would pass vacuously", files)
 	}
 }
+
+// kmsDataPlaneActions are the KMS operations that read or write ciphertext,
+// or (CreateGrant) delegate the right to. No resource in terraform/modules
+// needs the deploy role to call any of them: the only CMK the modules create
+// on the AWS path (modules/compute/aws/lambda/signing-key.tf) is an
+// asymmetric SIGN_VERIFY key that cannot serve Encrypt, Decrypt or
+// GenerateDataKey at all, and every other encrypted resource (RDS storage,
+// Secrets Manager secrets, ECR, the S3 state bucket, Lambda environment
+// variables) uses an AWS managed key whose own key policy authorizes account
+// principals through the owning service, so no IAM grant is needed. An
+// unconditioned Allow of any of these therefore protects nothing CUDly owns
+// and, because customer managed keys carry a default key policy that
+// delegates to IAM, reaches every CMK in the shared account (#1969). A grant
+// gated on aws:ResourceTag/Project, the KMSMutateTaggedOnly convention in
+// policy_compute.tf, or on kms:GrantIsForAWSResource for CreateGrant, still
+// passes this guard if a CUDly symmetric key ever needs one.
+var kmsDataPlaneActions = []string{
+	"kms:CreateGrant",
+	"kms:Decrypt",
+	"kms:Encrypt",
+	"kms:GenerateDataKey",
+	"kms:GenerateDataKeyPair",
+	"kms:GenerateDataKeyPairWithoutPlaintext",
+	"kms:GenerateDataKeyWithoutPlaintext",
+	"kms:ReEncryptFrom",
+	"kms:ReEncryptTo",
+}
+
+// TestKMSDataPlaneActionsAreNotUnconditionallyGranted is the KMS counterpart of
+// TestBoundaryGatedActionsAreNotUnconditionallyGranted: every deploy-role
+// identity policy in this directory may grant a kmsDataPlaneActions entry only
+// under a Condition. policy_boundary.tf is skipped on purpose: its
+// WorkloadServiceCeiling allows kms:* by design and, being a permissions
+// boundary, grants nothing on its own.
+func TestKMSDataPlaneActionsAreNotUnconditionallyGranted(t *testing.T) {
+	scanned := 0
+	for _, f := range append(guardedPolicyFiles(t), iamFile) {
+		if f == boundaryFile {
+			continue
+		}
+		t.Run(f, func(t *testing.T) {
+			stmts := extractStatementBlocks(readPolicySource(t, f))
+			if len(stmts) == 0 {
+				t.Fatalf("%s: found zero Statement objects; the statement splitter in this test is broken and would otherwise pass vacuously", f)
+			}
+			for _, stmt := range stmts {
+				scanned++
+				if !effectIsAllowPattern.MatchString(stmt) || statementConditionBody(stmt) != "" {
+					continue
+				}
+				granted := extractActionListActions(stmt)
+				if n := countActionListStrings(stmt); n != len(granted) {
+					t.Errorf("%s: statement %q has %d Action entries but this test could parse only %d of them; an entry it cannot read is still granted by IAM, so it may be a KMS data-plane grant this guard never sees", f, statementSid(stmt), n, len(granted))
+				}
+				for _, action := range kmsDataPlaneActions {
+					if actionPermitted(granted, action) {
+						t.Errorf("%s: statement %q grants %s with no Condition. Customer managed keys delegate to IAM by default, so this reaches every CMK in the account, not just CUDly's (#1969). Nothing on the deploy path needs it; if a CUDly symmetric key ever does, gate the grant on aws:ResourceTag/Project like KMSMutateTaggedOnly in policy_compute.tf (and CreateGrant additionally on kms:GrantIsForAWSResource)", f, statementSid(stmt), action)
+					}
+				}
+			}
+		})
+	}
+	if scanned == 0 {
+		t.Fatalf("scanned zero statements; this guard would pass vacuously")
+	}
+}

--- a/terraform/environments/aws/ci-cd-permissions/policy_networking.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_networking.tf
@@ -162,18 +162,6 @@ resource "aws_iam_policy" "networking" {
         ]
         Resource = "*"
       },
-      {
-        Sid    = "KMS"
-        Effect = "Allow"
-        Action = [
-          "kms:CreateGrant",
-          "kms:Decrypt",
-          "kms:DescribeKey",
-          "kms:Encrypt",
-          "kms:GenerateDataKey",
-        ]
-        Resource = "*"
-      },
     ]
   })
 


### PR DESCRIPTION
## What

Closes #1969.

The CI/CD deploy role granted `kms:Decrypt`, `kms:Encrypt`, `kms:GenerateDataKey` and `kms:CreateGrant` on `Resource: "*"` with no condition. `CreateGrant` is the serious half: it is a permission-granting action, held account-wide by the identity that runs every deployment.

**The fix is deletion rather than a narrower scope, because the correct scope is empty.** Nothing on the deploy path uses any of the four.

## Why nothing needs them

Each claim was verified independently by a reviewer that did not write the change:

| Claim | Evidence |
| --- | --- |
| The only customer managed key the modules create is the OIDC signing key | `ECC_NIST_P256`, `SIGN_VERIFY`; KMS rejects encrypt, decrypt and data-key operations on it regardless of IAM |
| The SNS key module is never instantiated | no environment references it, and it is behind a flag defaulting to false |
| RDS, the seven secrets, Lambda env and the state bucket use AWS managed keys | no `kms_key_id` set anywhere in the modules, environment or tfvars; the backend uses SSE-S3 |
| ECR uses AES256 | `modules/registry/aws/main.tf:12` |
| `kms:DescribeKey`, the one action the deploy path uses, is already granted | `policy_compute.tf`, unaffected by this change |

The crux is that an **AWS managed key does not consult the caller's identity policy**. Its key policy is service-controlled and authorises through `kms:CallerAccount` and `kms:ViaService`; the service performs the operation on the caller's behalf. Only a customer managed key would depend on the identity policy, and the deploy path has none. So the removed statement was not adding permission to any working path.

`kms:CreateGrant` has one plausible consumer, EBS volumes on the NAT auto-scaling group. Those grants are created by the Auto Scaling service-linked role and authorised by the key's own policy, never by the caller of `CreateAutoScalingGroup`.

## The guard test

A new test asserts these four actions are never granted without a condition. It fails with exactly four errors on the unfixed tree and passes after.

Its teeth were checked in several directions: a single re-added action fails naming only that action; the same grant in a *different* policy file is caught; so is one in a brand-new file, since the test globs; a scalar `Action` string is caught; `kms:*` produces nine errors. A tag-gated grant passes, which is the intended escape hatch, and the shape a future customer managed key should use is documented in the test's comment.

**Known limitation, stated rather than hidden:** the guard reaches `policy_*.tf` only. An inline `aws_iam_role_policy` in `role.tf` would be invisible to it. There are none today, and the sibling guard has the same reach.

`policy_boundary.tf` is deliberately excluded: it carries `kms:*` as a permissions **ceiling** for roles the deploy role creates, not as a grant to the deploy role, so skipping it hides nothing.

The policy `description` is deliberately left saying "KMS". It is `ForceNew` on `aws_iam_policy`, confirmed in the provider source, so editing it would replace the managed policy and its attachment rather than update it in place. A slightly stale word is the cheaper problem.

## Operator runbook

**Nothing changes until a privileged human re-applies `ci-cd-permissions/`.** That module is applied manually by design, per the bootstrap-versus-runtime split.

**Before applying**, rule out a customer managed key the repository cannot see. Any one of these returning a CMK ARN means re-add the statement scoped to that key first:

```bash
aws s3api get-bucket-encryption --bucket <state-bucket>      # expect AES256, or aws:kms with no KMSMasterKeyID
aws secretsmanager describe-secret --secret-id <arn> --query KmsKeyId   # expect null, for each of the seven
aws rds describe-db-instances --query '...KmsKeyId'          # expect alias/aws/rds
aws lambda get-function-configuration --query KMSKeyArn      # expect null
```

**The plan must show exactly one change**: `~ aws_iam_policy.networking` updated in place, `policy` attribute only. Any `-/+` or attachment change means stop.

**After applying**, run the dev deploy workflow. Green means the removed actions were genuinely unused.

**If a hidden customer managed key exists**, the failure is loud and immediate: `AccessDeniedException` on `kms:Decrypt` at state read or secret read. Nothing is corrupted, and recovery is a revert plus re-apply, a matter of minutes.

**Unrelated but worth knowing:** if EBS encryption by default is ever enabled with a customer managed key in this account, the NAT auto-scaling group needs that key's policy to admit the Auto Scaling service-linked role. That is not caused by this PR, but it is the one KMS failure an operator might otherwise attribute to it.

## Verification

| Check | Result |
| --- | --- |
| `go test ./terraform/...` | ok, both packages |
| `terraform fmt -check -recursive`, `validate` | exit 0, configuration valid |
| `gofmt -l`, `go vet` | clean |

`terraform plan` needs bootstrap credentials and was not run here. That is the operator's step above.

---

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_01Fu9uWjxtDFx5HDKeMRt1jC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Improvements**
  - Tightened deployment permissions by removing unnecessary KMS access from the networking deployment policy.
  - Deployment workflows now have reduced access to encryption and key-management operations from this policy.

- **Tests**
  - Added automated checks to prevent unconditioned grants of sensitive KMS data-plane actions across guarded deployment policies.
  - Added validation to ensure these checks scan policy statements correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->