### PR TITLE
sec(iac/azure): pull and push ACR with Entra identities, disable the admin account

### DIFF
--- a/terraform/environments/azure/build.tf
+++ b/terraform/environments/azure/build.tf
@@ -20,8 +20,9 @@ module "build" {
   source_path = "${path.root}/../../.." # Root of the project (where Dockerfile is)
   # platform not set — auto-detected from builder host (Container Apps and AKS support arm64 and amd64)
 
-  # Registry login for ACR using admin credentials
-  registry_login_command = "echo '${nonsensitive(azurerm_container_registry.main.admin_password)}' | docker login ${azurerm_container_registry.main.login_server} -u ${azurerm_container_registry.main.admin_username} --password-stdin"
+  # Registry login with the caller's Entra identity (deploy SP in CI, az login
+  # locally); the principal needs AcrPush on the registry.
+  registry_login_command = "az acr login --name ${azurerm_container_registry.main.name}"
 
   # Build options
   skip_docker_build  = false

--- a/terraform/environments/azure/compute.tf
+++ b/terraform/environments/azure/compute.tf
@@ -97,10 +97,9 @@ module "compute_container_apps" {
     },
     var.additional_env_vars
   )
-  # ACR registry credentials for image pull
-  registry_server   = azurerm_container_registry.main.login_server
-  registry_username = azurerm_container_registry.main.admin_username
-  registry_password = azurerm_container_registry.main.admin_password
+  # Image pulls authenticate with the app's managed identity (AcrPull inside the module)
+  registry_server       = azurerm_container_registry.main.login_server
+  container_registry_id = azurerm_container_registry.main.id
 
   # Scheduled tasks (Logic Apps)
   #

--- a/terraform/environments/azure/registry.tf
+++ b/terraform/environments/azure/registry.tf
@@ -7,16 +7,14 @@ resource "azurerm_container_registry" "main" {
   resource_group_name = azurerm_resource_group.main.name
   location            = var.location
   sku                 = "Basic"
-  admin_enabled       = true # Enables username/password login for docker push
+  admin_enabled       = false
 
   tags = local.common_tags
 }
 
-# Grant Container Apps managed identity permission to pull images
-resource "azurerm_role_assignment" "acr_pull" {
-  count = var.compute_platform == "container-apps" && length(module.compute_container_apps) > 0 ? 1 : 0
-
-  scope                = azurerm_container_registry.main.id
-  role_definition_name = "AcrPull"
-  principal_id         = module.compute_container_apps[0].managed_identity_principal_id
+# The Container App pulls with its user-assigned identity; the AcrPull grant
+# lives inside the container-apps module so the app can depend on it.
+moved {
+  from = azurerm_role_assignment.acr_pull[0]
+  to   = module.compute_container_apps[0].azurerm_role_assignment.acr_pull
 }

--- a/terraform/modules/compute/azure/container-apps/main.tf
+++ b/terraform/modules/compute/azure/container-apps/main.tf
@@ -85,14 +85,10 @@ resource "azurerm_container_app" "main" {
     identity_ids = [azurerm_user_assigned_identity.container_app.id]
   }
 
-  # Registry authentication
-  dynamic "registry" {
-    for_each = var.registry_server != "" ? [1] : []
-    content {
-      server               = var.registry_server
-      username             = var.registry_username
-      password_secret_name = "registry-password"
-    }
+  # Registry authentication: pull with the user-assigned identity (AcrPull below)
+  registry {
+    server   = var.registry_server
+    identity = azurerm_user_assigned_identity.container_app.id
   }
 
   # Container configuration
@@ -220,19 +216,15 @@ resource "azurerm_container_app" "main" {
     }
   }
 
-  # Registry password secret (for ACR admin auth)
-  dynamic "secret" {
-    for_each = var.registry_server != "" ? [1] : []
-    content {
-      name  = "registry-password"
-      value = var.registry_password
-    }
-  }
-
   tags = merge(var.tags, {
     managed_by   = "terraform"
     architecture = "x86_64"
   })
+
+  # Ordering only, not a propagation wait: the first revision's image pull
+  # needs AcrPull to exist. If RBAC has not propagated yet the revision fails
+  # to provision and the apply errors; re-running the apply recovers.
+  depends_on = [azurerm_role_assignment.acr_pull]
 }
 
 # ==============================================
@@ -252,6 +244,13 @@ locals {
   # plan time. scope is ForceNew on azurerm_role_assignment, so it must match the
   # casing Azure returns in resource IDs; the caller normalises for that.
   subscription_resource_id = "/subscriptions/${var.subscription_id}"
+}
+
+# AcrPull: lets the container app's identity pull the image from the registry.
+resource "azurerm_role_assignment" "acr_pull" {
+  scope                = var.container_registry_id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.container_app.principal_id
 }
 
 # Cost Management Reader: grants access to Azure Consumption API (reservation

--- a/terraform/modules/compute/azure/container-apps/variables.tf
+++ b/terraform/modules/compute/azure/container-apps/variables.tf
@@ -192,20 +192,11 @@ variable "custom_domains" {
 variable "registry_server" {
   description = "Container registry server URL (e.g. myacr.azurecr.io)"
   type        = string
-  default     = ""
 }
 
-variable "registry_username" {
-  description = "Container registry username (for admin auth)"
+variable "container_registry_id" {
+  description = "Container registry ARM resource ID, the scope of the AcrPull grant to the app's managed identity"
   type        = string
-  default     = ""
-}
-
-variable "registry_password" {
-  description = "Container registry password (for admin auth)"
-  type        = string
-  default     = ""
-  sensitive   = true
 }
 
 variable "tags" {


### PR DESCRIPTION
## What

Closes #1970.

The Azure Container Registry had its admin account enabled, and both sides of the pipeline used it. CI authenticated with the static admin password to push images, and the Container App pulled with the same password stored as a `registry-password` secret. The deploy workflow also passed it through `nonsensitive()` at the login step, so the password was printed in plaintext into every Azure deploy log.

Both halves now use Entra identities. CI pushes through its existing OIDC login, the app pulls with the user-assigned managed identity it already has attached, the stored secret is gone, and the admin account is disabled.

## Both halves were proven, not assumed

An independent reviewer read the locked provider's source rather than trusting the plan.

**Pull.** The new `registry { identity = ... }` block references the same user-assigned identity the app already carries. That is the form the provider expects: `registry.identity` takes the identity's resource id, and validation requires exactly one of an identity or a username and password pair. Registry and secret changes are folded into a single update call, so there is no window where the registry references a deleted secret.

**Push.** The deploy role's definition carries a `Microsoft.ContainerRegistry/registries/*` action with no exclusions. Azure RBAC wildcards match across segments, so it covers both control-plane actions behind AcrPush and the read that resolves the login server. The workflow performs its OIDC login in the same job before Terraform runs, so the registry login inherits those credentials. The rollback workflow has the same login before its apply and is covered too.

**The `moved` block.** The reviewer rebuilt its shape independently against three states: existing state moves with zero changes, fresh state produces a single add, and the block does not error when the module's count is zero. The role assignment keeps the same principal, role and scope, so the moved instance has no attribute diff.

## Two operational ceilings, neither blocking

The OIDC token cannot silently refresh, so a run where more than roughly an hour elapses between the Azure login and the image push fails at the push. The steps in between include an up-to-15-minute resource-group deletion wait, so normal runs sit well inside the limit. The old static login had no such ceiling.

The first plan after deploy may show a cosmetic no-op diff on the registry identity attribute if the service echoes different casing than was submitted. That is a display difference, not a pull failure.

**Once per registry, before deploying:** confirm `az acr show -n $ACR --query roleAssignmentMode` returns legacy permissions or nothing. If a registry was switched to ABAC repository permissions, the AcrPull and AcrPush roles stop granting data-plane access and both halves fail. The provider version in use does not expose this attribute, so it cannot be checked in code.

## Operator runbook

**Deploy first, rotate second.** This is the reverse of what the original plan specified, and the reason matters. Rotating the admin passwords before deploying invalidates the password the running app still holds in its stored secret, so pulls fail for the entire deploy, roughly 10 to 30 minutes, not the brief window inside a single apply. On production, which runs two replicas, any restart or scale-out in that window cannot pull. For dev there is a second problem: any other push to main between the rotation and this merge runs the old code, which refreshes the renewed password and prints it again in a fresh log.

Per environment:

1. Deploy the new code. Merge for dev; dispatch the workflow for staging and production.
2. Confirm the app is on the identity and the newest revision is healthy:

```bash
az containerapp show -g "$RG" -n "$APP" --query 'properties.configuration.registries'
az containerapp revision list -g "$RG" -n "$APP" \
  --query '[].{name:name,state:properties.provisioningState,healthy:properties.healthState}'
```

3. Rotate in one line. Admin is enabled for seconds, and nothing uses it any more:

```bash
az acr update -n "$ACR" --admin-enabled true && \
  az acr credential renew -n "$ACR" --password-name password && \
  az acr credential renew -n "$ACR" --password-name password2 && \
  az acr update -n "$ACR" --admin-enabled false
```

4. Verify `az acr show -n "$ACR" --query adminUserEnabled` returns false.

**If a rotation is missed and admin is already disabled**, renewal is refused, but the same one-liner above recovers it. Do not leave admin enabled afterwards. Terraform would disable it on the next apply, but the old password stays live until then.

**On a brand-new environment**, the first revision can fail its pull with a 401 before the role assignment propagates. Re-run the apply. Do not add credentials to work around it. The `depends_on` edge orders creation but cannot wait for RBAC propagation, which is why the existing three environments are unaffected: their assignment has existed for months and is only being moved.

## Leftovers

A repository-wide search for admin and registry credential references returns only the AWS build path, which uses a different registry and is unchanged, the unused Azure registry module, which already defaults admin off, and the application's own bootstrap admin login secret, which is unrelated to the registry. No workflow, document or variables file referenced the ACR admin account.

## Verification

| Check | Result |
| --- | --- |
| `terraform fmt -check -recursive`, `validate` in both environment and module | exit 0 |
| tflint, all module types | exit 0, no output |
| trivy config, high and critical | exit 0 |
| the four Azure Key Vault and role parity guard scripts | exit 0; 13 and 78 assertions passed |

`terraform plan` and `apply` need Azure credentials and are the operator's steps above.

---

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_01Fu9uWjxtDFx5HDKeMRt1jC
