### PR TITLE
sec(scripts): git-secrets allowlist matched whole lines and whitelisted most of the repo

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -54,10 +54,15 @@
 # and three of them (Azure connection string, PostgreSQL and MySQL DSN
 # detectors, verified empirically -- MongoDB's does not) match their own
 # registration line. Each entry below is anchored on the path, the line
-# number, AND the full added pattern, not just the "git secrets --add '"
-# command prefix -- a prefix-only anchor would whitelist a secret appended
-# to ANY registration line in this file, which is exactly the #1972 hole
-# this allowlist exists to close, reintroduced at the scale of one file.
+# number, AND the entire line as it appears in that file (including the
+# trailing comment), with a trailing $ -- not just the "git secrets --add
+# '" command prefix, and not just the added pattern with the anchor left
+# open at the end. A prefix-only anchor whitelists a secret appended to
+# ANY registration line in this file; an anchor missing the trailing $
+# whitelists a secret appended to the END of one of these three specific
+# lines. Both are the #1972 hole reintroduced at a smaller scale, and both
+# were caught only by a fixture exercising exactly that mutation -- add
+# one for any future entry in this block that isn't already covered.
 #
 # Each entry below also replaces one letter of its own trigger substring
 # with a single-character bracket expression, e.g. "Protoco[l]" for
@@ -68,15 +73,10 @@
 # suppress (confirmed empirically: without this, the .gitallowed
 # self-scan case below fails -- and note this comment must not spell any
 # of those spans out literally either, for the same reason).
-^scripts/setup-git-secrets\.sh:[0-9]+:git secrets --add 'DefaultEndpointsProtoco[l]=https'
-^scripts/setup-git-secrets\.sh:[0-9]+:git secrets --add 'postgre[s]://\[\^:\]\+:\[\^@\]\+@'
-^scripts/setup-git-secrets\.sh:[0-9]+:git secrets --add 'mysq[l]://\[\^:\]\+:\[\^@\]\+@'
+^scripts/setup-git-secrets\.sh:[0-9]+:git secrets --add 'DefaultEndpointsProtoco[l]=https'                      # Azure Connection String$
+^scripts/setup-git-secrets\.sh:[0-9]+:git secrets --add 'postgre[s]://\[\^:\]\+:\[\^@\]\+@'                           # PostgreSQL$
+^scripts/setup-git-secrets\.sh:[0-9]+:git secrets --add 'mysq[l]://\[\^:\]\+:\[\^@\]\+@'                              # MySQL$
 # Truncated PEM fixtures in cmd/configure_test.go: a PEM header followed by
 # "\n..." is never a key body. Written without "BEGIN" so this line itself
 # does not trip the PEM detector.
 PRIVATE KEY-----\\n(MIIEvQIBADANBg)?\.\.\.
-# Go format-string DSN (fmt.Sprintf with "%s" in the credential position,
-# e.g. building a connection string from parsed config). Not currently
-# present in the tree, but a recurring, benign Go idiom the DSN detectors
-# must not flag; scripts/test-git-secrets-allowlist.sh exercises it.
-postgres://%s:%s@

--- a/.gitallowed
+++ b/.gitallowed
@@ -10,8 +10,11 @@
 # DO NOT add a real account ID here. If a real account ID lands in the repo,
 # rotate it and treat the leak seriously instead of silencing the scanner.
 #
-# Format: one regex per line, matched against each line of file content
-# (path-scoping is not supported by .gitallowed).
+# Format: one regex per line, matched against the scanner's whole
+# "path:line:content" output line (not just the file content), so an entry
+# may anchor on the path with "^path:[0-9]+:". Every entry must still be a
+# synthetic literal or one known benign line, never a bare keyword: a
+# keyword whitelists every line that happens to contain it (#1972).
 
 # Sequential test placeholders (ascending and descending).
 123456789012
@@ -46,3 +49,18 @@
 # UUID-shaped account ID used in handler_accounts_test.go (synthetic, not a
 # real subscription/account).
 11111111-1111-1111-1111-111111111111
+
+# scripts/setup-git-secrets.sh registers its detectors as literal regex text and
+# three of them (Azure connection string, PostgreSQL and MySQL DSN detectors)
+# match their own registration line. Anchored on the path AND the command so
+# this cannot cover any file but the script.
+^scripts/setup-git-secrets\.sh:[0-9]+:git secrets --add '
+# Truncated PEM fixtures in cmd/configure_test.go: a PEM header followed by
+# "\n..." is never a key body. Written without "BEGIN" so this line itself
+# does not trip the PEM detector.
+PRIVATE KEY-----\\n(MIIEvQIBADANBg)?\.\.\.
+# Go format-string DSN (fmt.Sprintf with "%s" in the credential position,
+# e.g. building a connection string from parsed config). Not currently
+# present in the tree, but a recurring, benign Go idiom the DSN detectors
+# must not flag; scripts/test-git-secrets-allowlist.sh exercises it.
+postgres://%s:%s@

--- a/.gitallowed
+++ b/.gitallowed
@@ -50,11 +50,27 @@
 # real subscription/account).
 11111111-1111-1111-1111-111111111111
 
-# scripts/setup-git-secrets.sh registers its detectors as literal regex text and
-# three of them (Azure connection string, PostgreSQL and MySQL DSN detectors)
-# match their own registration line. Anchored on the path AND the command so
-# this cannot cover any file but the script.
-^scripts/setup-git-secrets\.sh:[0-9]+:git secrets --add '
+# scripts/setup-git-secrets.sh registers its detectors as literal regex text
+# and three of them (Azure connection string, PostgreSQL and MySQL DSN
+# detectors, verified empirically -- MongoDB's does not) match their own
+# registration line. Each entry below is anchored on the path, the line
+# number, AND the full added pattern, not just the "git secrets --add '"
+# command prefix -- a prefix-only anchor would whitelist a secret appended
+# to ANY registration line in this file, which is exactly the #1972 hole
+# this allowlist exists to close, reintroduced at the scale of one file.
+#
+# Each entry below also replaces one letter of its own trigger substring
+# with a single-character bracket expression, e.g. "Protoco[l]" for
+# "Protocol". This is a no-op for matching (as a regex, [l] matches the
+# literal letter l exactly like l would) but it breaks the contiguous
+# trigger span each entry is built from, so .gitallowed does not need to
+# allow-list ITSELF against the very patterns these entries exist to
+# suppress (confirmed empirically: without this, the .gitallowed
+# self-scan case below fails -- and note this comment must not spell any
+# of those spans out literally either, for the same reason).
+^scripts/setup-git-secrets\.sh:[0-9]+:git secrets --add 'DefaultEndpointsProtoco[l]=https'
+^scripts/setup-git-secrets\.sh:[0-9]+:git secrets --add 'postgre[s]://\[\^:\]\+:\[\^@\]\+@'
+^scripts/setup-git-secrets\.sh:[0-9]+:git secrets --add 'mysq[l]://\[\^:\]\+:\[\^@\]\+@'
 # Truncated PEM fixtures in cmd/configure_test.go: a PEM header followed by
 # "\n..." is never a key body. Written without "BEGIN" so this line itself
 # does not trip the PEM detector.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -946,9 +946,20 @@ jobs:
           persist-credentials: false
 
       - name: Install git-secrets
+        # The 1.3.0 tag is mutable in principle, so clone it and then assert
+        # HEAD resolves to the exact commit verified at the time this was
+        # written (`git ls-remote --tags` against the upstream repo) before
+        # trusting it enough to `sudo make install`.
+        env:
+          GIT_SECRETS_SHA: ad82d68ee924906a0401dfd48de5057731a9bc84
         run: |
           set -euo pipefail
           git clone --depth 1 --branch 1.3.0 https://github.com/awslabs/git-secrets.git /tmp/git-secrets
+          resolved="$(git -C /tmp/git-secrets rev-parse HEAD)"
+          if [ "${resolved}" != "${GIT_SECRETS_SHA}" ]; then
+            echo "git-secrets 1.3.0 tag resolved to ${resolved}, expected ${GIT_SECRETS_SHA}" >&2
+            exit 1
+          fi
           sudo make -C /tmp/git-secrets install
 
       - name: Run allowlist self-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -931,8 +931,7 @@ jobs:
 
   # Self-test for the git-secrets allowlist (#1972): asserts, through the
   # real pre-commit hook scan path, that secret-shaped fixtures are still
-  # caught and that the documented false positives still scan clean. Not
-  # part of ci-success yet, so it cannot block unrelated PRs while it beds in.
+  # caught and that the documented false positives still scan clean.
   git-secrets-allowlist:
     name: git-secrets allowlist self-test
     runs-on: ubuntu-latest
@@ -1110,6 +1109,7 @@ jobs:
       - azure-role-parity
       - aws-iam-parity
       - gcp-secret-scope
+      - git-secrets-allowlist
       - ecr-delete-selection
       - rds-deletion-protection-scope
       - aws-tfstate-platform-key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -929,6 +929,31 @@ jobs:
       - name: Run guard script self-tests
         run: bash scripts/test-gcp-secret-scope.sh
 
+  # Self-test for the git-secrets allowlist (#1972): asserts, through the
+  # real pre-commit hook scan path, that secret-shaped fixtures are still
+  # caught and that the documented false positives still scan clean. Not
+  # part of ci-success yet, so it cannot block unrelated PRs while it beds in.
+  git-secrets-allowlist:
+    name: git-secrets allowlist self-test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install git-secrets
+        run: |
+          set -euo pipefail
+          git clone --depth 1 --branch 1.3.0 https://github.com/awslabs/git-secrets.git /tmp/git-secrets
+          sudo make -C /tmp/git-secrets install
+
+      - name: Run allowlist self-tests
+        run: bash scripts/test-git-secrets-allowlist.sh
+
   # Assert that the ECR repository selector used by destroy-fargate-dev.yml and
   # cleanup-staging.yml picks the repository each state owns and nothing else.
   # The consumers force-delete what the selector prints, so both directions are

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -172,14 +172,25 @@ jobs:
           sh /tmp/trivy-install.sh -b /usr/local/bin "${TRIVY_VERSION}"
 
       - name: Install git-secrets
-        # Pinned to a release tag rather than master HEAD. After install
-        # we register the AWS pattern set and ASSERT at least one pattern
-        # was registered — without the assert, a registration failure
-        # produces a patternless scanner that exits 0 unconditionally,
-        # leaving the gate silently downgraded.
+        # Pinned to a release tag rather than master HEAD. The tag is
+        # mutable in principle, so also assert HEAD resolves to the exact
+        # commit verified at the time this was written (`git ls-remote
+        # --tags` against the upstream repo) before trusting it enough to
+        # `sudo make install`. After install we register the AWS pattern
+        # set and ASSERT at least one pattern was registered — without the
+        # assert, a registration failure produces a patternless scanner
+        # that exits 0 unconditionally, leaving the gate silently
+        # downgraded.
+        env:
+          GIT_SECRETS_SHA: ad82d68ee924906a0401dfd48de5057731a9bc84
         run: |
           set -euo pipefail
           git clone --depth 1 --branch 1.3.0 https://github.com/awslabs/git-secrets.git /tmp/git-secrets
+          resolved="$(git -C /tmp/git-secrets rev-parse HEAD)"
+          if [ "${resolved}" != "${GIT_SECRETS_SHA}" ]; then
+            echo "git-secrets 1.3.0 tag resolved to ${resolved}, expected ${GIT_SECRETS_SHA}" >&2
+            exit 1
+          fi
           sudo make -C /tmp/git-secrets install
           git secrets --register-aws --global
           git secrets --list --global | grep -q '.' || {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Align pre-commit gocyclo threshold (10) with CI pipeline
 - Pin tool versions in GitHub Actions for reproducible builds
 - Update README Go version badge to match go.mod (1.25+)
+- The local git-secrets setup script aborted on its PEM pattern and, when
+  patched past that, made every scan fail on an invalid regex; its keyword
+  allowlist whitelisted whole Terraform and test-file lines. Allowlisting now
+  lives in `.gitallowed` as literal entries and the PEM detector covers
+  PKCS#8 keys (#1972)
 
 ## [0.9.0] - 2026-03-06
 

--- a/scripts/setup-git-secrets.sh
+++ b/scripts/setup-git-secrets.sh
@@ -53,7 +53,6 @@ git secrets --add '[^A-Za-z0-9/+=]{40}[^A-Za-z0-9/+=]'                 # AWS Sec
 git secrets --add 'aws(.{0,20})?['\''"][0-9a-zA-Z/+]{40}['\''"]'       # AWS Credentials
 
 # GCP patterns
-git secrets --add 'type.*service_account'                               # GCP Service Account JSON
 git secrets --add 'AIza[0-9A-Za-z_-]{35}'                              # GCP API Key
 
 # Azure patterns
@@ -63,46 +62,17 @@ git secrets --add 'DefaultEndpointsProtocol=https'                      # Azure 
 git secrets --add 'password\s*[=:]\s*['\''"][^'\''"]{8,}'             # Password with quoted value
 git secrets --add 'api[_-]?key\s*[=:]\s*['\''"][^'\''"]{8,}'         # API key with quoted value
 git secrets --add 'secret[_-]?key\s*[=:]\s*['\''"][^'\''"]{8,}'      # Secret key with quoted value
-git secrets --add '-----BEGIN (RSA|DSA|EC|OPENSSH) PRIVATE KEY-----'  # PEM private keys
+git secrets --add 'BEGIN[[:space:]]((RSA|DSA|EC|OPENSSH|ENCRYPTED)[[:space:]])?PRIVATE[[:space:]]KEY-----'  # PEM private keys
 
 # Database connection strings
 git secrets --add 'postgres://[^:]+:[^@]+@'                           # PostgreSQL
 git secrets --add 'mysql://[^:]+:[^@]+@'                              # MySQL
 git secrets --add 'mongodb(\+srv)?://[^:]+:[^@]+@'                    # MongoDB
 
-# Add allowed patterns (things that look like secrets but aren't)
-echo ""
-echo "Adding allowed patterns (false positives)..."
-
-# Terraform variables and outputs
-git secrets --add --allowed 'var\.'
-git secrets --add --allowed 'local\.'
-git secrets --add --allowed 'output\.'
-git secrets --add --allowed 'data\.'
-
-# Test files
-git secrets --add --allowed '_test\.go'
-git secrets --add --allowed 'testdata/'
-git secrets --add --allowed 'test_password'
-git secrets --add --allowed 'test_secret'
-
-# Documentation and examples
-git secrets --add --allowed 'example\.com'
-git secrets --add --allowed 'YOUR_'
-git secrets --add --allowed '<your-'
-git secrets --add --allowed 'placeholder'
-
-# Go code patterns (function signatures, struct fields, variable names)
-git secrets --add --allowed 'func.*password'
-git secrets --add --allowed 'func.*secret'
-git secrets --add --allowed 'func.*token'
-git secrets --add --allowed 'Password\s+string'
-git secrets --add --allowed 'Secret\s+string'
-git secrets --add --allowed 'Token\s+string'
-
-# Terraform resource references
-git secrets --add --allowed 'resource\s'
-git secrets --add --allowed 'module\.'
+# Allowed patterns live in .gitallowed (versioned, applied by every scan, including CI).
+# They are matched against the whole "path:line:content" scanner output line, so an entry
+# must describe the benign literal or anchor on the path; a bare keyword whitelists
+# every line that contains it (#1972).
 
 echo -e "${GREEN}✓ Secret patterns registered${NC}"
 

--- a/scripts/setup-git-secrets.sh
+++ b/scripts/setup-git-secrets.sh
@@ -54,7 +54,7 @@ git secrets --add 'aws(.{0,20})?['\''"][0-9a-zA-Z/+]{40}['\''"]'       # AWS Cre
 
 # GCP patterns
 git secrets --add 'type.*service_account'                               # GCP Service Account JSON
-git secrets --add 'AIza[0-9A-Za-z-_]{35}'                              # GCP API Key
+git secrets --add 'AIza[0-9A-Za-z_-]{35}'                              # GCP API Key
 
 # Azure patterns
 git secrets --add 'DefaultEndpointsProtocol=https'                      # Azure Connection String

--- a/scripts/setup-git-secrets.sh
+++ b/scripts/setup-git-secrets.sh
@@ -30,6 +30,19 @@ echo -e "${GREEN}✓ git-secrets is installed${NC}"
 echo ""
 
 # Install git hooks
+#
+# git-secrets 1.3.0's install_hook() writes and chmods the hook file, then
+# reports success via a `say` call it never defines as a function. On macOS
+# that resolves to /usr/bin/say (the text-to-speech binary) and exits 0 by
+# accident; on Linux there is no such binary, so it's "command not found"
+# and `git secrets --install -f` returns non-zero even though every hook
+# file was already written correctly. Define `say` as a no-op here and
+# export it so the exported function is visible in the git-secrets child
+# process on both platforms, making the real hook-writing exit status the
+# one that reaches the check below.
+say() { :; }
+export -f say
+
 echo "Installing git-secrets hooks..."
 if git secrets --install -f; then
     echo -e "${GREEN}✓ Git hooks installed${NC}"

--- a/scripts/setup-git-secrets.sh
+++ b/scripts/setup-git-secrets.sh
@@ -32,14 +32,21 @@ echo ""
 # Install git hooks
 #
 # git-secrets 1.3.0's install_hook() writes and chmods the hook file, then
-# reports success via a `say` call it never defines as a function. On macOS
-# that resolves to /usr/bin/say (the text-to-speech binary) and exits 0 by
-# accident; on Linux there is no such binary, so it's "command not found"
-# and `git secrets --install -f` returns non-zero even though every hook
-# file was already written correctly. Define `say` as a no-op here and
-# export it so the exported function is visible in the git-secrets child
-# process on both platforms, making the real hook-writing exit status the
-# one that reaches the check below.
+# reports success via a `say` call. `say` was never its own function:
+# git-secrets sources git's git-sh-setup and relied on `say` being defined
+# there (introduced in git-sh-setup.sh in 2009). Git removed it in commit
+# 5b893f7d81 ("git-sh-setup.sh: remove 'say' function, change last users"),
+# first shipped in Git 2.38 (2022), because it was undocumented and unused
+# within git's own tree, breaking git-secrets as an unintended side effect
+# of a git upgrade rather than a git-secrets regression. On macOS the bare
+# `say` call resolves to /usr/bin/say (the text-to-speech binary) instead
+# and exits 0 by accident; on Linux (or on a new-enough git anywhere) there
+# is no such fallback, so it's "command not found" and `git secrets
+# --install -f` returns non-zero even though every hook file was already
+# written correctly. Define `say` as a no-op here and export it so the
+# exported function is visible in the git-secrets child process on both
+# platforms, making the real hook-writing exit status the one that reaches
+# the check below.
 say() { :; }
 export -f say
 

--- a/scripts/test-git-secrets-allowlist.sh
+++ b/scripts/test-git-secrets-allowlist.sh
@@ -120,17 +120,31 @@ run_case "untruncated PKCS8 body" 1 e.json \
 run_case "corrected GCP API key range" 1 f.txt \
     "$AIZA"
 
-# Negative control for the setup-script allowlist entries below: a secret
-# appended to a DIFFERENT git-secrets registration line in that file (the
-# GCP one, not one of the three that legitimately self-match) must still be
-# caught. A prefix-only entry anchored on just "git secrets --add '" would
-# hide this too -- the exact #1972 hole, reintroduced at the scale of one
-# file. Mutates the tracked copy of the setup script in place at its real
-# path, since the allowlist entries are anchored on that path; restores the
-# pristine copy afterward so the later self-scan case below sees it intact.
+# Negative controls for the setup-script allowlist entries below, each
+# closing one instance of the same class of hole (#1972 reintroduced at
+# the scale of one file) that a narrower-but-still-wrong anchor leaves
+# open. Both mutate the tracked copy of the setup script in place at its
+# real path, since the allowlist entries are anchored on that path, and
+# restore the pristine copy afterward so the later self-scan case below
+# sees it intact.
+
+# A secret appended to a DIFFERENT git-secrets registration line in that
+# file (the GCP one, not one of the three that legitimately self-match)
+# must still be caught. A prefix-only entry anchored on just "git secrets
+# --add '" would hide this.
 run_case "secret appended to an unrelated registration line stays caught" 1 \
     scripts/setup-git-secrets.sh \
     "$(sed "s/# GCP API Key\$/# GCP API Key ${KEY}/" "$REPO_ROOT/scripts/setup-git-secrets.sh")"
+cp "$REPO_ROOT/scripts/setup-git-secrets.sh" scripts/setup-git-secrets.sh
+
+# A secret appended to the END of one of the three self-matching lines
+# THEMSELVES must also still be caught. An entry anchored on the path and
+# pattern but missing a trailing $ would stop matching at the end of the
+# pattern it names and let anything appended after it through, which is a
+# narrower version of the same hole the entry above closes.
+run_case "secret appended to a self-matching line itself stays caught" 1 \
+    scripts/setup-git-secrets.sh \
+    "$(sed "s/# PostgreSQL\$/# PostgreSQL ${KEY}/" "$REPO_ROOT/scripts/setup-git-secrets.sh")"
 cp "$REPO_ROOT/scripts/setup-git-secrets.sh" scripts/setup-git-secrets.sh
 
 # Must scan clean (exit 0): what the tree contains, and what the allowlist
@@ -138,8 +152,6 @@ cp "$REPO_ROOT/scripts/setup-git-secrets.sh" scripts/setup-git-secrets.sh
 run_staged_case "setup script's own self-matching lines" 0 scripts/setup-git-secrets.sh
 run_case "GCP type marker alone, no key material" 0 g.json \
     '{"type": "service_account", "project_id": "p"}'
-run_case "Go format-string DSN" 0 h.go \
-    '"postgres://%s:%s@%s:%d/%s?sslmode=%s",'
 run_case "truncated PEM in a struct literal" 0 i.go \
     'PrivateKey: "'"$PEM"'\n...",'
 run_case "truncated PEM in a JSON literal" 0 j.go \

--- a/scripts/test-git-secrets-allowlist.sh
+++ b/scripts/test-git-secrets-allowlist.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Self-test for the git-secrets allowlist (#1972). Exercises the real
-# scripts/setup-git-secrets.sh and .gitallowed in a throwaway repo, through
-# the pre-commit hook scan path, in both directions: fixtures that must be
-# caught, and fixtures that must scan clean.
+# scripts/setup-git-secrets.sh and .gitallowed in a throwaway repo, both
+# directly via `git secrets --scan --cached` and through the installed
+# pre-commit hook, in both directions: fixtures that must be caught, and
+# fixtures that must scan clean.
 #
 # Fixture safety: every positive fixture below is a secret-shaped string
 # that this script itself, and the repo's detect-private-key / git-secrets
@@ -42,11 +43,34 @@ fi
 # Same HOME-isolation reason: drop the provider before any further scan.
 git config --unset-all secrets.providers
 
+# The pre-commit hook ignores the args git would pass it and recomputes its
+# own file list from the index (diff against HEAD, or the empty tree if
+# there is no HEAD yet, which is always true in this never-committed
+# throwaway repo). So it scans every currently staged path, not just
+# $relpath -- calling it with no args, as git itself does, is correct.
+HOOK_DIR="$(git rev-parse --git-dir)/hooks"
+
 pass=0
 fail=0
 
-# Writes $content to $relpath, stages it, scans it through the hook path,
-# compares the exit code to $expected, then unstages and removes it.
+# Records one pass/fail against $expected, printing a FAIL line labeled
+# $label on mismatch. Shared by both scan paths in run_case/run_staged_case
+# so a direct-scan/hook disagreement surfaces as its own labeled failure
+# instead of being silently reconciled.
+check_result() {
+    local label=$1 expected=$2 actual=$3
+    if [ "$actual" -eq "$expected" ]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        echo "FAIL: $label (expected exit $expected, got $actual)" >&2
+    fi
+}
+
+# Writes $content to $relpath, stages it, scans it two ways -- directly via
+# `git secrets --scan --cached` (exact file argument) and via the installed
+# pre-commit hook (the real path a developer's commit takes) -- compares
+# each exit code to $expected, then unstages and removes it.
 run_case() {
     local label=$1 expected=$2 relpath=$3 content=$4
     mkdir -p "$(dirname "$relpath")"
@@ -54,14 +78,12 @@ run_case() {
     git add "$relpath"
     local actual=0
     git secrets --scan --cached "$relpath" >/dev/null 2>&1 || actual=$?
+    check_result "$label (direct scan)" "$expected" "$actual"
+    local hook_actual=0
+    "$HOOK_DIR/pre-commit" >/dev/null 2>&1 || hook_actual=$?
+    check_result "$label (installed hook)" "$expected" "$hook_actual"
     git rm -q --cached "$relpath"
     rm -f "$relpath"
-    if [ "$actual" -eq "$expected" ]; then
-        pass=$((pass + 1))
-    else
-        fail=$((fail + 1))
-        echo "FAIL: $label (expected exit $expected, got $actual)" >&2
-    fi
 }
 
 # Same as run_case, for a file already on disk (the copied setup script and
@@ -71,12 +93,10 @@ run_staged_case() {
     git add "$relpath"
     local actual=0
     git secrets --scan --cached "$relpath" >/dev/null 2>&1 || actual=$?
-    if [ "$actual" -eq "$expected" ]; then
-        pass=$((pass + 1))
-    else
-        fail=$((fail + 1))
-        echo "FAIL: $label (expected exit $expected, got $actual)" >&2
-    fi
+    check_result "$label (direct scan)" "$expected" "$actual"
+    local hook_actual=0
+    "$HOOK_DIR/pre-commit" >/dev/null 2>&1 || hook_actual=$?
+    check_result "$label (installed hook)" "$expected" "$hook_actual"
 }
 
 # Fixtures, assembled from adjacent literals so this file scans clean.
@@ -99,6 +119,19 @@ run_case "untruncated PKCS8 body" 1 e.json \
     '"private_key": "'"$PEM"'\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC\n"'
 run_case "corrected GCP API key range" 1 f.txt \
     "$AIZA"
+
+# Negative control for the setup-script allowlist entries below: a secret
+# appended to a DIFFERENT git-secrets registration line in that file (the
+# GCP one, not one of the three that legitimately self-match) must still be
+# caught. A prefix-only entry anchored on just "git secrets --add '" would
+# hide this too -- the exact #1972 hole, reintroduced at the scale of one
+# file. Mutates the tracked copy of the setup script in place at its real
+# path, since the allowlist entries are anchored on that path; restores the
+# pristine copy afterward so the later self-scan case below sees it intact.
+run_case "secret appended to an unrelated registration line stays caught" 1 \
+    scripts/setup-git-secrets.sh \
+    "$(sed "s/# GCP API Key\$/# GCP API Key ${KEY}/" "$REPO_ROOT/scripts/setup-git-secrets.sh")"
+cp "$REPO_ROOT/scripts/setup-git-secrets.sh" scripts/setup-git-secrets.sh
 
 # Must scan clean (exit 0): what the tree contains, and what the allowlist
 # must keep clean.

--- a/scripts/test-git-secrets-allowlist.sh
+++ b/scripts/test-git-secrets-allowlist.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Self-test for the git-secrets allowlist (#1972). Exercises the real
+# scripts/setup-git-secrets.sh and .gitallowed in a throwaway repo, through
+# the pre-commit hook scan path, in both directions: fixtures that must be
+# caught, and fixtures that must scan clean.
+#
+# Fixture safety: every positive fixture below is a secret-shaped string
+# that this script itself, and the repo's detect-private-key / git-secrets
+# pre-commit hooks, would flag if it appeared as a contiguous literal. Each
+# is assembled at runtime from adjacent string literals so this file's own
+# source never contains a scannable token. Where a fixture shows \n below,
+# it is the two literal characters backslash and n, as in a Go string
+# literal, never an actual newline.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v git-secrets >/dev/null 2>&1; then
+    echo "git-secrets not found on PATH; install it before running this test" >&2
+    exit 1
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/home"
+# Isolate HOME: --register-aws reads ~/.aws/credentials, and git-secrets
+# echoes the whole joined pattern list on a regex error, which would print
+# real credentials into this log.
+export HOME="$tmp/home"
+
+git init -q "$tmp/repo"
+mkdir -p "$tmp/repo/scripts"
+cp "$REPO_ROOT/scripts/setup-git-secrets.sh" "$tmp/repo/scripts/setup-git-secrets.sh"
+cp "$REPO_ROOT/.gitallowed" "$tmp/repo/.gitallowed"
+cd "$tmp/repo"
+
+if ! bash scripts/setup-git-secrets.sh > "$tmp/setup.log" 2>&1; then
+    echo "scripts/setup-git-secrets.sh failed in the throwaway repo:" >&2
+    cat "$tmp/setup.log" >&2
+    exit 1
+fi
+# Same HOME-isolation reason: drop the provider before any further scan.
+git config --unset-all secrets.providers
+
+pass=0
+fail=0
+
+# Writes $content to $relpath, stages it, scans it through the hook path,
+# compares the exit code to $expected, then unstages and removes it.
+run_case() {
+    local label=$1 expected=$2 relpath=$3 content=$4
+    mkdir -p "$(dirname "$relpath")"
+    printf '%s\n' "$content" >"$relpath"
+    git add "$relpath"
+    local actual=0
+    git secrets --scan --cached "$relpath" >/dev/null 2>&1 || actual=$?
+    git rm -q --cached "$relpath"
+    rm -f "$relpath"
+    if [ "$actual" -eq "$expected" ]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        echo "FAIL: $label (expected exit $expected, got $actual)" >&2
+    fi
+}
+
+# Same as run_case, for a file already on disk (the copied setup script and
+# .gitallowed), left staged afterward like any other tracked file would be.
+run_staged_case() {
+    local label=$1 expected=$2 relpath=$3
+    git add "$relpath"
+    local actual=0
+    git secrets --scan --cached "$relpath" >/dev/null 2>&1 || actual=$?
+    if [ "$actual" -eq "$expected" ]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        echo "FAIL: $label (expected exit $expected, got $actual)" >&2
+    fi
+}
+
+# Fixtures, assembled from adjacent literals so this file scans clean.
+KEY="AKIA""0123456789ABCDEF"
+PEM="-----BEGIN ""PRIVATE KEY-----"
+AIZA="AIza$(head -c 35 /dev/zero | tr '\0' X)"
+
+# Must be caught (exit 1): the #1972 hole and the coverage this PR adds.
+run_case "terraform resource with a real-shaped key" 1 a.tf \
+    'resource "aws_iam_access_key" "x" { key = "'"$KEY"'" }'
+run_case "terraform var reference alongside a key" 1 b.tf \
+    'secret = var.x # '"$KEY"
+run_case "go test const with a key" 1 c_test.go \
+    'const k = "'"$KEY"'"'
+run_case "testdata fixture with a key" 1 testdata/creds.txt \
+    'key='"$KEY"
+run_case "placeholder line with a key" 1 d.txt \
+    'placeholder '"$KEY"
+run_case "untruncated PKCS8 body" 1 e.json \
+    '"private_key": "'"$PEM"'\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC\n"'
+run_case "corrected GCP API key range" 1 f.txt \
+    "$AIZA"
+
+# Must scan clean (exit 0): what the tree contains, and what the allowlist
+# must keep clean.
+run_staged_case "setup script's own self-matching lines" 0 scripts/setup-git-secrets.sh
+run_case "GCP type marker alone, no key material" 0 g.json \
+    '{"type": "service_account", "project_id": "p"}'
+run_case "Go format-string DSN" 0 h.go \
+    '"postgres://%s:%s@%s:%d/%s?sslmode=%s",'
+run_case "truncated PEM in a struct literal" 0 i.go \
+    'PrivateKey: "'"$PEM"'\n...",'
+run_case "truncated PEM in a JSON literal" 0 j.go \
+    '"private_key": "'"$PEM"'\nMIIEvQIBADANBg...\n",'
+run_case "PEM word fragments are not a real header" 0 k.txt \
+    'this is PRIVATE data
+algo EC here
+-----BEGIN CERTIFICATE-----'
+run_staged_case ".gitallowed self-scan" 0 .gitallowed
+
+echo "$pass PASS, $fail FAIL"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

git-secrets allowed patterns are applied with `grep -Ev` against the scanner's **whole** `path:line:content` output line, not against file content alone. `scripts/setup-git-secrets.sh` registered 20 keyword entries, among them `var\.`, `resource\s`, `_test\.go`, `placeholder` and `example\.com`. Any line containing one of those scanned clean, including a line carrying a real access key.

Reproduced both directions: with `resource\s` allowed, a Terraform line holding a synthetic access key exits 0; with it removed, the same line exits 1.

Measured against the tree with the script's own detectors, **none of the 20 entries suppressed a legitimate false positive.** The real false positives were 22 lines mentioning the GCP key-file `type` marker, the script matching three of its own registration lines, and three truncated PEM fixtures.

## The script had never actually run to completion

**Three** independent defects meant this hole was latent rather than live. Each had to be fixed before anything here could be verified, and the third was found by the new CI job on its first run:

- `git secrets --add` puts its value through git's option parser, which rejects a value starting with a dash. The PEM pattern starts with one, so the script aborted there under `set -e` and **never reached the allowed block on any machine.**
- The GCP API-key pattern registered before that abort is an invalid bracket range under BSD regex, glibc regex and GNU grep alike. git-secrets joins every pattern into one `git grep -E`, so once registered it makes **every** scan exit 128, including the pre-commit hook. Filed as #2080 and fixed here as the first commit, since nothing else could be measured until scans ran.
- **On Linux the script exits before registering anything at all.** git-secrets writes and chmods each hook file, then reports success by calling `say`. That function came from `git-sh-setup`, which git-secrets sources, and **git removed it** in `5b893f7d81` as undocumented and unused, first shipping in Git 2.38 (September 2022), so this is a git regression git-secrets inherited rather than a defect it ever had alone; older git versions never hit it. On macOS that resolves to `/usr/bin/say`, the text-to-speech binary, and exits 0 by accident, so the workstation literally speaks the message. On Linux there is no such command, so the install returns non-zero despite every hook being written correctly, and this script trusted that status: it printed a wrong error and exited before reaching pattern registration. The script now defines a no-op `say` and exports it, making the real hook-writing status the one that is checked. It is the only call site, so nothing else is masked.

## Changes

- Delete the allowed-pattern block from the setup script. `.gitallowed` becomes the single allowlist.
- Correct `.gitallowed`'s header, which claimed path scoping was impossible. It is not, and the file now says what an entry is actually matched against.
- Add three entries: one path-anchored for the script's self-matching registration lines, and two literals.
- Replace the `type.*service_account` marker detector with PKCS#8 coverage in the PEM detector. The marker cannot be narrowed, since the benign literal is byte-identical to the one in a real key file. The secret in such a file is the private key body, which the old detector missed because it required an algorithm word. Detecting key material beats detecting a marker.
- Rewrite that detector so it registers at all and is not word-split into four fragments on the git-grep path.
- `scripts/test-git-secrets-allowlist.sh` runs the real script in a temporary repository and asserts both directions, through **both** a direct scan and the installed pre-commit hook, checking the two against the same expectation so a disagreement surfaces as its own failure. A new CI job runs it.
- Pin the git-secrets clone to a verified commit SHA rather than a mutable tag, in the new job **and** in the existing `pre-commit.yml` step it was copied from.

### One entry was still too broad, and it was the same bug again

Review caught that the path-anchored entry for the script's self-matching lines was written as a command prefix, so it covered **every** registration line in that file, not the three that genuinely self-match. A secret appended to any other one would have been whitelisted. That is precisely the defect this PR exists to close, reintroduced at the scale of a single file.

Which three self-match was then determined by measurement rather than assumption (the Azure connection-string detector and the PostgreSQL and MySQL DSN detectors; MongoDB's does not), and each entry is now anchored on the path, line number and full pattern. A negative fixture covers a key appended to a different registration line, confirmed to pass under the old entry and fail under the new ones.

Narrowing exposed a genuine tension worth recording: spelling out the full pattern means each entry contains the trigger text it exists to suppress, so `.gitallowed` began matching itself, which the vague entry avoided only by naming no trigger at all. Each entry now replaces one letter of its trigger with a single-character bracket expression, a no-op for matching that breaks the contiguous literal. The comment explaining this is written the same way, for the same reason. **Do not tidy `Protoco[l]` back to `Protocol`**; it will silently reopen the problem.

**Then it happened twice more, and both were caught only by review.** The narrowed entries were anchored on the pattern but left open at the end, so a key appended to the end of one of those three specific lines still scanned clean. The fixture from the first round only covered a key on a *different* registration line, so it stayed green throughout. All three are now pinned to the entire line including its trailing comment, with a closing anchor and a fixture for exactly that mutation.

The same review found the format-string connection-string entry suppressed **nothing in the tree except this PR's own fixture**. The idiom it claimed to guard uses a different scheme the detector never matched, so the fixture justified the entry and the entry justified the fixture while neither matched real code. Both are deleted.

The recurring lesson is now written into `.gitallowed` itself: a fixture proving one instance of this class says nothing about its siblings, so any future entry in that block needs its own mutation fixture.

## Verification

Measured in a throwaway shared clone with its own config and an isolated `HOME`, never in a real checkout. `HOME` isolation is not incidental: `--register-aws` installs a provider that reads the developer's credentials file, and git-secrets echoes its entire joined pattern list on any regex error, so a malformed pattern prints real credentials to the terminal. That was observed while measuring.

| | Before | After |
| --- | ---: | ---: |
| Total hits | 996 | 972 |
| Genuine false positives | 24 | **0** |
| New scanner hits introduced | | **none** |

The location diff between before and after is empty: the only change is the 24 false positives disappearing. No file gains a hit.

The remaining 972 are all separator lines (box drawing and rules) matched by the inverted secret-key pattern on line 52, which is #2030 and out of scope here. They exist with or without this PR.

**On the totals differing from the plan's predicted 966 and 942:** that is base drift, attributed rather than assumed, by two independent methods that agree.

Counting the separator pattern alone with `LC_ALL=C git grep -nwHEI` gives 942 hits at the commit the plan measured and 972 at this PR's base. Separately, re-running the full before-measurement at the plan's own base reproduces its 966 and 24 exactly, against 996 and 24 here. Both methods give a delta of exactly 30, with no remainder.

Those 30 land in 14 files, six of which did not exist at the earlier commit (a scope test, two migration files and three scripts); the rest are existing files that gained separator comments. Every delta line inspected is box drawing or a rule. It also holds algebraically: the false-positive count is 24 in both measurements, so the entire delta is separator noise by construction.

One measurement artefact worth recording, since it looks alarming: comparing `path:line` pairs across the two **base commits** reports 253 locations added and 253 removed. That is line-number churn from unrelated edits shifting existing separator lines within files, netting to zero, not new hits. The comparison that matters is before against after on the *same* base, and that location diff is empty.

Other checks: the self-test passes 30 of 30 assertions **on both macOS and Linux**, the latter reproduced in a Debian container with git-secrets built from the same pinned tag CI uses; the per-file path used by pre-commit exits 0 on the three formerly-flagged files; `pre-commit run` is green on every touched file, including `detect-private-key` against the new test script; the test script is shellcheck-clean.

The cross-platform run is not incidental. The Linux defect above was invisible for as long as the script was only ever exercised on macOS, and this job is the first thing to run it on Linux.

## For developers who already ran `make setup-git-secrets`

The script aborted partway for you, leaving a partial and invalid pattern set, so scans on that clone have been exiting 128. Clear the stale per-clone config before re-running, since a second run otherwise aborts on duplicate patterns (#2031):

```
git config --unset-all secrets.patterns; git config --unset-all secrets.allowed; make setup-git-secrets
```

## Not in this PR

#2030, the inverted line-52 pattern responsible for every remaining hit. #2031, a second run aborting on duplicates. #2081, the connection-string detectors never firing on a real connection string, because the word-boundary flag rejects a match ending before a hostname letter. #2082, three detectors using a whitespace escape POSIX does not have, which degrades to a literal `s` on macOS so those detectors silently miss the spaced form.

There is no gitleaks job in CI despite a `.gitleaksignore` existing, so this local gate is currently the only content scanner beyond the AWS patterns that pre-commit registers.

Closes #1972

---

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_01Fu9uWjxtDFx5HDKeMRt1jC
